### PR TITLE
Fix GA4 mutation of track method properties

### DIFF
--- a/integrations/GA4/utils.js
+++ b/integrations/GA4/utils.js
@@ -135,8 +135,6 @@ function getDestinationEventProperties(
           );
         }
         destinationProperties[param.dest] = props[key];
-        // eslint-disable-next-line no-param-reassign
-        delete props[key];
       }
     });
   });


### PR DESCRIPTION
## Description of the change

The GA4 integration mutates the `rudderAnalaytics.track()` `properties` object, which impacts other integrations as well (e.g. Facebook Pixel). The rogue code does not appear to do anything (although it's always very hard to tell with mutations), so I have simply removed it.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#273 ]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/274)
<!-- Reviewable:end -->
