### PR TITLE
Fix: dataset attribute syntax updated in scriptLoader

### DIFF
--- a/integrations/Amplitude/browser.js
+++ b/integrations/Amplitude/browser.js
@@ -64,7 +64,7 @@ class Amplitude {
           "sha384-girahbTbYZ9tT03PWWj0mEVgyxtZoyDF9KVZdL+R53PP5wCY0PiVUKq0jeRlMx9M";
         r.crossOrigin = "anonymous";
         r.async = true;
-        r.dataset.loader = LOAD_ORIGIN;
+        r.setAttribute("data-loader", LOAD_ORIGIN);
         r.src = "https://cdn.amplitude.com/libs/amplitude-7.2.1-min.gz.js";
         r.onload = function () {
           if (!e.amplitude.runQueuedFunctions) {

--- a/integrations/BingAds/browser.js
+++ b/integrations/BingAds/browser.js
@@ -21,7 +21,7 @@ class BingAds {
         (n = d.createElement(t)),
         (n.src = r),
         (n.async = 1),
-        (n.dataset.loader = LOAD_ORIGIN),
+        (n.setAttribute("data-loader", LOAD_ORIGIN)),
         (n.onload = n.onreadystatechange =
           function () {
             let s = this.readyState;

--- a/integrations/Braze/browser.js
+++ b/integrations/Braze/browser.js
@@ -89,7 +89,7 @@ class Braze {
       };
       (y = p.createElement(P)).type = "text/javascript";
       y.src = "https://js.appboycdn.com/web-sdk/2.4/appboy.min.js";
-      y.dataset.loader = LOAD_ORIGIN;
+      y.setAttribute("data-loader", LOAD_ORIGIN);
       y.async = 1;
       (b = p.getElementsByTagName(P)[0]).parentNode.insertBefore(y, b);
     })(window, document, "script");

--- a/integrations/Chartbeat/browser.js
+++ b/integrations/Chartbeat/browser.js
@@ -109,7 +109,7 @@ class Chartbeat {
         e.type = "text/javascript";
         e.async = true;
         e.src = `//static.chartbeat.com/js/${script}`;
-        e.dataset.loader = LOAD_ORIGIN;
+        e.setAttribute("data-loader", LOAD_ORIGIN);
         n.parentNode.insertBefore(e, n);
       }
       loadChartbeat();

--- a/integrations/Comscore/browser.js
+++ b/integrations/Comscore/browser.js
@@ -72,7 +72,7 @@ class Comscore {
       const s = document.createElement("script");
       const el = document.getElementsByTagName("script")[0];
       s.async = true;
-      s.dataset.loader = LOAD_ORIGIN;
+      s.setAttribute("data-loader", LOAD_ORIGIN);
       s.src = `${
         document.location.protocol == "https:" ? "https://sb" : "http://b"
       }.scorecardresearch.com/beacon.js`;

--- a/integrations/CustomerIO/browser.js
+++ b/integrations/CustomerIO/browser.js
@@ -32,7 +32,7 @@ class CustomerIO {
       const t = document.createElement("script");
       const s = document.getElementsByTagName("script")[0];
       t.async = true;
-      t.dataset.loader = LOAD_ORIGIN;
+      t.setAttribute("data-loader", LOAD_ORIGIN);
       t.id = "cio-tracker";
       t.setAttribute("data-site-id", siteID);
       t.src = "https://assets.customer.io/assets/track.js";

--- a/integrations/Drip/browser.js
+++ b/integrations/Drip/browser.js
@@ -42,7 +42,7 @@ class Drip {
     (function () {
       var dc = document.createElement("script");
       dc.type = "text/javascript";
-      dc.dataset.loader = LOAD_ORIGIN;
+      dc.setAttribute("data-loader", LOAD_ORIGIN);
       dc.async = true;
       dc.src = `//tag.getdrip.com/${window._dcs.account}.js`;
       var s = document.getElementsByTagName("script")[0];

--- a/integrations/Fullstory/browser.js
+++ b/integrations/Fullstory/browser.js
@@ -73,7 +73,7 @@ class Fullstory {
       o.async = 1;
       o.crossOrigin = "anonymous";
       o.src = `https://${_fs_script}`;
-      o.dataset.loader = LOAD_ORIGIN;
+      o.setAttribute("data-loader", LOAD_ORIGIN);
       y = n.getElementsByTagName(t)[0];
       y.parentNode.insertBefore(o, y);
       g.identify = function (i, v, s) {

--- a/integrations/GoogleAds/browser.js
+++ b/integrations/GoogleAds/browser.js
@@ -25,7 +25,7 @@ class GoogleAds {
       const js = document.createElement("script");
       js.src = src;
       js.async = 1;
-      js.dataset.loader = LOAD_ORIGIN;
+      js.setAttribute("data-loader", LOAD_ORIGIN);
       js.type = "text/javascript";
       js.id = id;
       const e = document.getElementsByTagName("head")[0];

--- a/integrations/GoogleOptimize/browser.js
+++ b/integrations/GoogleOptimize/browser.js
@@ -47,7 +47,7 @@ class GoogleOptimize {
       const flick = document.createElement("style");
       flick.innerHTML = ".async-hide { opacity: 0 !important}";
       const js = document.createElement("script");
-      js.dataset.loader = LOAD_ORIGIN;
+      js.setAttribute("data-loader", LOAD_ORIGIN);
       js.innerHTML = `(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;})(window,document.documentElement,'async-hide','dataLayer',4000,{'${this.containerId}':true});`;
       const e = document.getElementsByTagName("script")[0];
       e.parentNode.insertBefore(flick, e); // style tag in anti flicker snippet should be before the a-flicker script as per docs

--- a/integrations/GoogleTagManager/browser.js
+++ b/integrations/GoogleTagManager/browser.js
@@ -25,7 +25,7 @@ class GoogleTagManager {
       const f = d.getElementsByTagName(s)[0];
       const j = d.createElement(s);
       const dl = l !== "dataLayer" ? `&l=${l}` : "";
-      j.dataset.loader = LOAD_ORIGIN;
+      j.setAttribute("data-loader", LOAD_ORIGIN);
       j.async = true;
       j.src = `${window.finalUrl}/gtm.js?id=${i}${dl}`;
       f.parentNode.insertBefore(j, f);

--- a/integrations/Heap/browser.js
+++ b/integrations/Heap/browser.js
@@ -22,7 +22,7 @@ class Heap {
         var r = document.createElement("script");
         (r.type = "text/javascript"),
           (r.async = !0),
-          (r.dataset.loader = LOAD_ORIGIN),
+          (r.setAttribute("data-loader", LOAD_ORIGIN)),
           (r.src = "https://cdn.heapanalytics.com/js/heap-" + e + ".js");
         var a = document.getElementsByTagName("script")[0];
         a.parentNode.insertBefore(r, a);

--- a/integrations/Hotjar/browser.js
+++ b/integrations/Hotjar/browser.js
@@ -24,7 +24,7 @@ class Hotjar {
       h._hjSettings = { hjid: h.hotjarSiteId, hjsv: 6 };
       a = o.getElementsByTagName("head")[0];
       r = o.createElement("script");
-      r.dataset.loader = LOAD_ORIGIN;
+      r.setAttribute("data-loader", LOAD_ORIGIN);
       r.async = 1;
       r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
       a.appendChild(r);

--- a/integrations/INTERCOM/browser.js
+++ b/integrations/INTERCOM/browser.js
@@ -36,7 +36,7 @@ class INTERCOM {
         w.Intercom = i;
         const l = function () {
           const s = d.createElement("script");
-          s.dataset.loader = LOAD_ORIGIN;
+          s.setAttribute("data-loader", LOAD_ORIGIN);
           s.type = "text/javascript";
           s.async = true;
           s.src = `https://widget.intercom.io/widget/${window.intercomSettings.app_id}`;

--- a/integrations/Kissmetrics/browser.js
+++ b/integrations/Kissmetrics/browser.js
@@ -25,7 +25,7 @@ class Kissmetrics {
         const s = d.createElement("script");
         s.type = "text/javascript";
         s.async = true;
-        s.dataset.loader = LOAD_ORIGIN;
+        s.setAttribute("data-loader", LOAD_ORIGIN);
         s.src = u;
         f.parentNode.insertBefore(s, f);
       }, 1);

--- a/integrations/Lytics/browser.js
+++ b/integrations/Lytics/browser.js
@@ -59,7 +59,7 @@ class Lytics {
         n("call"),
         (o.loadScript = function (n, t, i) {
           var e = document.createElement("script");
-          (e.async = !0), (e.src = n), (e.onload = t), (e.onerror = i), (e.dataset.loader = LOAD_ORIGIN);
+          (e.async = !0), (e.src = n), (e.onload = t), (e.onerror = i), (e.setAttribute("data-loader", LOAD_ORIGIN));
           var o = document.getElementsByTagName("script")[0],
             r = (o && o.parentNode) || document.head || document.body,
             c = o || r.lastChild;

--- a/integrations/Matomo/browser.js
+++ b/integrations/Matomo/browser.js
@@ -12,6 +12,7 @@ import {
   checkCustomDimensions,
 } from "./util";
 import { getHashFromArrayWithDuplicate } from "../utils/commonUtils";
+import { LOAD_ORIGIN } from "../ScriptLoader";
 
 class Matomo {
   constructor(config) {
@@ -58,6 +59,7 @@ class Matomo {
       g.async = true;
       u = u.replace("https://", "");
       g.src = `//cdn.matomo.cloud/${u}matomo.js`;
+      g.setAttribute("data-loader", LOAD_ORIGIN);
       s.parentNode.insertBefore(g, s);
     })(this.serverUrl, this.siteId);
   }

--- a/integrations/Mixpanel/browser.js
+++ b/integrations/Mixpanel/browser.js
@@ -134,7 +134,7 @@ class Mixpanel {
         e = f.createElement("script");
         e.type = "text/javascript";
         e.async = !0;
-        e.dataset.loader = LOAD_ORIGIN;
+        e.setAttribute("data-loader", LOAD_ORIGIN);
         e.src =
           "undefined" !== typeof MIXPANEL_CUSTOM_LIB_URL
             ? MIXPANEL_CUSTOM_LIB_URL

--- a/integrations/MoEngage/browser.js
+++ b/integrations/MoEngage/browser.js
@@ -68,7 +68,7 @@ class MoEngage {
       a = s.createElement(o);
       m = s.getElementsByTagName(o)[0];
       a.async = 1;
-      a.dataset.loader = LOAD_ORIGIN;
+      a.setAttribute("data-loader", LOAD_ORIGIN);
       a.src = g;
       m.parentNode.insertBefore(a, m);
       i.moe =

--- a/integrations/Pendo/browser.js
+++ b/integrations/Pendo/browser.js
@@ -30,7 +30,7 @@ class Pendo {
               };
           })(v[w]);
         y = e.createElement(n);
-        y.dataset.loader = LOAD_ORIGIN;
+        y.setAttribute("data-loader", LOAD_ORIGIN);
         y.async = !0;
         y.src = `https://cdn.pendo.io/agent/static/${apiKey}/pendo.js`;
         z = e.getElementsByTagName(n)[0];

--- a/integrations/PinterestTag/browser.js
+++ b/integrations/PinterestTag/browser.js
@@ -35,7 +35,7 @@ export default class PinterestTag {
         var n = window.pintrk;
         (n.queue = []), (n.version = "3.0");
         var t = document.createElement("script");
-        (t.async = !0), (t.src = e), (t.dataset.loader = LOAD_ORIGIN);
+        (t.async = !0), (t.src = e), (t.setAttribute("data-loader", LOAD_ORIGIN));
         var r = document.getElementsByTagName("script")[0];
         r.parentNode.insertBefore(t, r);
       }

--- a/integrations/Posthog/browser.js
+++ b/integrations/Posthog/browser.js
@@ -58,7 +58,7 @@ class Posthog {
           }
           ((p = t.createElement("script")).type = "text/javascript"),
             (p.async = !0),
-            (p.dataset.loader = LOAD_ORIGIN),
+            (p.setAttribute("data-loader", LOAD_ORIGIN)),
             (p.src = s.api_host + "/static/array.js"),
             (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(
               p,

--- a/integrations/ProfitWell/browser.js
+++ b/integrations/ProfitWell/browser.js
@@ -35,7 +35,7 @@ class ProfitWell {
       a = s.createElement(g);
       m = s.getElementsByTagName(g)[0];
       a.async = 1;
-      a.dataset.loader = LOAD_ORIGIN;
+      a.setAttribute("data-loader", LOAD_ORIGIN);
       a.src = r + "?auth=" + window.publicApiKey;
       m.parentNode.insertBefore(a, m);
     })(

--- a/integrations/Qualtrics/browser.js
+++ b/integrations/Qualtrics/browser.js
@@ -91,7 +91,7 @@ class Qualtrics {
           if (this.check()) {
             var a = document.createElement("script");
             a.type = "text/javascript";
-            a.dataset.loader = LOAD_ORIGIN;
+            a.setAttribute("data-loader", LOAD_ORIGIN);
             a.src = g;
             document.body && document.body.appendChild(a);
           }

--- a/integrations/RedditPixel/browser.js
+++ b/integrations/RedditPixel/browser.js
@@ -30,7 +30,7 @@ class RedditPixel {
         p.callQueue = [];
         var t = d.createElement("script");
         (t.src = "https://www.redditstatic.com/ads/pixel.js"), (t.async = !0);
-        (t.dataset.loader = LOAD_ORIGIN);
+        (t.setAttribute("data-loader", LOAD_ORIGIN));
         var s = d.getElementsByTagName("script")[0];
         s.parentNode.insertBefore(t, s);
       }

--- a/integrations/ScriptLoader.js
+++ b/integrations/ScriptLoader.js
@@ -22,9 +22,9 @@ const ScriptLoader = (id, src, options = {}) => {
   js.id = id;
   // This checking is in place to skip the dataset attribute for some cases(while loading polyfill)
   if (options.skipDatasetAttributes !== true) {
-    js.dataset.loader = LOAD_ORIGIN;
+    js.setAttribute("data-loader", LOAD_ORIGIN);
     if (options.isNonNativeSDK !== undefined) {
-      js.dataset.isNonNativeSDK = options.isNonNativeSDK;
+      js.setAttribute("data-isNonNativeSDK", options.isNonNativeSDK);
     }
   }
   const headElmColl = document.getElementsByTagName("head");

--- a/integrations/Sentry/utils.js
+++ b/integrations/Sentry/utils.js
@@ -18,7 +18,7 @@ const SentryScriptLoader = (id, src, integrity) => {
   js.crossOrigin = "anonymous";
   js.type = "text/javascript";
   js.id = id;
-  js.dataset.loader = LOAD_ORIGIN;
+  js.setAttribute("data-loader", LOAD_ORIGIN);
   const e = document.getElementsByTagName("script")[0];
   logger.debug("==parent script==", e);
   logger.debug("==adding script==", js);

--- a/integrations/SnapPixel/browser.js
+++ b/integrations/SnapPixel/browser.js
@@ -73,7 +73,7 @@ class SnapPixel {
       var r = t.createElement(s);
       r.async = !0;
       r.src = n;
-      r.dataset.loader = LOAD_ORIGIN;
+      r.setAttribute("data-loader", LOAD_ORIGIN);
       var u = t.getElementsByTagName(s)[0];
       u.parentNode.insertBefore(r, u);
     })(window, document, "https://sc-static.net/scevent.min.js");

--- a/integrations/VWO/browser.js
+++ b/integrations/VWO/browser.js
@@ -51,7 +51,7 @@ class VWO {
             const b = d.createElement("script");
             b.src = a;
             b.type = "text/javascript";
-            b.dataset.loader = LOAD_ORIGIN;
+            b.setAttribute("data-loader", LOAD_ORIGIN);
             b.innerText;
             b.onerror = function () {
               _vwo_code.finish();


### PR DESCRIPTION
## Description of the change

> Dataset attribute syntax updated in scriptLoader as the previous syntax was not working in IE 10.

From `element.dataset.property=propertyValue` to `element.setAttribute("data-property","propertyValue")`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/598)
<!-- Reviewable:end -->
