### PR TITLE
product is not defined

### DIFF
--- a/integrations/FacebookPixel/browser.js
+++ b/integrations/FacebookPixel/browser.js
@@ -353,7 +353,7 @@ class FacebookPixel {
       var contents = [];
 
       for (var i = 0; i < products.length; i++) {
-        var pId = product.product_id;
+        var pId = products[i].product_id;
         contentIds.push(pId);
         var content = {
           id: pId,


### PR DESCRIPTION
## Description of the change

The FacebookPixel integration fails to submit "Purchase" events due to an undefined variable, `product`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

#188

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/187)
<!-- Reviewable:end -->
