### PR TITLE
Addresses issue #49: sets updated page data on GA tracker

### DIFF
--- a/integrations/GA/browser.js
+++ b/integrations/GA/browser.js
@@ -64,12 +64,28 @@ class GA {
   page(rudderElement) {
     logger.debug("in GoogleAnalyticsManager page");
     var path =
-      rudderElement.properties && rudderElement.properties.path
-        ? rudderElement.properties.path
+      rudderElement.message.properties && rudderElement.message.properties.path
+        ? rudderElement.message.properties.path
         : undefined;
+    var title = rudderElement.message.properties && rudderElement.message.properties.title
+        ? rudderElement.message.properties.title
+        : undefined;
+    var location = rudderElement.message.properties && rudderElement.message.properties.url
+        ? rudderElement.message.properties.url
+        : undefined;
+
     if (path) {
       ga("set", "page", path);
     }
+
+    if (title) {
+      ga("set", "title", title);
+    }
+
+    if (location) {
+      ga("set", "location", location);
+    }
+
     ga("send", "pageview");
   }
 


### PR DESCRIPTION
Mainly fixes property access issue (`rudderElement.properties` instead of `rudderElement.message.properties`).

Also sets page title and URL from the values of the `properties` object passed to rudder instead of keeping just the default ones. This makes native sdk's behavior consistent with the cloud version. 

This PR does not contain updated dist files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/52)
<!-- Reviewable:end -->
