### PR TITLE
chore(build): update terser plugin options for rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -145,7 +145,12 @@ export default {
         ["@babel/plugin-transform-object-assign"],
       ],
     }),
-    process.env.uglify === "true" && terser(),
+    process.env.uglify === "true" && terser({
+        // remove all comments
+        format: {
+          comments: false,
+        },
+      }),
     process.env.ENC === "gzip" && gzipPlugin(),
     process.env.ENC === "br" && brotli(),
     process.env.visualizer === "true" &&

--- a/rollup.intgConfig.js
+++ b/rollup.intgConfig.js
@@ -148,7 +148,12 @@ export default {
         ["@babel/plugin-transform-object-assign"],
       ],
     }),
-    process.env.uglify === "true" && terser(),
+    process.env.uglify === "true" && terser({
+        // remove all comments
+        format: {
+          comments: false,
+        },
+      }),
     process.env.ENC === "gzip" && gzipPlugin(),
     process.env.ENC === "br" && brotli(),
     process.env.visualizer === "true" &&


### PR DESCRIPTION
## Description of the change

Added options to the `terser` rollup plugin to remove all the comments in the minified output.
Earlier the documentation comments of `store-js` and `get-value` packages were getting added to the rollup output file.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/602)
<!-- Reviewable:end -->
