### PR TITLE
Fix eventCustomProperties issue in FacebookPixel buildPayLoad method.

### DIFF
--- a/integrations/FacebookPixel/browser.js
+++ b/integrations/FacebookPixel/browser.js
@@ -606,9 +606,12 @@ class FacebookPixel {
         continue;
       }
 
-      if (isStandardEvent && eventCustomProperties.indexOf(property) < 0) {
+      const customProperties = eventCustomProperties.map(e => e.eventCustomProperties);
+
+      if (isStandardEvent && customProperties.indexOf(property) < 0) {
         continue;
       }
+
       const value = properties[property];
 
       if (dateFields.indexOf(properties) >= 0) {


### PR DESCRIPTION
## Description of the change

> To fix the issue with `eventCustomProperties` on `buildPayLoad` method.
>
>When checking the `indexOf` against `eventCustomProperties` it will always return -1 since actually  it's an array of objects with `eventCustomProperties` prop and their values. 
>
>Problem is the loop would continue and user defined custom properties for "Standard Events custom properties" always get ignored. 
>
> <img src="https://user-images.githubusercontent.com/5405770/121843319-4154d880-ccf7-11eb-9a45-7d74fcd22dfb.png" width=500 />


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#253](https://github.com/rudderlabs/rudder-sdk-js/issues/253) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/255)
<!-- Reviewable:end -->
