### PR TITLE
Fix: Accessing dead object error in Firefox

### DIFF
--- a/utils/utils.js
+++ b/utils/utils.js
@@ -193,7 +193,12 @@ function getDefaultPageProperties() {
 }
 
 function getReferrer() {
-  return document.referrer || "$direct";
+  // This error handling is in place to avoid accessing dead object(document)
+  try {
+    return document.referrer || "$direct";
+  } catch(e){
+    return "$direct";
+  }
 }
 
 function getReferringDomain(referrer) {

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -194,10 +194,12 @@ function getDefaultPageProperties() {
 
 function getReferrer() {
   // This error handling is in place to avoid accessing dead object(document)
+  const referrer = "$direct";
   try {
-    return document.referrer || "$direct";
-  } catch(e) {
-    return "$direct";
+    return document.referrer || referrer;
+  } catch (e) {
+    logger.error(e);
+    return referrer;
   }
 }
 

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -196,7 +196,7 @@ function getReferrer() {
   // This error handling is in place to avoid accessing dead object(document)
   try {
     return document.referrer || "$direct";
-  } catch(e){
+  } catch(e) {
     return "$direct";
   }
 }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -198,7 +198,7 @@ function getReferrer() {
   try {
     return document.referrer || referrer;
   } catch (e) {
-    logger.error(e);
+    logger.error("Error trying to access 'document.referrer': ", e);
     return referrer;
   }
 }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -194,7 +194,7 @@ function getDefaultPageProperties() {
 
 function getReferrer() {
   // This error handling is in place to avoid accessing dead object(document)
-  const referrer = "$direct";
+  const defaultReferrer = "$direct";
   try {
     return document.referrer || referrer;
   } catch (e) {


### PR DESCRIPTION
## Description of the change

> Added error handling for accessing dead object error in Firefox

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/567)
<!-- Reviewable:end -->
