### PR TITLE
FB Pixel: Added object validations in getEventId function

### DIFF
--- a/integrations/FacebookPixel/utils.js
+++ b/integrations/FacebookPixel/utils.js
@@ -1,9 +1,8 @@
 function getEventId(message) {
-  return (
-    message.traits.event_id ||
-    message.context.traits.event_id ||
-    message.properties.event_id ||
-    message.messageId
-  );
+  if (message.traits) return message.traits.event_id;
+  if (message.context && message.context.traits)
+    return message.context.traits.event_id;
+  if (message.properties) return message.properties.event_id;
+  return message.messageId;
 }
 export default getEventId;


### PR DESCRIPTION
## Description of the change

> In FB Pixel utils, added object validations to check for `traits`, `context.traits`, and `properties` on the `message` object before accessing the `event_id` field.
Without these changes, it was causing an exception, and events do not flow to any other destinations that are after the FB Pixel destination.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/491)
<!-- Reviewable:end -->
