### PR TITLE
Support LaunchDarkly key override

### DIFF
--- a/integrations/LaunchDarkly/utils.js
+++ b/integrations/LaunchDarkly/utils.js
@@ -1,6 +1,6 @@
 const createUser = (message) => {
   const user = {};
-  user.key = message.userId || message.anonymousId;
+  user.key = message.integrations.LaunchDarkly.key || message.userId || message.anonymousId;
   const { traits } = message.context;
   if (traits.anonymous !== undefined) {
     user.anonymous = traits.anonymous;


### PR DESCRIPTION
## Support LaunchDarkly `key` override

> This supports `options.integrations.LaunchDarkly.key` as an override of the `key` field sent to the LaunchDarkly JS API. This allows for anonymous users to have a shared key so that the autogenerated Rudderstack ID for anonymous users is not sent to LaunchDarkly, and therefore all anonymous users share the same key. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Fix #569

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
