### PR TITLE
chore(build): update filesize rollup plugin options

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -163,6 +163,9 @@ export default {
         gzipSize: true,
         brotliSize: true,
       }),
-    filesize(),
+    filesize({
+      showBeforeSizes: "build",
+      showBrotliSize: true,
+    }),
   ],
 };

--- a/rollup.intgConfig.js
+++ b/rollup.intgConfig.js
@@ -166,6 +166,9 @@ export default {
         gzipSize: true,
         brotliSize: true,
       }),
-    filesize(),
+    filesize({
+      showBeforeSizes: "build",
+      showBrotliSize: true,
+    }),
   ],
 };


### PR DESCRIPTION
## Description of the change

Added an option to filesize rollup plugin, which will help compare the size of the output b/w the previous and current build runs. Also, added another option to show the size of Brotli compressed SDK.
This will be helpful during development.

Example output:
```
analytics.js → dist/rudder-analytics.min.js...
┌─────────────────────────────────────────────────────────────┐
│                                                             │
│   Destination: dist/rudder-analytics.min.js                 │
│   Bundle Size:  115.14 KB (was 115.58 KB in last build)     │
│   Minified Size:  114.58 KB (was 114.97 KB in last build)   │
│   Gzipped Size:  36.95 KB (was 37.2 KB in last build)       │
|   Brotli size: 30.27 KB (was 31.87 KB in last build)        |
│                                                             │
└─────────────────────────────────────────────────────────────┘
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/603)
<!-- Reviewable:end -->
