### PR TITLE
Support LaunchDarkly anonymous users shared key

### DIFF
--- a/integrations/LaunchDarkly/browser.js
+++ b/integrations/LaunchDarkly/browser.js
@@ -1,4 +1,5 @@
 /* eslint-disable class-methods-use-this */
+import get from "get-value"
 import logger from "../../utils/logUtil";
 import ScriptLoader from "../ScriptLoader";
 import createUser from "./utils";
@@ -33,14 +34,15 @@ class LaunchDarkly {
 
   identify(rudderElement) {
     const { message } = rudderElement;
-    window.user = createUser(message);
+    const anonymousUsersSharedKey = get(message, `integrations.${NAME}.key`) || this.anonymousUsersSharedKey;
+    this.launchDarklyUser = createUser(message, anonymousUsersSharedKey);
 
     if (window.ldclient) {
-      window.ldclient.identify(window.user);
+      window.ldclient.identify(this.launchDarklyUser);
     } else {
       window.ldclient = window.LDClient.initialize(
         this.clientSideId,
-        window.user
+        this.launchDarklyUser
       );
     }
   }
@@ -60,7 +62,7 @@ class LaunchDarkly {
     const newUser = { key: message.userId };
 
     if (window.ldclient) {
-      window.ldclient.alias(newUser, window.user);
+      window.ldclient.alias(newUser, this.launchDarklyUser);
     } else
       logger.error(
         "=== In LaunchDarkly, alias is not supported before identify ==="

--- a/integrations/LaunchDarkly/utils.js
+++ b/integrations/LaunchDarkly/utils.js
@@ -1,9 +1,10 @@
-const createUser = (message) => {
+const createUser = (message, anonymousUsersSharedKey = undefined) => {
   const user = {};
   user.key = message.userId || message.anonymousId;
   const { traits } = message.context;
   if (traits.anonymous !== undefined) {
     user.anonymous = traits.anonymous;
+    if (!!anonymousUsersSharedKey) user.key = anonymousUsersSharedKey;
   }
   if (traits.avatar !== undefined) user.avatar = traits.avatar;
   if (traits.country !== undefined) user.country = traits.country;
@@ -18,4 +19,5 @@ const createUser = (message) => {
   if (traits.secondary !== undefined) user.secondary = traits.secondary;
   return user;
 };
+
 export default createUser;


### PR DESCRIPTION
## Support LaunchDarkly `key` override

> This supports `options.integrations.LaunchDarkly.key` as an override of the `key` field sent to the LaunchDarkly JS API. This allows for anonymous users to have a shared key so that the autogenerated Rudderstack ID for anonymous users is not sent to LaunchDarkly, and therefore all anonymous users share the same key. This is an additive change.
> [LaunchDarkly JS SDK `key` API ](https://launchdarkly.github.io/js-client-sdk/interfaces/_launchdarkly_js_client_sdk_.lduser.html#key)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Fix #569
> This originated with #570 but that was branched off of `develop`. This branches from `v1-staging`.

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/570)
<!-- Reviewable:end -->
