### PR TITLE
Support PostHog's `loaded` config parameter

### DIFF
--- a/integrations/Posthog/browser.js
+++ b/integrations/Posthog/browser.js
@@ -16,6 +16,7 @@ class Posthog {
     this.propertyBlackList = [];
     this.xhrHeaders = {};
     this.enableLocalStoragePersistence = config.enableLocalStoragePersistence;
+    this.loaded = config.loaded; // Function that will be run once PostHog loads
 
     if (config.xhrHeaders && config.xhrHeaders.length > 0) {
       config.xhrHeaders.forEach((header) => {
@@ -67,6 +68,7 @@ class Posthog {
       disable_session_recording: this.disableSessionRecording,
       property_blacklist: this.propertyBlackList,
       disable_cookie: this.disableCookie,
+      loaded: this.loaded
     };
     if (this.xhrHeaders && Object.keys(this.xhrHeaders).length > 0) {
       configObject.xhr_headers = this.xhrHeaders;


### PR DESCRIPTION
## Description of the change

This is a better solution to the problem https://github.com/rudderlabs/rudder-sdk-js/pull/428 was made to address.
With this PR, the affected customer will be able to pass in a `loaded` function like this to RudderStack SDK's internal `Posthog`:

```javascript
function loaded(posthog) {
    Sentry.init({
        dsn: '<Sentry DSN>',
        integrations: [new posthog.SentryIntegration(posthog, '<Sentry organization>', '<Sentry project ID>')],
    })
}
```

Which would init Sentry without the need to create a second PostHog SDK instance outside of RudderStack.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/432)
<!-- Reviewable:end -->
