### PR TITLE
Fix Facebook content type

### DIFF
--- a/integrations/FacebookPixel/browser.js
+++ b/integrations/FacebookPixel/browser.js
@@ -499,7 +499,8 @@ class FacebookPixel {
   }
 
   getContentType(rudderElement, defaultValue) {
-    const { options, properties } = rudderElement.message;
+    const { properties } = rudderElement.message;
+    const options = rudderElement?.message?.integrations?.FACEBOOK_PIXEL;
     if (options && options.contentType) {
       return [options.contentType];
     }

--- a/integrations/GA4/utils.js
+++ b/integrations/GA4/utils.js
@@ -135,8 +135,6 @@ function getDestinationEventProperties(
           );
         }
         destinationProperties[param.dest] = props[key];
-        // eslint-disable-next-line no-param-reassign
-        delete props[key];
       }
     });
   });


### PR DESCRIPTION
## Description of the change

Fix to allow contentType to be set on Facebook Events (e.g. if you want to send a "destination" or "flight" rather than "product" content type.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#282]() 