### PR TITLE
feat(integration): add common util function for mapping event names in ads destinations

### DIFF
--- a/integrations/FacebookPixel/browser.js
+++ b/integrations/FacebookPixel/browser.js
@@ -167,10 +167,7 @@ class FacebookPixel {
     }
     const customProperties = this.buildPayLoad(rudderElement, true);
     const derivedEventID = getEventId(rudderElement.message);
-    if (
-      this.eventsToEvents[event] === "ViewContent" ||
-      event === "Product List Viewed"
-    ) {
+    if (event === "Product List Viewed") {
       let contentType;
       const contentIds = [];
       const contents = [];
@@ -283,10 +280,7 @@ class FacebookPixel {
           );
         }
       }, legacyTo);
-    } else if (
-      this.eventsToEvents[event] === "AddToCart" ||
-      event === "Product Added"
-    ) {
+    } else if (event === "Product Added") {
       const contentIds = [];
       const contents = [];
 
@@ -337,10 +331,7 @@ class FacebookPixel {
         }
       }, legacyTo);
       this.merge(productInfo, customProperties);
-    } else if (
-      this.eventsToEvents[event] === "Purchase" ||
-      event === "Order Completed"
-    ) {
+    } else if (event === "Order Completed") {
       const contentType = this.getContentType(rudderElement, ["product"]);
       const contentIds = [];
       const contents = [];
@@ -402,10 +393,7 @@ class FacebookPixel {
           );
         }
       }, legacyTo);
-    } else if (
-      this.eventsToEvents[event] === "Search" ||
-      event === "Products Searched"
-    ) {
+    } else if (event === "Products Searched") {
       window.fbq(
         "trackSingle",
         self.pixelId,
@@ -437,10 +425,7 @@ class FacebookPixel {
           );
         }
       }, legacyTo);
-    } else if (
-      this.eventsToEvents[event] === "InitiateCheckout" ||
-      event === "Checkout Started"
-    ) {
+    } else if (event === "Checkout Started") {
       let contentCategory = category;
       const contentIds = [];
       const contents = [];

--- a/integrations/FacebookPixel/browser.js
+++ b/integrations/FacebookPixel/browser.js
@@ -167,7 +167,10 @@ class FacebookPixel {
     }
     const customProperties = this.buildPayLoad(rudderElement, true);
     const derivedEventID = getEventId(rudderElement.message);
-    if (event === "Product List Viewed") {
+    if (
+      this.eventsToEvents[event] === "ViewContent" ||
+      event === "Product List Viewed"
+    ) {
       let contentType;
       const contentIds = [];
       const contents = [];
@@ -280,7 +283,10 @@ class FacebookPixel {
           );
         }
       }, legacyTo);
-    } else if (event === "Product Added") {
+    } else if (
+      this.eventsToEvents[event] === "AddToCart" ||
+      event === "Product Added"
+    ) {
       const contentIds = [];
       const contents = [];
 
@@ -331,7 +337,10 @@ class FacebookPixel {
         }
       }, legacyTo);
       this.merge(productInfo, customProperties);
-    } else if (event === "Order Completed") {
+    } else if (
+      this.eventsToEvents[event] === "Purchase" ||
+      event === "Order Completed"
+    ) {
       const contentType = this.getContentType(rudderElement, ["product"]);
       const contentIds = [];
       const contents = [];
@@ -393,7 +402,10 @@ class FacebookPixel {
           );
         }
       }, legacyTo);
-    } else if (event === "Products Searched") {
+    } else if (
+      this.eventsToEvents[event] === "Search" ||
+      event === "Products Searched"
+    ) {
       window.fbq(
         "trackSingle",
         self.pixelId,
@@ -425,7 +437,10 @@ class FacebookPixel {
           );
         }
       }, legacyTo);
-    } else if (event === "Checkout Started") {
+    } else if (
+      this.eventsToEvents[event] === "InitiateCheckout" ||
+      event === "Checkout Started"
+    ) {
       let contentCategory = category;
       const contentIds = [];
       const contents = [];

--- a/integrations/GoogleAds/browser.js
+++ b/integrations/GoogleAds/browser.js
@@ -3,6 +3,7 @@ import logger from "../../utils/logUtil";
 import { LOAD_ORIGIN } from "../ScriptLoader";
 import {
   getHashFromArray,
+  getHashFromArrayWithDuplicate,
   removeUndefinedAndNullValues,
   setEventMappingFromConfig,
 } from "../utils/commonUtils";
@@ -90,7 +91,7 @@ class GoogleAds {
     } else {
       let { event } = rudderElement.message;
       // modify the event name to mapped event name from the config
-      const eventsHashmap = getHashFromArray(
+      const eventsHashmap = getHashFromArrayWithDuplicate(
         this.eventsMap,
         "from",
         "to",

--- a/integrations/GoogleAds/browser.js
+++ b/integrations/GoogleAds/browser.js
@@ -4,7 +4,7 @@ import { LOAD_ORIGIN } from "../ScriptLoader";
 import {
   getHashFromArrayWithDuplicate,
   removeUndefinedAndNullValues,
-  setEventMappingFromConfig,
+  getEventMappingFromConfig,
 } from "../utils/commonUtils";
 import { NAME } from "./constants";
 
@@ -88,7 +88,7 @@ class GoogleAds {
         window.gtag("event", eventName, properties);
       }
     } else {
-      let { event } = rudderElement.message;
+      const { event } = rudderElement.message;
       if (!event) {
         logger.error("Event name not present");
         return;
@@ -108,7 +108,7 @@ class GoogleAds {
       }
       payload.send_to = sendToValue;
 
-      const events = setEventMappingFromConfig(event, eventsHashmap);
+      const events = getEventMappingFromConfig(event, eventsHashmap);
       if (events) {
         events.forEach((ev) => {
           window.gtag("event", ev, payload);

--- a/integrations/GoogleAds/browser.js
+++ b/integrations/GoogleAds/browser.js
@@ -1,7 +1,11 @@
 /* eslint-disable class-methods-use-this */
 import logger from "../../utils/logUtil";
 import { LOAD_ORIGIN } from "../ScriptLoader";
-import { removeUndefinedAndNullValues } from "../utils/commonUtils";
+import {
+  getHashFromArray,
+  removeUndefinedAndNullValues,
+  eventMappingFromConfig,
+} from "../utils/commonUtils";
 import { NAME } from "./constants";
 
 class GoogleAds {
@@ -16,6 +20,7 @@ class GoogleAds {
     this.conversionLinker = config.conversionLinker || true;
     this.disableAdPersonalization = config.disableAdPersonalization || false;
     this.name = NAME;
+    this.eventsMap = config.eventsMap;
   }
 
   init() {
@@ -83,7 +88,10 @@ class GoogleAds {
         window.gtag("event", eventName, properties);
       }
     } else {
-      const { event } = rudderElement.message;
+      let { event } = rudderElement.message;
+      // modify the event name to mapped event name from the config
+      const eventsHashmap = getHashFromArray(this.eventsMap);
+      event = eventMappingFromConfig(event, eventsHashmap);
       if (!event) {
         logger.error("Event name not present");
         return;

--- a/integrations/GoogleAds/browser.js
+++ b/integrations/GoogleAds/browser.js
@@ -2,7 +2,6 @@
 import logger from "../../utils/logUtil";
 import { LOAD_ORIGIN } from "../ScriptLoader";
 import {
-  getHashFromArray,
   getHashFromArrayWithDuplicate,
   removeUndefinedAndNullValues,
   setEventMappingFromConfig,
@@ -109,8 +108,7 @@ class GoogleAds {
       }
       payload.send_to = sendToValue;
 
-      let events = [];
-      events = setEventMappingFromConfig(event, eventsHashmap);
+      const events = setEventMappingFromConfig(event, eventsHashmap);
       if (events) {
         events.forEach((ev) => {
           window.gtag("event", ev, payload);

--- a/integrations/GoogleAds/browser.js
+++ b/integrations/GoogleAds/browser.js
@@ -4,7 +4,7 @@ import { LOAD_ORIGIN } from "../ScriptLoader";
 import {
   getHashFromArray,
   removeUndefinedAndNullValues,
-  eventMappingFromConfig,
+  setEventMappingFromConfig,
 } from "../utils/commonUtils";
 import { NAME } from "./constants";
 
@@ -90,8 +90,13 @@ class GoogleAds {
     } else {
       let { event } = rudderElement.message;
       // modify the event name to mapped event name from the config
-      const eventsHashmap = getHashFromArray(this.eventsMap);
-      event = eventMappingFromConfig(event, eventsHashmap);
+      const eventsHashmap = getHashFromArray(
+        this.eventsMap,
+        "from",
+        "to",
+        false
+      );
+      event = setEventMappingFromConfig(event, eventsHashmap);
       if (!event) {
         logger.error("Event name not present");
         return;

--- a/integrations/RedditPixel/browser.js
+++ b/integrations/RedditPixel/browser.js
@@ -12,6 +12,7 @@ import { LOAD_ORIGIN } from "../ScriptLoader";
 import { NAME } from "./constants";
 import {
   getHashFromArray,
+  getHashFromArrayWithDuplicate,
   setEventMappingFromConfig,
 } from "../utils/commonUtils";
 
@@ -62,12 +63,12 @@ class RedditPixel {
   track(rudderElement) {
     logger.debug("===In RedditPixel track===");
 
-    let { event } = rudderElement.message;
+    const { event } = rudderElement.message;
     if (!event) {
       logger.error("Event name is not present");
       return;
     }
-    const eventMappingFromConfigMap = getHashFromArray(
+    const eventMappingFromConfigMap = getHashFromArrayWithDuplicate(
       this.eventMappingFromConfig,
       "from",
       "to",
@@ -75,8 +76,13 @@ class RedditPixel {
     );
     if (eventMappingFromConfigMap[event]) {
       // mapping event from UI
-      event = setEventMappingFromConfig(event, eventMappingFromConfigMap);
-      window.rdt("track", eventMappingFromConfigMap[event]);
+      const events = setEventMappingFromConfig(
+        event,
+        eventMappingFromConfigMap
+      );
+      events.forEach((ev) => {
+        window.rdt("track", events[ev]);
+      });
     } else {
       switch (event.toLowerCase()) {
         case "product added":

--- a/integrations/RedditPixel/browser.js
+++ b/integrations/RedditPixel/browser.js
@@ -12,6 +12,7 @@ import { LOAD_ORIGIN } from "../ScriptLoader";
 import { NAME } from "./constants";
 import {
   getHashFromArray,
+  setEventMappingFromConfig,
 } from "../utils/commonUtils";
 
 class RedditPixel {
@@ -34,7 +35,7 @@ class RedditPixel {
         p.callQueue = [];
         var t = d.createElement("script");
         (t.src = "https://www.redditstatic.com/ads/pixel.js"), (t.async = !0);
-        (t.setAttribute("data-loader", LOAD_ORIGIN));
+        t.setAttribute("data-loader", LOAD_ORIGIN);
         var s = d.getElementsByTagName("script")[0];
         s.parentNode.insertBefore(t, s);
       }
@@ -61,7 +62,7 @@ class RedditPixel {
   track(rudderElement) {
     logger.debug("===In RedditPixel track===");
 
-    const { event } = rudderElement.message;
+    let { event } = rudderElement.message;
     if (!event) {
       logger.error("Event name is not present");
       return;
@@ -70,10 +71,12 @@ class RedditPixel {
       this.eventMappingFromConfig,
       "from",
       "to",
-      false 
+      false
     );
-    if (eventMappingFromConfigMap[event]){
-      window.rdt("track", eventMappingFromConfigMap[event])
+    if (eventMappingFromConfigMap[event]) {
+      // mapping event from UI
+      event = setEventMappingFromConfig(event, eventMappingFromConfigMap);
+      window.rdt("track", eventMappingFromConfigMap[event]);
     } else {
       switch (event.toLowerCase()) {
         case "product added":

--- a/integrations/RedditPixel/browser.js
+++ b/integrations/RedditPixel/browser.js
@@ -10,11 +10,15 @@
 import logger from "../../utils/logUtil";
 import { LOAD_ORIGIN } from "../ScriptLoader";
 import { NAME } from "./constants";
+import {
+  getHashFromArray,
+} from "../utils/commonUtils";
 
 class RedditPixel {
   constructor(config) {
     this.advertiserId = config.advertiserId;
     this.name = NAME;
+    this.eventMappingFromConfig = config.eventMappingFromConfig;
   }
 
   init() {
@@ -62,29 +66,38 @@ class RedditPixel {
       logger.error("Event name is not present");
       return;
     }
-
-    switch (event.toLowerCase()) {
-      case "product added":
-        window.rdt("track", "AddToCart");
-        break;
-      case "product added to wishlist":
-        window.rdt("track", "AddToWishlist");
-        break;
-      case "order completed":
-        window.rdt("track", "Purchase");
-        break;
-      case "lead":
-        window.rdt("track", "Lead");
-        break;
-      case "view content":
-        window.rdt("track", "ViewContent");
-        break;
-      case "search":
-        window.rdt("track", "Search");
-        break;
-      default:
-        logger.error(`Invalid event ${event}. Track call not supported`);
-        break;
+    const eventMappingFromConfigMap = getHashFromArray(
+      this.eventMappingFromConfig,
+      "from",
+      "to",
+      false 
+    );
+    if (eventMappingFromConfigMap[event]){
+      window.rdt("track", eventMappingFromConfigMap[event])
+    } else {
+      switch (event.toLowerCase()) {
+        case "product added":
+          window.rdt("track", "AddToCart");
+          break;
+        case "product added to wishlist":
+          window.rdt("track", "AddToWishlist");
+          break;
+        case "order completed":
+          window.rdt("track", "Purchase");
+          break;
+        case "lead":
+          window.rdt("track", "Lead");
+          break;
+        case "view content":
+          window.rdt("track", "ViewContent");
+          break;
+        case "search":
+          window.rdt("track", "Search");
+          break;
+        default:
+          logger.error(`Invalid event ${event}. Track call not supported`);
+          break;
+      }
     }
   }
 

--- a/integrations/RedditPixel/browser.js
+++ b/integrations/RedditPixel/browser.js
@@ -81,7 +81,7 @@ class RedditPixel {
         eventMappingFromConfigMap
       );
       events.forEach((ev) => {
-        window.rdt("track", events[ev]);
+        window.rdt("track", ev);
       });
     } else {
       switch (event.toLowerCase()) {

--- a/integrations/RedditPixel/browser.js
+++ b/integrations/RedditPixel/browser.js
@@ -11,7 +11,6 @@ import logger from "../../utils/logUtil";
 import { LOAD_ORIGIN } from "../ScriptLoader";
 import { NAME } from "./constants";
 import {
-  getHashFromArray,
   getHashFromArrayWithDuplicate,
   setEventMappingFromConfig,
 } from "../utils/commonUtils";

--- a/integrations/RedditPixel/browser.js
+++ b/integrations/RedditPixel/browser.js
@@ -12,7 +12,7 @@ import { LOAD_ORIGIN } from "../ScriptLoader";
 import { NAME } from "./constants";
 import {
   getHashFromArrayWithDuplicate,
-  setEventMappingFromConfig,
+  getEventMappingFromConfig,
 } from "../utils/commonUtils";
 
 class RedditPixel {
@@ -75,7 +75,7 @@ class RedditPixel {
     );
     if (eventMappingFromConfigMap[event]) {
       // mapping event from UI
-      const events = setEventMappingFromConfig(
+      const events = getEventMappingFromConfig(
         event,
         eventMappingFromConfigMap
       );

--- a/integrations/SnapPixel/browser.js
+++ b/integrations/SnapPixel/browser.js
@@ -6,7 +6,6 @@ import logger from "../../utils/logUtil";
 import {
   setEventMappingFromConfig,
   removeUndefinedAndNullValues,
-  getHashFromArray,
   getHashFromArrayWithDuplicate,
 } from "../utils/commonUtils";
 import {

--- a/integrations/SnapPixel/browser.js
+++ b/integrations/SnapPixel/browser.js
@@ -159,7 +159,7 @@ class SnapPixel {
         );
         events.forEach((ev) => {
           sendEvent(
-            events[ev],
+            ev,
             ecommEventPayload(
               event,
               message,

--- a/integrations/SnapPixel/browser.js
+++ b/integrations/SnapPixel/browser.js
@@ -4,7 +4,7 @@ import Storage from "../../utils/storage";
 import logger from "../../utils/logUtil";
 
 import {
-  setEventMappingFromConfig,
+  getEventMappingFromConfig,
   removeUndefinedAndNullValues,
   getHashFromArrayWithDuplicate,
 } from "../utils/commonUtils";
@@ -152,7 +152,7 @@ class SnapPixel {
     try {
       if (eventMappingFromConfigMap[event]) {
         // mapping event from UI
-        const events = setEventMappingFromConfig(
+        const events = getEventMappingFromConfig(
           event,
           eventMappingFromConfigMap
         );

--- a/integrations/SnapPixel/browser.js
+++ b/integrations/SnapPixel/browser.js
@@ -3,7 +3,10 @@ import get from "get-value";
 import Storage from "../../utils/storage";
 import logger from "../../utils/logUtil";
 
-import { removeUndefinedAndNullValues } from "../utils/commonUtils";
+import {
+  removeUndefinedAndNullValues,
+  getHashFromArray,
+} from "../utils/commonUtils";
 import {
   ecommEventPayload,
   eventPayload,
@@ -20,6 +23,7 @@ class SnapPixel {
     this.name = NAME;
     this.deduplicationKey = config.deduplicationKey;
     this.enableDeduplication = config.enableDeduplication;
+    this.eventMappingFromConfig = config.eventMappingFromConfig;
     this.trackEvents = [
       "SIGN_UP",
       "OPEN_APP",
@@ -132,6 +136,12 @@ class SnapPixel {
 
     const { message } = rudderElement;
     const { event } = message;
+    const eventMappingFromConfigMap = getHashFromArray(
+      this.eventMappingFromConfig,
+      "from",
+      "to",
+      false 
+    );
 
     if (!event) {
       logger.error("Event name not present");
@@ -139,124 +149,137 @@ class SnapPixel {
     }
 
     try {
-      switch (event.toLowerCase().trim()) {
-        case "order completed":
-          sendEvent(
-            this.ecomEvents.PURCHASE,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        case "checkout started":
-          sendEvent(
-            this.ecomEvents.START_CHECKOUT,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        case "product added":
-          sendEvent(
-            this.ecomEvents.ADD_CART,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        case "payment info entered":
-          sendEvent(
-            this.ecomEvents.ADD_BILLING,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        case "promotion clicked":
-          sendEvent(
-            this.ecomEvents.AD_CLICK,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        case "promotion viewed":
-          sendEvent(
-            this.ecomEvents.AD_VIEW,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        case "product added to wishlist":
-          sendEvent(
-            this.ecomEvents.ADD_TO_WISHLIST,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        case "product viewed":
-        case "product list viewed":
-          sendEvent(
-            this.ecomEvents.VIEW_CONTENT,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        case "products searched":
-          sendEvent(
-            this.ecomEvents.SEARCH,
-            ecommEventPayload(
-              event,
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
-        default:
-          if (
-            !this.trackEvents.includes(event.trim().toUpperCase()) &&
-            !this.customEvents.includes(event.trim().toLowerCase())
-          ) {
-            logger.error("Event doesn't match with Snap Pixel Events!");
-            return;
-          }
-          sendEvent(
+      if (eventMappingFromConfigMap[event]) {
+        // mapping event
+        sendEvent(
+          eventMappingFromConfigMap[event],
+          ecommEventPayload(
             event,
-            eventPayload(
-              message,
-              this.deduplicationKey,
-              this.enableDeduplication
-            )
-          );
-          break;
+            message,
+            this.deduplicationKey,
+            this.enableDeduplication
+          )
+        );
+      } else {
+        switch (event.toLowerCase().trim()) {
+          case "order completed":
+            sendEvent(
+              this.ecomEvents.PURCHASE,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          case "checkout started":
+            sendEvent(
+              this.ecomEvents.START_CHECKOUT,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          case "product added":
+            sendEvent(
+              this.ecomEvents.ADD_CART,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          case "payment info entered":
+            sendEvent(
+              this.ecomEvents.ADD_BILLING,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          case "promotion clicked":
+            sendEvent(
+              this.ecomEvents.AD_CLICK,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          case "promotion viewed":
+            sendEvent(
+              this.ecomEvents.AD_VIEW,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          case "product added to wishlist":
+            sendEvent(
+              this.ecomEvents.ADD_TO_WISHLIST,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          case "product viewed":
+          case "product list viewed":
+            sendEvent(
+              this.ecomEvents.VIEW_CONTENT,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          case "products searched":
+            sendEvent(
+              this.ecomEvents.SEARCH,
+              ecommEventPayload(
+                event,
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+          default:
+            if (
+              !this.trackEvents.includes(event.trim().toUpperCase()) &&
+              !this.customEvents.includes(event.trim().toLowerCase())
+            ) {
+              logger.error("Event doesn't match with Snap Pixel Events!");
+              return;
+            }
+            sendEvent(
+              event,
+              eventPayload(
+                message,
+                this.deduplicationKey,
+                this.enableDeduplication
+              )
+            );
+            break;
+        }
       }
     } catch (err) {
       logger.error("[Snap Pixel] track failed with following error", err);

--- a/integrations/SnapPixel/browser.js
+++ b/integrations/SnapPixel/browser.js
@@ -4,6 +4,7 @@ import Storage from "../../utils/storage";
 import logger from "../../utils/logUtil";
 
 import {
+  setEventMappingFromConfig,
   removeUndefinedAndNullValues,
   getHashFromArray,
 } from "../utils/commonUtils";
@@ -135,12 +136,12 @@ class SnapPixel {
     logger.debug("===In SnapPixel track===");
 
     const { message } = rudderElement;
-    const { event } = message;
+    let { event } = message;
     const eventMappingFromConfigMap = getHashFromArray(
       this.eventMappingFromConfig,
       "from",
       "to",
-      false 
+      false
     );
 
     if (!event) {
@@ -150,9 +151,10 @@ class SnapPixel {
 
     try {
       if (eventMappingFromConfigMap[event]) {
-        // mapping event
+        // mapping event from UI
+        event = setEventMappingFromConfig(event, eventMappingFromConfigMap);
         sendEvent(
-          eventMappingFromConfigMap[event],
+          event,
           ecommEventPayload(
             event,
             message,

--- a/integrations/utils/commonUtils.js
+++ b/integrations/utils/commonUtils.js
@@ -123,7 +123,7 @@ function flattenJson(data) {
  * @param {*} eventsHashmap
  * @returns mappedEventName
  */
-function setEventMappingFromConfig(event, eventsHashmap) {
+function getEventMappingFromConfig(event, eventsHashmap) {
   // if the event name is mapped in the config, use the mapped name
   // else use the original event name
   if (eventsHashmap[event]) {
@@ -133,7 +133,7 @@ function setEventMappingFromConfig(event, eventsHashmap) {
 }
 
 export {
-  setEventMappingFromConfig,
+  getEventMappingFromConfig,
   getHashFromArrayWithDuplicate,
   getHashFromArray,
   toIso,

--- a/integrations/utils/commonUtils.js
+++ b/integrations/utils/commonUtils.js
@@ -126,13 +126,10 @@ function flattenJson(data) {
 function setEventMappingFromConfig(event, eventsHashmap) {
   // if the event name is mapped in the config, use the mapped name
   // else use the original event name
-  const events = [];
   if (eventsHashmap[event]) {
-    eventsHashmap.forEach((ev) => {
-      events.push(ev);
-    });
+    return eventsHashmap[event];
   }
-  return events;
+  return null;
 }
 
 export {

--- a/integrations/utils/commonUtils.js
+++ b/integrations/utils/commonUtils.js
@@ -123,7 +123,7 @@ function flattenJson(data) {
  * @param {*} eventsHashmap
  * @returns mappedEventName
  */
-function eventMappingFromConfig(event, eventsHashmap) {
+function setEventMappingFromConfig(event, eventsHashmap) {
   // if the event name is mapped in the config, use the mapped name
   // else use the original event name
   if (eventsHashmap[event]) {
@@ -134,7 +134,7 @@ function eventMappingFromConfig(event, eventsHashmap) {
 }
 
 export {
-  eventMappingFromConfig,
+  setEventMappingFromConfig,
   getHashFromArrayWithDuplicate,
   getHashFromArray,
   toIso,

--- a/integrations/utils/commonUtils.js
+++ b/integrations/utils/commonUtils.js
@@ -126,11 +126,13 @@ function flattenJson(data) {
 function setEventMappingFromConfig(event, eventsHashmap) {
   // if the event name is mapped in the config, use the mapped name
   // else use the original event name
+  const events = [];
   if (eventsHashmap[event]) {
-    const mappedEventName = eventsHashmap[event];
-    return mappedEventName;
+    eventsHashmap.forEach((ev) => {
+      events.push(ev);
+    });
   }
-  return event;
+  return events;
 }
 
 export {

--- a/integrations/utils/commonUtils.js
+++ b/integrations/utils/commonUtils.js
@@ -116,7 +116,25 @@ function flattenJson(data) {
   return result;
 }
 
+/**
+ * Check whether the passed eventname is mapped in the config
+ * and return the mapped event name.
+ * @param {*} event
+ * @param {*} eventsHashmap
+ * @returns mappedEventName
+ */
+function eventMappingFromConfig(event, eventsHashmap) {
+  // if the event name is mapped in the config, use the mapped name
+  // else use the original event name
+  if (eventsHashmap[event]) {
+    const mappedEventName = eventsHashmap[event];
+    return mappedEventName;
+  }
+  return event;
+}
+
 export {
+  eventMappingFromConfig,
   getHashFromArrayWithDuplicate,
   getHashFromArray,
   toIso,


### PR DESCRIPTION
## Description of the change

> Expose a mapping UI for the following ads destinations and support mapping event names to be set from the dashboard:
1. Google Ads
2. Reddit Pixel
3. Snap Pixel

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/643)
<!-- Reviewable:end -->
