### PR TITLE
Removing discrepancy with cloud mode for Facebook Pixel

### DIFF
--- a/integrations/FacebookPixel/browser.js
+++ b/integrations/FacebookPixel/browser.js
@@ -148,10 +148,10 @@ class FacebookPixel {
     if (properties) {
       products = properties.products;
       quantity = properties.quantity;
-      category = properties.category;
+      category = properties.category || "";
       prodId = properties.product_id || properties.id || properties.sku || "";
-      prodName = properties.product_name;
-      value = properties.value;
+      prodName = properties.product_name || properties.name || "";
+      value = properties.value || properties.price;
       price = properties.price;
       query = properties.query;
     }


### PR DESCRIPTION
## Description of the change

There are some differences in mapping for cloud mode and device mode. We are upgrading the device mode to parity with cloud mode.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
