### PR TITLE
Feat: altering page event name

### DIFF
--- a/dist/rudder-sdk-js/package.json
+++ b/dist/rudder-sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-sdk-js",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "RudderStack Javascript SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/integrations/Amplitude/browser.js
+++ b/integrations/Amplitude/browser.js
@@ -338,23 +338,25 @@ class Amplitude {
     this.setDeviceId(rudderElement);
 
     const { properties, name, category } = rudderElement.message;
-    const { alterPageEventName } = rudderElement.message.context;
+    const { useNewPageEventNameFormat } = rudderElement.message.context;
     // all pages
     if (this.trackAllPages) {
       const event = "Loaded a page";
       amplitude.getInstance().logEvent(event, properties);
     }
-    let event;
+
     // categorized pages
     if (category && this.trackCategorizedPages) {
-      if (!alterPageEventName) event = `Viewed page ${category}`;
+      let event;
+      if (!useNewPageEventNameFormat) event = `Viewed page ${category}`;
       else event = `Viewed ${category} Page`;
       amplitude.getInstance().logEvent(event, properties);
     }
 
     // named pages
     if (name && this.trackNamedPages) {
-      if (!alterPageEventName) event = `Viewed page ${name}`;
+      let event;
+      if (!useNewPageEventNameFormat) event = `Viewed page ${name}`;
       else event = `Viewed ${name} Page`;
       amplitude.getInstance().logEvent(event, properties);
     }

--- a/integrations/Amplitude/browser.js
+++ b/integrations/Amplitude/browser.js
@@ -49,7 +49,7 @@ class Amplitude {
   }
 
   init() {
-    if(this.analytics.loadIntegration){
+    if (this.analytics.loadIntegration) {
       (function (e, t) {
         const n = e.amplitude || {
           _q: [],
@@ -69,7 +69,7 @@ class Amplitude {
         };
         const i = t.getElementsByTagName("script")[0];
         i.parentNode.insertBefore(r, i);
-  
+
         function s(e, t) {
           e.prototype[t] = function () {
             this._q.push([t].concat(Array.prototype.slice.call(arguments, 0)));
@@ -132,7 +132,7 @@ class Amplitude {
           "setSessionId",
           "resetSessionId",
         ];
-  
+
         function v(e) {
           function t(t) {
             e[t] = function () {
@@ -338,22 +338,24 @@ class Amplitude {
     this.setDeviceId(rudderElement);
 
     const { properties, name, category } = rudderElement.message;
-
+    const { alterPageEventName } = rudderElement.message.context;
     // all pages
     if (this.trackAllPages) {
       const event = "Loaded a page";
       amplitude.getInstance().logEvent(event, properties);
     }
-
+    let event;
     // categorized pages
     if (category && this.trackCategorizedPages) {
-      const event = `Viewed page ${category}`;
+      if (!alterPageEventName) event = `Viewed page ${category}`;
+      else event = `Viewed ${category} Page`;
       amplitude.getInstance().logEvent(event, properties);
     }
 
     // named pages
     if (name && this.trackNamedPages) {
-      const event = `Viewed page ${name}`;
+      if (!alterPageEventName) event = `Viewed page ${name}`;
+      else event = `Viewed ${name} Page`;
       amplitude.getInstance().logEvent(event, properties);
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-analytics",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "",
   "main": "./dist/browser.min.js",
   "size-limit": [


### PR DESCRIPTION
Here we are adding support for segment like page event call. Before it we used to call the event with 'Viewed page ****' but now will call the event with 'Viewed ***** Page', if 'alterPageEventName' is set to true in options.

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/369)
<!-- Reviewable:end -->
