### PR TITLE
Replaces console.logs to logger.debug in FacebookPixel

### DIFF
--- a/integrations/FacebookPixel/browser.js
+++ b/integrations/FacebookPixel/browser.js
@@ -460,9 +460,9 @@ class FacebookPixel {
         logger.error("No product array found");
       }
     } else {
-      console.log("inside custom");
+      logger.debug("inside custom");
       if (!standardTo[event.toLowerCase()] && !legacyTo[event.toLowerCase()]) {
-        console.log("inside custom not mapped");
+        logger.debug("inside custom not mapped");
         const payloadVal = this.buildPayLoad(rudderElement, false);
         payloadVal.value = revValue;
         window.fbq("trackSingleCustom", self.pixelId, event, payloadVal, {


### PR DESCRIPTION
## Description of the change

> There was two `console log` inside Facebook Pixel script which caused unnecessary logs in clients sites. just replaced them with `logger.debug`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/324)
<!-- Reviewable:end -->
