### PR TITLE
Feature: Configure storage type from load options

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -6,7 +6,7 @@ test("Check SDK is loaded as object and api calls reaching to hit network", () =
     send: jest.fn(),
     readyState: 4,
     responseText: JSON.stringify({}),
-    status: 200
+    status: 200,
   };
 
   window.XMLHttpRequest = jest.fn(() => xhrMock);
@@ -23,7 +23,7 @@ test("Check SDK is loaded as object and api calls reaching to hit network", () =
         "group",
         "identify",
         "ready",
-        "reset"
+        "reset",
       ],
       i = 0;
     i < methods.length;
@@ -43,8 +43,6 @@ test("Check SDK is loaded as object and api calls reaching to hit network", () =
     rudderanalytics.page();
 
   require("./prodsdk.js");
-
-  console.log(rudderanalytics);
 
   rudderanalytics.page();
   rudderanalytics.track("test-event");

--- a/analytics.js
+++ b/analytics.js
@@ -923,6 +923,10 @@ class Analytics {
       throw Error("failed to initialize");
     }
 
+    if (options && options.defaultStorage)
+      this.storage.init(options.defaultStorage);
+    else this.storage.init();
+
     if (options && options.logLevel) {
       logger.setLogLevel(options.logLevel);
     }

--- a/dist/rudder-sdk-js/package.json
+++ b/dist/rudder-sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-sdk-js",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "RudderStack Javascript SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-analytics",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "main": "./dist/browser.min.js",
   "size-limit": [

--- a/utils/RudderApp.js
+++ b/utils/RudderApp.js
@@ -1,7 +1,7 @@
 // Application class
 class RudderApp {
   constructor() {
-    this.build = "1.0.0";
+    this.build = "1.2.2";
     this.name = "RudderLabs JavaScript SDK";
     this.namespace = "com.rudderlabs.javascript";
     this.version = "process.package_version";

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -1,4 +1,3 @@
-import { tsImportEqualsDeclaration } from "@babel/types";
 import AES from "crypto-js/aes";
 import Utf8 from "crypto-js/enc-utf8";
 import logger from "../logUtil";

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -13,27 +13,102 @@ const defaults = {
   page_storage_init_referrer: "rl_page_init_referrer",
   page_storage_init_referring_domain: "rl_page_init_referring_domain",
   prefix: "RudderEncrypt:",
-  key: "Rudder"
+  key: "Rudder",
 };
+
+const storageTypes = {
+  COOKIES: { name: "cookies", instance: Cookie },
+  LOCAL_STORAGE: { name: "localstorage", instance: Store },
+};
+
+const DEF_STORAGE_NAME = storageTypes.COOKIES.name;
 
 /**
  * An object that handles persisting key-val from Analytics
  */
 class Storage {
   constructor() {
+    this.cookieSupportExists = false;
+    this.lsSupportExists = false;
+
+    // Check cookie support
     // First try setting the storage to cookie else to localstorage
     Cookie.set("rudder_cookies", true);
-
     if (Cookie.get("rudder_cookies")) {
       Cookie.remove("rudder_cookies");
-      this.storage = Cookie;
-      return;
+      this.cookieSupportExists = true;
     }
 
+    // Check local storage support
     // localStorage is enabled.
     if (Store.enabled) {
-      this.storage = Store;
+      this.lsSupportExists = true;
     }
+
+    this.storage = undefined;
+  }
+
+  init(defStorageName = DEF_STORAGE_NAME) {
+    // Data validation and setting to defaults
+    let storageName;
+    if (typeof defStorageName === "string" && defStorageName)
+      storageName = defStorageName.trim().toLowerCase();
+    else storageName = DEF_STORAGE_NAME;
+
+    if (!Object.values(storageTypes).some((x) => x.name === storageName))
+      storageName = DEF_STORAGE_NAME;
+
+    // Reset storage instance
+    this.storage = undefined;
+
+    let prevStorage;
+
+    // Determine storage type
+    switch (storageName) {
+      case storageTypes.COOKIES.name:
+        if (this.cookieSupportExists) {
+          this.storage = storageTypes.COOKIES.instance;
+          if (this.lsSupportExists)
+            prevStorage = storageTypes.LOCAL_STORAGE.instance;
+        } else if (this.lsSupportExists) {
+          this.storage = storageTypes.LOCAL_STORAGE.instance;
+        }
+        break;
+      case storageTypes.LOCAL_STORAGE.name:
+        if (this.lsSupportExists) {
+          this.storage = storageTypes.LOCAL_STORAGE.instance;
+          if (this.cookieSupportExists)
+            prevStorage = storageTypes.COOKIES.instance;
+        } else if (this.cookieSupportExists) {
+          this.storage = storageTypes.COOKIES.instance;
+        }
+        break;
+      default:
+        break;
+    }
+
+    // Migrate any valid data from previous storage type to current
+    if (this.storage && prevStorage) {
+      this.migrateData(prevStorage, this.storage);
+    }
+  }
+
+  migrateData(prevStorage, curStorage) {
+    logger.debug("Migrating data from previous storage to current");
+    const dataNames = Object.values(defaults).filter((val) =>
+      val.startsWith("rl_")
+    );
+    dataNames.forEach((dName) => {
+      const dVal = prevStorage.get(dName);
+      if (this.isValidData(dVal)) {
+        curStorage.set(dName, dVal);
+      }
+      prevStorage.remove(dName);
+    });
+  }
+
+  isValidData(val) {
+    return !(!val || (typeof val === "string" && this.trim(val) === ""));
   }
 
   options(options = {}) {
@@ -91,7 +166,7 @@ class Storage {
    * @param {*} value
    */
   decryptValue(value) {
-    if (!value || (typeof value === "string" && this.trim(value) == "")) {
+    if (!this.isValidData(value)) {
       return value;
     }
     if (value.substring(0, defaults.prefix.length) == defaults.prefix) {

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -40,7 +40,7 @@ class Storage {
 
     // Check cookie support
     // First try setting the storage to cookie else to localstorage
-    let cookieInst = storageTypes.COOKIES.instance;
+    const cookieInst = storageTypes.COOKIES.instance;
     cookieInst.set("rudder_cookies", true);
     if (cookieInst.get("rudder_cookies")) {
       cookieInst.remove("rudder_cookies");
@@ -49,26 +49,23 @@ class Storage {
 
     // Check local storage support
     // localStorage is enabled.
-    let lsInst = storageTypes.LOCAL_STORAGE.instance;
+    const lsInst = storageTypes.LOCAL_STORAGE.instance;
     if (lsInst.enabled) {
       this.lsSupportExists = true;
     }
 
     // Assign storage object
     // Local Storage > Cookies
-    let prevStorage;
     if (this.lsSupportExists) {
       this.storage = lsInst;
       this.storageName = storageTypes.LOCAL_STORAGE.name;
-      if (this.cookieSupportExists) prevStorage = Cookie;
+      // Migrate any valid data
+      if (this.cookieSupportExists) {
+        this.migrateData(cookieInst, this.storage);
+      }
     } else if (this.cookieSupportExists) {
       this.storage = cookieInst;
       this.storageName = storageTypes.COOKIES.name;
-    }
-
-    // Migrate any valid data from previous storage type to current
-    if (this.storage && prevStorage) {
-      this.migrateData(prevStorage, this.storage);
     }
   }
 
@@ -77,12 +74,13 @@ class Storage {
     // that only 2 storage types are supported in the SDK
     // TODO: Need to rewrite as this solution is not extendable.
 
-    // Data validation and setting to defaults
+    // Validate storage name
     let reqStorageName;
     if (typeof defStorageName === "string" && defStorageName)
       reqStorageName = defStorageName.trim().toLowerCase();
     else reqStorageName = DEF_STORAGE_NAME;
 
+    // Allow only defined storage types
     if (!Object.values(storageTypes).some((x) => x.name === reqStorageName))
       reqStorageName = DEF_STORAGE_NAME;
 


### PR DESCRIPTION
## Description of the change

Added a new parameter (`defaultStorage`) in `option` parameter of the 'load' API to configure the preferred storage type ("cookies" or "localstorage").

- By default, storage is set to local storage > cookies. Migrates data from other storage if valid.
- New parameter added to load options, defaults to "cookies".
- Migrates any valid data from previous storage type to current.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/357)
<!-- Reviewable:end -->
