### PR TITLE
Feature: Auto capture anonymous id 

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -106,7 +106,7 @@ class Analytics {
   /**
    * initialize the user after load config
    */
-  initializeUser(autoAssignAnonId) {
+  initializeUser(anonymousIdOptions) {
     this.userId =
       this.storage.getUserId() != undefined ? this.storage.getUserId() : "";
 
@@ -123,7 +123,7 @@ class Analytics {
         ? this.storage.getGroupTraits()
         : {};
 
-    this.anonymousId = this.getAnonymousId(autoAssignAnonId);
+    this.anonymousId = this.getAnonymousId(anonymousIdOptions);
 
     // save once for storing older values to encrypted
     this.storage.setUserId(this.userId);
@@ -936,9 +936,9 @@ class Analytics {
     this.storage.clear(flag);
   }
 
-  getAnonymousId(autoAssignAnonId) {
+  getAnonymousId(anonymousIdOptions) {
     // if (!this.loaded) return;
-    this.anonymousId = this.storage.getAnonymousId(autoAssignAnonId);
+    this.anonymousId = this.storage.getAnonymousId(anonymousIdOptions);
     if (!this.anonymousId) {
       this.setAnonymousId();
     }
@@ -1072,7 +1072,7 @@ class Analytics {
     }
 
     this.eventRepository.initialize(writeKey, serverUrl, options);
-    this.initializeUser(options ? options.autoAssignAnonId : undefined);
+    this.initializeUser(options ? options.anonymousIdOptions : undefined);
     this.setInitialPageProperties();
     this.loaded = true;
     if (

--- a/analytics.js
+++ b/analytics.js
@@ -1072,11 +1072,7 @@ class Analytics {
     }
 
     this.eventRepository.initialize(writeKey, serverUrl, options);
-    if (options && options.autoAssignAnonId) {
-      this.initializeUser(options.autoAssignAnonId);
-    } else {
-      this.initializeUser();
-    }
+    this.initializeUser(options ? options.autoAssignAnonId : undefined);
     this.setInitialPageProperties();
     this.loaded = true;
     if (

--- a/analytics.js
+++ b/analytics.js
@@ -106,7 +106,7 @@ class Analytics {
   /**
    * initialize the user after load config
    */
-  initializeUser() {
+  initializeUser(autoAssignAnonId) {
     this.userId =
       this.storage.getUserId() != undefined ? this.storage.getUserId() : "";
 
@@ -123,7 +123,7 @@ class Analytics {
         ? this.storage.getGroupTraits()
         : {};
 
-    this.anonymousId = this.getAnonymousId();
+    this.anonymousId = this.getAnonymousId(autoAssignAnonId);
 
     // save once for storing older values to encrypted
     this.storage.setUserId(this.userId);
@@ -936,9 +936,9 @@ class Analytics {
     this.storage.clear(flag);
   }
 
-  getAnonymousId() {
+  getAnonymousId(autoAssignAnonId) {
     // if (!this.loaded) return;
-    this.anonymousId = this.storage.getAnonymousId();
+    this.anonymousId = this.storage.getAnonymousId(autoAssignAnonId);
     if (!this.anonymousId) {
       this.setAnonymousId();
     }
@@ -1072,7 +1072,11 @@ class Analytics {
     }
 
     this.eventRepository.initialize(writeKey, serverUrl, options);
-    this.initializeUser();
+    if (options && options.autoAssignAnonId) {
+      this.initializeUser(options.autoAssignAnonId);
+    } else {
+      this.initializeUser();
+    }
     this.setInitialPageProperties();
     this.loaded = true;
     if (

--- a/dist/rudder-sdk-js/index.d.ts
+++ b/dist/rudder-sdk-js/index.d.ts
@@ -50,6 +50,16 @@ declare module "rudder-sdk-js" {
   }
 
   /**
+   * Represents the options parameter for anonymousId
+   */
+  interface anonymousIdOptions {
+    autoCapture?: {
+      enabled?: boolean;
+      source?: string;
+    };
+  }
+
+  /**
    * Represents the options parameter in the load API
    */
   interface loadOptions {
@@ -75,16 +85,6 @@ declare module "rudder-sdk-js" {
     beaconQueueOptions?: beaconQueueOptions;
     cookieConsentManager?: cookieConsentManager;
     anonymousIdOptions?: anonymousIdOptions;
-  }
-
-  /**
-   * Represents the options parameter for anonymousId
-   */
-  interface anonymousIdOptions {
-    autoCapture: {
-      enabled: boolean;
-      source: string;
-    };
   }
 
   /**
@@ -410,9 +410,7 @@ declare module "rudder-sdk-js" {
   /**
    * To get anonymousId set in the SDK
    */
-  function getAnonymousId(
-    anonymousIdOptions: undefined | anonymousIdOptions
-  ): string;
+  function getAnonymousId(options?: anonymousIdOptions): string;
 
   /**
    * To set anonymousId
@@ -442,6 +440,7 @@ declare module "rudder-sdk-js" {
     queueOptions,
     apiObject,
     apiCallback,
+    anonymousIdOptions,
     load,
     ready,
     reset,

--- a/dist/rudder-sdk-js/index.d.ts
+++ b/dist/rudder-sdk-js/index.d.ts
@@ -74,6 +74,17 @@ declare module "rudder-sdk-js" {
     useBeacon?: boolean; // Defaults to false
     beaconQueueOptions?: beaconQueueOptions;
     cookieConsentManager?: cookieConsentManager;
+    anonymousIdOptions?: anonymousIdOptions;
+  }
+
+  /**
+   * Represents the options parameter for anonymousId
+   */
+  interface anonymousIdOptions {
+    autoCapture: {
+      enabled: boolean;
+      source: string;
+    };
   }
 
   /**
@@ -399,7 +410,9 @@ declare module "rudder-sdk-js" {
   /**
    * To get anonymousId set in the SDK
    */
-  function getAnonymousId(): string;
+  function getAnonymousId(
+    anonymousIdOptions: undefined | anonymousIdOptions
+  ): string;
 
   /**
    * To set anonymousId

--- a/utils/storage/cookie.js
+++ b/utils/storage/cookie.js
@@ -12,7 +12,7 @@ class CookieLocal {
   constructor(options) {
     this._options = {};
     this.options(options);
-    this.isSupportAvailable = this.isSupportAvailable();
+    this.isSupportAvailable = this.checkSupportAvailability();
   }
 
   /**
@@ -74,7 +74,7 @@ class CookieLocal {
    * Function to check cookie support exists or not
    * @returns boolean
    */
-  isSupportAvailable() {
+  checkSupportAvailability() {
     const name = "test_rudder_cookie";
     this.set(name, true);
 

--- a/utils/storage/cookie.js
+++ b/utils/storage/cookie.js
@@ -12,7 +12,7 @@ class CookieLocal {
   constructor(options) {
     this._options = {};
     this.options(options);
-    this.cookieSupported = this.IsCookieSupported();
+    this.isSupportAvailable = this.isSupportAvailable();
   }
 
   /**
@@ -74,11 +74,12 @@ class CookieLocal {
    * Function to check cookie support exists or not
    * @returns boolean
    */
-  IsCookieSupported() {
-    this.set("rudder_cookies", true);
+  isSupportAvailable() {
+    const name = "test_rudder_cookie";
+    this.set(name, true);
 
-    if (this.get("rudder_cookies")) {
-      this.remove("rudder_cookies");
+    if (this.get(name)) {
+      this.remove(name);
       return true;
     }
     return false;

--- a/utils/storage/cookie.js
+++ b/utils/storage/cookie.js
@@ -33,11 +33,9 @@ class CookieLocal {
     });
 
     // try setting a cookie first
-    this.set("test_rudder", true);
-    if (!this.get("test_rudder")) {
+    if (this.IsCookieSupported()) {
       this._options.domain = null;
     }
-    this.remove("test_rudder");
   }
 
   /**

--- a/utils/storage/cookie.js
+++ b/utils/storage/cookie.js
@@ -12,6 +12,7 @@ class CookieLocal {
   constructor(options) {
     this._options = {};
     this.options(options);
+    this.cookieSupported = this.IsCookieSupported();
   }
 
   /**
@@ -31,11 +32,6 @@ class CookieLocal {
       domain,
       samesite: "Lax",
     });
-
-    // try setting a cookie first
-    if (this.IsCookieSupported()) {
-      this._options.domain = null;
-    }
   }
 
   /**

--- a/utils/storage/cookie.js
+++ b/utils/storage/cookie.js
@@ -75,6 +75,20 @@ class CookieLocal {
       return false;
     }
   }
+
+  /**
+   * Function to check cookie support exists or not
+   * @returns boolean
+   */
+  IsCookieSupported() {
+    this.set("rudder_cookies", true);
+
+    if (this.get("rudder_cookies")) {
+      this.remove("rudder_cookies");
+      return true;
+    }
+    return false;
+  }
 }
 
 // Exporting only the instance

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -271,6 +271,8 @@ class Storage {
         if (Store.enabled) {
           anonId = Store.get(anonymousIdKeyMap[key]);
         }
+        // If anonymousId is not present in local storage and check cookie support exists
+        // fetch it from cookie
         if (!anonId && Cookie.IsCookieSupported()) {
           anonId = Cookie.get(anonymousIdKeyMap[key]);
         }
@@ -295,26 +297,35 @@ class Storage {
    * Finally if no anonymous Id is present in the source it will return undefined.
    *
    * anonymousIdOptions example:
-   *
+   *  {
+        autoCapture: {
+          enabled: true,
+          source: "segment",
+        },
+      }
    *
    */
   getAnonymousId(anonymousIdOptions) {
+    // fetch the rl_anonymous_id from storage
     const rlAnonymousId = this.parse(
       this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
     );
     if (rlAnonymousId) {
-      return rlAnonymousId;
+      return rlAnonymousId; // return if already present
     }
+    // validate the provided anonymousIdOptions argument
     const source = get(anonymousIdOptions, "autoCapture.source");
     if (
       get(anonymousIdOptions, "autoCapture.enabled") === true &&
       typeof source === "string"
     ) {
+      // fetch the anonymousId from the external source
+      // ex - segment
       const anonId = this.fetchExternalAnonymousId(source);
-      if (anonId) return anonId;
+      if (anonId) return anonId; // return anonymousId if present
     }
 
-    return rlAnonymousId;
+    return rlAnonymousId; // return undefined
   }
 
   /**

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -260,7 +260,12 @@ class Storage {
           anonId = Store.get(anonymousIdKeyMap[key]);
         }
         if (!anonId) {
-          anonId = Cookie.get(anonymousIdKeyMap[key]);
+          Cookie.set("rudder_cookies", true);
+
+          if (Cookie.get("rudder_cookies")) {
+            Cookie.remove("rudder_cookies");
+            anonId = Cookie.get(anonymousIdKeyMap[key]);
+          }
         }
         return anonId;
 

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -255,9 +255,9 @@ class Storage {
    * @param {string} key source of the anonymousId
    * @returns string
    */
-  fetchExternalAnonymousId(key) {
+  fetchExternalAnonymousId(source) {
     let anonId;
-
+    const key = source.toLowerCase();
     if (!Object.keys(anonymousIdKeyMap).includes(key)) {
       return anonId;
     }
@@ -287,7 +287,7 @@ class Storage {
       typeof anonymousIdOptions.autoCapture.source === "string"
     ) {
       const anonId = this.fetchExternalAnonymousId(
-        anonymousIdOptions.autoCapture.source.toLowerCase()
+        anonymousIdOptions.autoCapture.source
       );
       if (anonId) return anonId;
     }

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -257,10 +257,10 @@ class Storage {
     switch (key) {
       case "segment":
         if (Store.enabled) {
-          anonId = Store.get(anonymousIdKeyMapper[key]);
+          anonId = Store.get(anonymousIdKeyMap[key]);
         }
         if (!anonId) {
-          anonId = Cookie.get(anonymousIdKeyMapper.segment);
+          anonId = Cookie.get(anonymousIdKeyMap[key]);
         }
         return anonId;
 
@@ -273,7 +273,7 @@ class Storage {
    * get stored anonymous id
    */
   getAnonymousId(key) {
-    if (Object.keys(anonymousIdKeyMapper).includes(key)) {
+    if (Object.keys(anonymousIdKeyMap).includes(key)) {
       const anonId = this.fetchAnonymousId(key);
       if (anonId) return anonId;
     }

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -273,7 +273,7 @@ class Storage {
    * get stored anonymous id
    */
   getAnonymousId(key) {
-    if (typeof key === "string" && anonymousIdKeyMapper[key]) {
+    if (Object.keys(anonymousIdKeyMapper).includes(key)) {
       const anonId = this.fetchAnonymousId(key);
       if (anonId) return anonId;
     }

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -287,7 +287,7 @@ class Storage {
   getAnonymousId(anonymousIdOptions) {
     const source = get(anonymousIdOptions, "autoCapture.source");
     if (
-      get(anonymousIdOptions, "autoCapture.enabled") &&
+      get(anonymousIdOptions, "autoCapture.enabled") === true &&
       typeof source === "string"
     ) {
       const anonId = this.fetchExternalAnonymousId(source);

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -17,6 +17,10 @@ const defaults = {
   key: "Rudder",
 };
 
+const anonymousIdKeyMapper = {
+  segment: "ajs_anonymous_id",
+};
+
 /**
  * An object that handles persisting key-val from Analytics
  */
@@ -248,10 +252,31 @@ class Storage {
     );
   }
 
+  fetchAnonymousId(key) {
+    let anonId;
+    switch (key) {
+      case "segment":
+        if (Store.enabled) {
+          anonId = Store.get(anonymousIdKeyMapper.segment);
+        }
+        if (!anonId) {
+          anonId = Cookie.get(anonymousIdKeyMapper.segment);
+        }
+        return anonId;
+
+      default:
+        return undefined;
+    }
+  }
+
   /**
    * get stored anonymous id
    */
-  getAnonymousId() {
+  getAnonymousId(key) {
+    if (typeof key === "string" && anonymousIdKeyMapper[key]) {
+      const anonId = this.fetchAnonymousId(key);
+      if (anonId) return anonId;
+    }
     return this.parse(
       this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
     );

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -263,6 +263,10 @@ class Storage {
     }
     switch (key) {
       case "segment":
+        /**
+         * First check the local storage for anonymousId
+         * Ref: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#identify
+         */
         if (Store.enabled) {
           anonId = Store.get(anonymousIdKeyMap[key]);
         }

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -311,11 +311,18 @@ class Storage {
       this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
     );
     // If RS's anonymous ID is available, return from here.
-    // The user, while migrating from a different analytics SDK, will only need to auto-capture the anonymous ID when the RS SDK loads for the first time. 
-    // The captured anonymous ID would be available in RS's persistent storage for all the subsequent SDK runs. 
-    // So, instead of always grabbing the ID from the migration source when the options are specified, it is first checked in the RS's persistent storage.
-    // Moreover, the user can also clear the anonymous ID from the storage via the 'reset' API, which renders the migration source's data useless.
-    ```
+    //
+    // The user, while migrating from a different analytics SDK,
+    // will only need to auto-capture the anonymous ID when the RS SDK
+    // loads for the first time.
+    //
+    // The captured anonymous ID would be available in RS's persistent storage
+    // for all the subsequent SDK runs.
+    // So, instead of always grabbing the ID from the migration source when
+    // the options are specified, it is first checked in the RS's persistent storage.
+    //
+    // Moreover, the user can also clear the anonymous ID from the storage via
+    // the 'reset' API, which renders the migration source's data useless.
     if (rlAnonymousId) {
       return rlAnonymousId;
     }

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -310,19 +310,21 @@ class Storage {
     const rlAnonymousId = this.parse(
       this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
     );
-    // If RS's anonymous ID is available, return from here.
-    //
-    // The user, while migrating from a different analytics SDK,
-    // will only need to auto-capture the anonymous ID when the RS SDK
-    // loads for the first time.
-    //
-    // The captured anonymous ID would be available in RS's persistent storage
-    // for all the subsequent SDK runs.
-    // So, instead of always grabbing the ID from the migration source when
-    // the options are specified, it is first checked in the RS's persistent storage.
-    //
-    // Moreover, the user can also clear the anonymous ID from the storage via
-    // the 'reset' API, which renders the migration source's data useless.
+    /**
+     * If RS's anonymous ID is available, return from here.
+     *
+     * The user, while migrating from a different analytics SDK,
+     * will only need to auto-capture the anonymous ID when the RS SDK
+     * loads for the first time.
+     *
+     * The captured anonymous ID would be available in RS's persistent storage
+     * for all the subsequent SDK runs.
+     * So, instead of always grabbing the ID from the migration source when
+     * the options are specified, it is first checked in the RS's persistent storage.
+     *
+     * Moreover, the user can also clear the anonymous ID from the storage via
+     * the 'reset' API, which renders the migration source's data useless.
+     */
     if (rlAnonymousId) {
       return rlAnonymousId;
     }

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -252,7 +252,7 @@ class Storage {
     );
   }
 
-  fetchAnonymousId(key) {
+  fetchExternalAnonymousId(key) {
     let anonId;
     switch (key) {
       case "segment":

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -310,9 +310,12 @@ class Storage {
     const rlAnonymousId = this.parse(
       this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
     );
-    /**
-     * If rl_anonymous_id is already present return the value rather then executing the rest of the block
-     */
+    // If RS's anonymous ID is available, return from here.
+    // The user, while migrating from a different analytics SDK, will only need to auto-capture the anonymous ID when the RS SDK loads for the first time. 
+    // The captured anonymous ID would be available in RS's persistent storage for all the subsequent SDK runs. 
+    // So, instead of always grabbing the ID from the migration source when the options are specified, it is first checked in the RS's persistent storage.
+    // Moreover, the user can also clear the anonymous ID from the storage via the 'reset' API, which renders the migration source's data useless.
+    ```
     if (rlAnonymousId) {
       return rlAnonymousId;
     }

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -17,7 +17,7 @@ const defaults = {
   key: "Rudder",
 };
 
-const anonymousIdKeyMapper = {
+const anonymousIdKeyMap = {
   segment: "ajs_anonymous_id",
 };
 

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -1,7 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import AES from "crypto-js/aes";
 import Utf8 from "crypto-js/enc-utf8";
-import get from "get-value";
 import logger from "../logUtil";
 import { Cookie } from "./cookie";
 import { Store } from "./store";
@@ -259,7 +258,7 @@ class Storage {
   fetchExternalAnonymousId(key) {
     let anonId;
 
-    if (Object.keys(anonymousIdKeyMap).includes(key)) {
+    if (!Object.keys(anonymousIdKeyMap).includes(key)) {
       return anonId;
     }
     switch (key) {
@@ -281,9 +280,15 @@ class Storage {
    * get stored anonymous id
    */
   getAnonymousId(anonymousIdOptions) {
-    const source = get(anonymousIdOptions, "source");
-    if (get(anonymousIdOptions, "enabled") && typeof source === "string") {
-      const anonId = this.fetchExternalAnonymousId(source.toLowerCase());
+    if (
+      anonymousIdOptions &&
+      anonymousIdOptions.autoCapture &&
+      anonymousIdOptions.autoCapture.enabled &&
+      typeof anonymousIdOptions.autoCapture.source === "string"
+    ) {
+      const anonId = this.fetchExternalAnonymousId(
+        anonymousIdOptions.autoCapture.source.toLowerCase()
+      );
       if (anonId) return anonId;
     }
 

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -254,7 +254,7 @@ class Storage {
 
   fetchAnonymousId(key) {
     let anonId;
-    switch (key.toLowerCase()) {
+    switch (key) {
       case "segment":
         if (Store.enabled) {
           anonId = Store.get(anonymousIdKeyMap[key]);
@@ -277,11 +277,20 @@ class Storage {
   /**
    * get stored anonymous id
    */
-  getAnonymousId(key) {
-    if (Object.keys(anonymousIdKeyMap).includes(key)) {
-      const anonId = this.fetchAnonymousId(key);
-      if (anonId) return anonId;
+  getAnonymousId(anonymousIdOptions) {
+    if (
+      anonymousIdOptions &&
+      anonymousIdOptions.autoCapture &&
+      anonymousIdOptions.autoCapture.enabled &&
+      typeof anonymousIdOptions.autoCapture.source === "string"
+    ) {
+      const source = anonymousIdOptions.autoCapture.source.toLowerCase();
+      if (Object.keys(anonymousIdKeyMap).includes(source)) {
+        const anonId = this.fetchAnonymousId(source);
+        if (anonId) return anonId;
+      }
     }
+
     return this.parse(
       this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
     );

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -29,7 +29,7 @@ class Storage {
   constructor() {
     // First try setting the storage to cookie else to localstorage
 
-    if (Cookie.IsCookieSupported()) {
+    if (Cookie.cookieSupported) {
       this.storage = Cookie;
       return;
     }

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -29,7 +29,7 @@ class Storage {
   constructor() {
     // First try setting the storage to cookie else to localstorage
 
-    if (Cookie.cookieSupported) {
+    if (Cookie.isSupportAvailable) {
       this.storage = Cookie;
       return;
     }
@@ -310,8 +310,11 @@ class Storage {
     const rlAnonymousId = this.parse(
       this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
     );
+    /**
+     * If rl_anonymous_id is already present return the value rather then executing the rest of the block
+     */
     if (rlAnonymousId) {
-      return rlAnonymousId; // return if already present
+      return rlAnonymousId;
     }
     // validate the provided anonymousIdOptions argument
     const source = get(anonymousIdOptions, "autoCapture.source");

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import AES from "crypto-js/aes";
 import Utf8 from "crypto-js/enc-utf8";
+import get from "get-value";
 import logger from "../logUtil";
 import { Cookie } from "./cookie";
 import { Store } from "./store";
@@ -284,15 +285,12 @@ class Storage {
    * get stored anonymous id
    */
   getAnonymousId(anonymousIdOptions) {
+    const source = get(anonymousIdOptions, "autoCapture.source");
     if (
-      anonymousIdOptions &&
-      anonymousIdOptions.autoCapture &&
-      anonymousIdOptions.autoCapture.enabled &&
-      typeof anonymousIdOptions.autoCapture.source === "string"
+      get(anonymousIdOptions, "autoCapture.enabled") &&
+      typeof source === "string"
     ) {
-      const anonId = this.fetchExternalAnonymousId(
-        anonymousIdOptions.autoCapture.source
-      );
+      const anonId = this.fetchExternalAnonymousId(source);
       if (anonId) return anonId;
     }
 

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -283,8 +283,28 @@ class Storage {
 
   /**
    * get stored anonymous id
+   *
+   * Use cases:
+   * 1. getAnonymousId() ->  anonymousIdOptions is undefined this function will return rl_anonymous_id
+   * if present otherwise undefined
+   *
+   * 2. getAnonymousId(anonymousIdOptions) -> In case anonymousIdOptions is present this function will check
+   * if rl_anonymous_id is present then it will return that
+   *
+   * otherwise it will validate the anonymousIdOptions and try to fetch the anonymous Id from the provided source.
+   * Finally if no anonymous Id is present in the source it will return undefined.
+   *
+   * anonymousIdOptions example:
+   *
+   *
    */
   getAnonymousId(anonymousIdOptions) {
+    const rlAnonymousId = this.parse(
+      this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
+    );
+    if (rlAnonymousId) {
+      return rlAnonymousId;
+    }
     const source = get(anonymousIdOptions, "autoCapture.source");
     if (
       get(anonymousIdOptions, "autoCapture.enabled") === true &&
@@ -294,9 +314,7 @@ class Storage {
       if (anonId) return anonId;
     }
 
-    return this.parse(
-      this.decryptValue(this.storage.get(defaults.user_storage_anonymousId))
-    );
+    return rlAnonymousId;
   }
 
   /**

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -254,7 +254,7 @@ class Storage {
 
   fetchAnonymousId(key) {
     let anonId;
-    switch (key) {
+    switch (key.toLowerCase()) {
       case "segment":
         if (Store.enabled) {
           anonId = Store.get(anonymousIdKeyMap[key]);

--- a/utils/storage/storage.js
+++ b/utils/storage/storage.js
@@ -257,7 +257,7 @@ class Storage {
     switch (key) {
       case "segment":
         if (Store.enabled) {
-          anonId = Store.get(anonymousIdKeyMapper.segment);
+          anonId = Store.get(anonymousIdKeyMapper[key]);
         }
         if (!anonId) {
           anonId = Cookie.get(anonymousIdKeyMapper.segment);


### PR DESCRIPTION
## Description of the change

> For the customers migrating from Segment, SDK will auto capture Segment’s anonymousID and set it as RS’s anonymousID.
 - Added an option in the load call, `autoAssignAnonId`. If you set it to `segment`, it will auto capture the anonymousID if present in cookie or local storage.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/497)
<!-- Reviewable:end -->
