### PR TITLE
Configure storage type from options

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -922,6 +922,11 @@ class Analytics {
       });
       throw Error("failed to initialize");
     }
+
+    if (options && options.defStorageType)
+      this.storage.init(options.defStorageType);
+    else this.storage.init();
+
     if (options && options.logLevel) {
       logger.setLogLevel(options.logLevel);
     }


### PR DESCRIPTION
## Description of the change

> Added a new parameter (defStorageType) in 'option' parameter of 'load' API to configure the preferred storage type (COOKIES or LOCAL_STORAGE).

- New parameter added to load options.
- If no option provided, defaults to Cookies.
- If the support for provided storage preference doesn't exist, switches to the next type.
- Migrates any *valid* data from previous storage type to current.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [*] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
