### PR TITLE
Allow empty event names in device mode event filtering

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -702,10 +702,7 @@ class Analytics {
         return false;
       // Blacklist is choosen for filtering events
       case "blacklistedEvents":
-        const isValidBlackList =
-          blacklistedEvents && Array.isArray(blacklistedEvents);
-
-        if (isValidBlackList) {
+        if (Array.isArray(blacklistedEvents)) {
           return blacklistedEvents.find(
             (eventObj) =>
               eventObj.eventName.trim().toUpperCase() === formattedEventName
@@ -717,9 +714,7 @@ class Analytics {
         }
       // Whitelist is choosen for filtering events
       case "whitelistedEvents":
-        const isValidWhiteList =
-          whitelistedEvents && Array.isArray(whitelistedEvents);
-        if (isValidWhiteList) {
+        if (Array.isArray(whitelistedEvents)) {
           return whitelistedEvents.find(
             (eventObj) =>
               eventObj.eventName.trim().toUpperCase() === formattedEventName

--- a/analytics.js
+++ b/analytics.js
@@ -695,6 +695,7 @@ class Analytics {
       return false;
     }
 
+    const formattedEventName = eventName.trim().toUpperCase();
     switch (eventFilteringOption) {
       // disabled filtering
       case "disable":
@@ -702,15 +703,12 @@ class Analytics {
       // Blacklist is choosen for filtering events
       case "blacklistedEvents":
         const isValidBlackList =
-          blacklistedEvents &&
-          Array.isArray(blacklistedEvents) &&
-          blacklistedEvents.every((x) => x.eventName !== "");
+          blacklistedEvents && Array.isArray(blacklistedEvents);
 
         if (isValidBlackList) {
           return blacklistedEvents.find(
             (eventObj) =>
-              eventObj.eventName.trim().toUpperCase() ===
-              eventName.trim().toUpperCase()
+              eventObj.eventName.trim().toUpperCase() === formattedEventName
           ) === undefined
             ? false
             : true;
@@ -720,14 +718,11 @@ class Analytics {
       // Whitelist is choosen for filtering events
       case "whitelistedEvents":
         const isValidWhiteList =
-          whitelistedEvents &&
-          Array.isArray(whitelistedEvents) &&
-          whitelistedEvents.some((x) => x.eventName !== "");
+          whitelistedEvents && Array.isArray(whitelistedEvents);
         if (isValidWhiteList) {
           return whitelistedEvents.find(
             (eventObj) =>
-              eventObj.eventName.trim().toUpperCase() ===
-              eventName.trim().toUpperCase()
+              eventObj.eventName.trim().toUpperCase() === formattedEventName
           ) === undefined
             ? true
             : false;


### PR DESCRIPTION
## Description of the change

Empty event names in the destination event filtering config prevents users from either blacklisting or whitelisting their events. 
Hence, removed the check for empty event names.

_Note: Currently, users cannot delete event names in the destination config once added. As a result, if a user accidentally clicks on "add new item" and saves the configuration, the event name will be stored as an empty string ("") in the database._

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/489)
<!-- Reviewable:end -->
