### PR TITLE
Feature: Allow API calls before load

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1336,10 +1336,13 @@ const eventsPushedAlready =
   !!window.rudderanalytics &&
   window.rudderanalytics.push == Array.prototype.push;
 
-const argumentsArray = window.rudderanalytics;
+let argumentsArray = window.rudderanalytics;
+
+const apiCallsBeforeLoad = [];
 
 while (argumentsArray && argumentsArray[0] && argumentsArray[0][0] !== "load") {
-  argumentsArray.shift();
+  // Collect the methods that are called before load in "apiCallsBeforeLoad" array
+  apiCallsBeforeLoad.push(argumentsArray.shift());
 }
 if (
   argumentsArray &&
@@ -1351,6 +1354,14 @@ if (
   logger.debug("=====from init, calling method:: ", method);
   instance[method](...argumentsArray[0]);
   argumentsArray.shift();
+  /**
+   * After load is called
+   * Check if the array has any method that is called before load
+   * If present, Push the calls at the front of the call stack
+   */
+  if (apiCallsBeforeLoad.length) {
+    argumentsArray = apiCallsBeforeLoad.concat(argumentsArray);
+  }
 }
 
 // once loaded, parse querystring of the page url to send events

--- a/analytics.js
+++ b/analytics.js
@@ -1336,7 +1336,7 @@ const eventsPushedAlready =
   !!window.rudderanalytics &&
   window.rudderanalytics.push == Array.prototype.push;
 
-const argumentsArray = window.rudderanalytics;
+const argumentsArray = window.rudderanalytics || [];
 /**
  * Iterate the call stack until we find load call and
  * then shift it to the beginning.
@@ -1345,32 +1345,25 @@ const argumentsArray = window.rudderanalytics;
  * It will become [load, page, identify, track]
  */
 let i = 0;
-let loadPresent = false;
 while (i < argumentsArray.length) {
   if (argumentsArray[i] && argumentsArray[i][0] === "load") {
     argumentsArray.unshift(argumentsArray.splice(i, 1)[0]);
-    loadPresent = true;
     break;
   }
   i += 1;
 }
-/**
- * When load is not present in the call stack restrict other events from proceeding
- */
-if (!loadPresent) {
-  argumentsArray.length = 0;
-}
 
-if (
-  argumentsArray &&
-  argumentsArray.length > 0 &&
-  argumentsArray[0][0] === "load"
-) {
+if (argumentsArray.length > 0 && argumentsArray[0][0] === "load") {
   const method = argumentsArray[0][0];
   argumentsArray[0].shift();
   logger.debug("=====from init, calling method:: ", method);
   instance[method](...argumentsArray[0]);
   argumentsArray.shift();
+} else {
+  /**
+   * When load is not present in the call stack restrict other events from proceeding
+   */
+  argumentsArray.length = 0;
 }
 
 // once loaded, parse querystring of the page url to send events

--- a/analytics.js
+++ b/analytics.js
@@ -1336,7 +1336,7 @@ const eventsPushedAlready =
   !!window.rudderanalytics &&
   window.rudderanalytics.push == Array.prototype.push;
 
-const argumentsArray = window.rudderanalytics || [];
+const argumentsArray = window.rudderanalytics;
 /**
  * Iterate the call stack until we find load call and
  * then shift it to the beginning.
@@ -1345,7 +1345,7 @@ const argumentsArray = window.rudderanalytics || [];
  * It will become [load, page, identify, track]
  */
 let i = 0;
-while (i < argumentsArray.length) {
+while (argumentsArray && i < argumentsArray.length) {
   if (argumentsArray[i] && argumentsArray[i][0] === "load") {
     argumentsArray.unshift(argumentsArray.splice(i, 1)[0]);
     break;
@@ -1353,17 +1353,16 @@ while (i < argumentsArray.length) {
   i += 1;
 }
 
-if (argumentsArray.length > 0 && argumentsArray[0][0] === "load") {
+if (
+  argumentsArray &&
+  argumentsArray.length > 0 &&
+  argumentsArray[0][0] === "load"
+) {
   const method = argumentsArray[0][0];
   argumentsArray[0].shift();
   logger.debug("=====from init, calling method:: ", method);
   instance[method](...argumentsArray[0]);
   argumentsArray.shift();
-} else {
-  /**
-   * When load is not present in the call stack restrict other events from proceeding
-   */
-  argumentsArray.length = 0;
 }
 
 // once loaded, parse querystring of the page url to send events

--- a/analytics.js
+++ b/analytics.js
@@ -1370,7 +1370,7 @@ const parsedQueryObject = instance.parseQueryString(window.location.search);
 
 pushQueryStringDataToAnalyticsArray(parsedQueryObject);
 
-if (argumentsArray && argumentsArray.length > 0) {
+if (Array.isArray(argumentsArray) && argumentsArray.length > 0) {
   for (let i = 0; i < argumentsArray.length; i++) {
     instance.toBeProcessedArray.push(argumentsArray[i]);
   }

--- a/analytics.js
+++ b/analytics.js
@@ -1344,11 +1344,13 @@ const argumentsArray = window.rudderanalytics;
  * Ex: Say the call stack currently have [page, identify, load, track]
  * It will become [load, page, identify, track]
  */
-for (let i = 0; i < argumentsArray.length; i++) {
+let i = 0;
+while (i < argumentsArray.length) {
   if (argumentsArray[i] && argumentsArray[i][0] === "load") {
     argumentsArray.unshift(argumentsArray.splice(i, 1)[0]);
     break;
   }
+  i += 1;
 }
 
 if (

--- a/analytics.js
+++ b/analytics.js
@@ -1345,12 +1345,20 @@ const argumentsArray = window.rudderanalytics;
  * It will become [load, page, identify, track]
  */
 let i = 0;
+let loadPresent = false;
 while (i < argumentsArray.length) {
   if (argumentsArray[i] && argumentsArray[i][0] === "load") {
     argumentsArray.unshift(argumentsArray.splice(i, 1)[0]);
+    loadPresent = true;
     break;
   }
   i += 1;
+}
+/**
+ * When load is not present in the call stack restrict other events from proceeding
+ */
+if (!loadPresent) {
+  argumentsArray.length = 0;
 }
 
 if (

--- a/analytics.js
+++ b/analytics.js
@@ -1337,32 +1337,31 @@ const eventsPushedAlready =
   window.rudderanalytics.push == Array.prototype.push;
 
 const argumentsArray = window.rudderanalytics;
-/**
- * Iterate the call stack until we find load call and
- * then shift it to the beginning.
- *
- * Ex: Say the call stack currently have [page, identify, load, track]
- * It will become [load, page, identify, track]
- */
-let i = 0;
-while (Array.isArray(argumentsArray) && i < argumentsArray.length) {
-  if (argumentsArray[i] && argumentsArray[i][0] === "load") {
-    argumentsArray.unshift(argumentsArray.splice(i, 1)[0]);
-    break;
+const isArray = Array.isArray(argumentsArray);
+if (isArray) {
+  /**
+   * Iterate the call stack until we find load call and
+   * then shift it to the beginning.
+   *
+   * Ex: Say the call stack currently have [page, identify, load, track]
+   * It will become [load, page, identify, track]
+   */
+  let i = 0;
+  while (i < argumentsArray.length) {
+    if (argumentsArray[i] && argumentsArray[i][0] === "load") {
+      argumentsArray.unshift(argumentsArray.splice(i, 1)[0]);
+      break;
+    }
+    i += 1;
   }
-  i += 1;
-}
 
-if (
-  Array.isArray(argumentsArray) &&
-  argumentsArray.length > 0 &&
-  argumentsArray[0][0] === "load"
-) {
-  const method = argumentsArray[0][0];
-  argumentsArray[0].shift();
-  logger.debug("=====from init, calling method:: ", method);
-  instance[method](...argumentsArray[0]);
-  argumentsArray.shift();
+  if (argumentsArray.length > 0 && argumentsArray[0][0] === "load") {
+    const method = argumentsArray[0][0];
+    argumentsArray[0].shift();
+    logger.debug("=====from init, calling method:: ", method);
+    instance[method](...argumentsArray[0]);
+    argumentsArray.shift();
+  }
 }
 
 // once loaded, parse querystring of the page url to send events
@@ -1370,7 +1369,7 @@ const parsedQueryObject = instance.parseQueryString(window.location.search);
 
 pushQueryStringDataToAnalyticsArray(parsedQueryObject);
 
-if (Array.isArray(argumentsArray) && argumentsArray.length > 0) {
+if (isArray && argumentsArray.length > 0) {
   for (let i = 0; i < argumentsArray.length; i++) {
     instance.toBeProcessedArray.push(argumentsArray[i]);
   }

--- a/analytics.js
+++ b/analytics.js
@@ -1345,7 +1345,7 @@ const argumentsArray = window.rudderanalytics;
  * It will become [load, page, identify, track]
  */
 let i = 0;
-while (argumentsArray && i < argumentsArray.length) {
+while (Array.isArray(argumentsArray) && i < argumentsArray.length) {
   if (argumentsArray[i] && argumentsArray[i][0] === "load") {
     argumentsArray.unshift(argumentsArray.splice(i, 1)[0]);
     break;
@@ -1354,7 +1354,7 @@ while (argumentsArray && i < argumentsArray.length) {
 }
 
 if (
-  argumentsArray &&
+  Array.isArray(argumentsArray) &&
   argumentsArray.length > 0 &&
   argumentsArray[0][0] === "load"
 ) {

--- a/analytics.js
+++ b/analytics.js
@@ -1338,6 +1338,10 @@ const eventsPushedAlready =
 
 let argumentsArray = window.rudderanalytics;
 
+/**
+ * Usage of the below variable:
+ * It will be used to store the methods that are called before load.
+ */
 const apiCallsBeforeLoad = [];
 
 while (argumentsArray && argumentsArray[0] && argumentsArray[0][0] !== "load") {
@@ -1358,6 +1362,9 @@ if (
    * After load is called
    * Check if the array has any method that is called before load
    * If present, Push the calls at the front of the call stack
+   *
+   * Ex: Say the call stack currently have [page, identify, load, track]
+   * It will become [load, page, identify, track]
    */
   if (apiCallsBeforeLoad.length) {
     argumentsArray = apiCallsBeforeLoad.concat(argumentsArray);


### PR DESCRIPTION
## Description of the change

> This feature will enable the SDK methods to be called before load.
- All the previously called methods will be pushed to the call stack after load in the same order.
- Ex: Say the call stack currently have [page, identify, load, track]. It will become [load, page, identify, track]

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/507)
<!-- Reviewable:end -->
