### PR TITLE
Addresses issue #50: populate 'category' and 'label' fields in GA

### DIFF
--- a/integrations/GA/browser.js
+++ b/integrations/GA/browser.js
@@ -48,6 +48,12 @@ class GA {
       eventValue = rudderElement.message.properties.value
         ? rudderElement.message.properties.value
         : rudderElement.message.properties.revenue;
+      eventCategory = rudderElement.message.properties.category
+        ? rudderElement.message.properties.category
+        : eventCategory;
+      eventLabel = rudderElement.message.properties.label
+        ? rudderElement.message.properties.label
+        : eventLabel;
     }
 
     var payLoad = {


### PR DESCRIPTION
Theses changes allow for the `category` and `label` properties to be passed to the GA tracker, instead of populating all three of them with `rudderElement.message.event`. This brings consistency with the documentation and cloud version's behavior of the GA integration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/53)
<!-- Reviewable:end -->
