### PR TITLE
Bug Fix: Added array check for analytics object

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1252,7 +1252,8 @@ while (argumentsArray.length > 0) {
 // parse querystring of the page url to send events
 parseQueryString(window.location.search);
 
-argumentsArray.forEach((x) => instance.toBeProcessedArray.push(x));
+if (Array.isArray(argumentsArray))
+  argumentsArray.forEach((x) => instance.toBeProcessedArray.push(x));
 
 processDataInAnalyticsArray(instance);
 

--- a/dist/rudder-sdk-js/package.json
+++ b/dist/rudder-sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-sdk-js",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "RudderStack Javascript SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-analytics",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-analytics",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "ISC",
       "dependencies": {
         "@ndhoule/clone": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-analytics",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "main": "./dist/browser.min.js",
   "size-limit": [


### PR DESCRIPTION
## Description of the change

> In the SDK, `rudderanalytics` variable on the browser window is assumed to be always an array. However, once the SDK is initialized, it would be pointing to the analytics object. If the SDK is loaded more than once, it would result in the following error:

```
Uncaught TypeError: ms.forEach is not a function
    at rudder-analytics.min.js:1:114792
    at rudder-analytics.min.js:1:115524
(anonymous) @ rudder-analytics.min.js:1
(anonymous) @ rudder-analytics.min.js:1
```

Therefore, added a fix to check for array type before executing the queued methods.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/478)
<!-- Reviewable:end -->
