### PR TITLE
Expose `window.posthog`

### DIFF
--- a/integrations/Posthog/browser.js
+++ b/integrations/Posthog/browser.js
@@ -74,7 +74,7 @@ class Posthog {
     if (this.enableLocalStoragePersistence) {
       configObject.persistence = "localStorage+cookie";
     }
-
+    window.posthog = posthog
     posthog.init(this.teamApiKey, configObject);
   }
 


### PR DESCRIPTION
## Description of the change

Hey, Michael from PostHog here.
A common customer of RudderStack and PostHog would like to use our Sentry integration (https://posthog.com/docs/integrate/third-party/sentry#javascript-integration – this provides `$exception` events in PostHog) while instrumenting most of analytics via RudderStack. So the problem is that for this to work Sentry's SDK (`Sentry` object) needs to be initialized with the PostHog SDK's object (`posthog`) passed in, like so:

```javascript
Sentry.init({
    dsn: '<your Sentry DSN>',
    integrations: [new posthog.SentryIntegration(posthog, 'your organization', project-id)],
})
```

For this to work with non-RudderStack Sentry, `posthog` needs to be exposed via `window`. Or maybe there's an alternative way – I'm not intimately familiar with `rudder-sdk-js`. In any case, this is a real use case, so it would be beneficial for everyone to make it work!

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
