### PR TITLE
FB util file renamed and fixed `originalTimestamp` override

### DIFF
--- a/integrations/FacebookPixel/util.js
+++ b/integrations/FacebookPixel/util.js
@@ -1,4 +1,0 @@
-function getEventId(message){
-    return message.traits.event_id || message.context.traits.event_id || message.properties.event_id || message.messageId;
-};
-export default getEventId;

--- a/integrations/FacebookPixel/utils.js
+++ b/integrations/FacebookPixel/utils.js
@@ -1,0 +1,9 @@
+function getEventId(message) {
+  return (
+    message.traits.event_id ||
+    message.context.traits.event_id ||
+    message.properties.event_id ||
+    message.messageId
+  );
+}
+export default getEventId;

--- a/utils/EventRepository.js
+++ b/utils/EventRepository.js
@@ -63,9 +63,7 @@ class EventRepository {
    */
   enqueue(rudderElement, type) {
     const message = rudderElement.getElementContent();
-    message.originalTimestamp = message.originalTimestamp
-      ? message.originalTimestamp
-      : getCurrentTimeFormatted();
+    message.originalTimestamp = message.originalTimestamp || getCurrentTimeFormatted();
     message.sentAt = getCurrentTimeFormatted(); // add this, will get modified when actually being sent
 
     // check message size, if greater log an error

--- a/utils/EventRepository.js
+++ b/utils/EventRepository.js
@@ -63,7 +63,8 @@ class EventRepository {
    */
   enqueue(rudderElement, type) {
     const message = rudderElement.getElementContent();
-    message.originalTimestamp = message.originalTimestamp || getCurrentTimeFormatted();
+    message.originalTimestamp =
+      message.originalTimestamp || getCurrentTimeFormatted();
     message.sentAt = getCurrentTimeFormatted(); // add this, will get modified when actually being sent
 
     // check message size, if greater log an error

--- a/utils/EventRepository.js
+++ b/utils/EventRepository.js
@@ -63,7 +63,9 @@ class EventRepository {
    */
   enqueue(rudderElement, type) {
     const message = rudderElement.getElementContent();
-    message.originalTimestamp = getCurrentTimeFormatted();
+    message.originalTimestamp = message.originalTimestamp
+      ? message.originalTimestamp
+      : getCurrentTimeFormatted();
     message.sentAt = getCurrentTimeFormatted(); // add this, will get modified when actually being sent
 
     // check message size, if greater log an error


### PR DESCRIPTION
## Description of the change

- Fixed util file name typo
- Prevented original timestamp being overridden by current timestamp


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/488)
<!-- Reviewable:end -->
