### PR TITLE
feat: enhanced logger module

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1086,6 +1086,7 @@ class Analytics {
     let storageOptions = {};
     if (options && options.logLevel) {
       logger.setLogLevel(options.logLevel);
+      this.logLevel = options.logLevel;
     }
 
     if (options && options.setCookieDomain) {

--- a/integrations/Amplitude/browser.js
+++ b/integrations/Amplitude/browser.js
@@ -1,14 +1,17 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable class-methods-use-this */
-import logger from "../../utils/logUtil";
+import Logger from "../../utils/logger";
 import { type } from "../../utils/utils";
 import { LOAD_ORIGIN } from "../ScriptLoader";
 import { NAME } from "./constants";
+
+const logger = new Logger(NAME);
 
 class Amplitude {
   constructor(config, analytics) {
     this.name = NAME;
     this.analytics = analytics;
+    if (analytics.logLevel) logger.setLogLevel(analytics.logLevel);
     this.apiKey = config.apiKey;
     this.trackAllPages = config.trackAllPages || false;
     this.trackNamedPages = config.trackNamedPages || false;
@@ -431,7 +434,9 @@ class Amplitude {
     // If price not present set price as revenue's value and force quantity to be 1.
     // Ultimately set quantity to 1 if not already present from above logic.
     if (!revenue && !price) {
-      console.debug("revenue or price is not present.");
+      logger.warn(
+        'Neither "revenue" nor "price" is available. Hence, not logging revenue'
+      );
       return;
     }
 

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,93 @@
+const LogLevel = {
+  LOG: {
+    value: 0,
+    method: console.log,
+  },
+  INFO: {
+    value: 1,
+    method: console.info,
+  },
+  DEBUG: {
+    value: 2,
+    method: console.debug,
+  },
+  WARN: {
+    value: 3,
+    method: console.warn,
+  },
+  ERROR: {
+    value: 4,
+    method: console.error,
+  },
+};
+
+class Logger {
+  constructor(scope, level) {
+    this.level = +level || LogLevel.ERROR.value;
+    this.scope = scope || "";
+  }
+
+  setLogLevel(levelStr) {
+    this.level = levelStr
+      ? LogLevel[levelStr.toString().toUpperCase()].value
+      : this.level;
+  }
+
+  setScope(scopeVal) {
+    this.scope = scopeVal || this.scope;
+  }
+
+  log(...args) {
+    this.logBase(args, LogLevel.LOG.value);
+  }
+
+  info(...args) {
+    this.logBase(args, LogLevel.INFO.value);
+  }
+
+  debug(...args) {
+    this.logBase(args, LogLevel.DEBUG.value);
+  }
+
+  warn(...args) {
+    this.logBase(args, LogLevel.WARN.value);
+  }
+
+  error(...args) {
+    this.logBase(args, LogLevel.ERROR.value);
+  }
+
+  logBase(args, logLevel) {
+    if (this.level <= logLevel) {
+      const logVal = Object.values(LogLevel).find(
+        (val) => val.value === logLevel
+      );
+      logVal.method(...this.getLogData(args));
+    }
+  }
+
+  /**
+   * Formats the console message using `scope`
+   * @param {*} logArgs
+   * @returns updated log arguments
+   */
+  getLogData(logArgs) {
+    if (Array.isArray(logArgs) && logArgs.length > 0) {
+      let msg = `%c RS SDK `;
+      // format the log message using `scope`
+      if (this.scope) {
+        msg = `${msg}- ${this.scope}`;
+      }
+      msg = `${msg} %c ${logArgs[0].trim()}`;
+      const retArgs = [];
+      retArgs.push(msg);
+      retArgs.push("font-weight: bold; background: black; color: white;");
+      retArgs.push("font-weight: normal;");
+      retArgs.push(...logArgs.slice(1));
+      return retArgs;
+    }
+    return logArgs;
+  }
+}
+
+export default Logger;


### PR DESCRIPTION
## Description of the change

Added a new logger module and implemented it for Amplitude destination.
A few advantages:
- The logger instance is unique to the module that it is used. We can set `scope` which will be automatically prefixed to the messages. For destinations, it can be the name of the destination.
- Adds a default prefix "RS SDK".
- The message prefixes help the developers to easily identify and filter the messages of the SDK/scope on the browser console.

The plan is to slowly extend this for the rest of the SDK going forward.

Example output:
![image](https://user-images.githubusercontent.com/88789928/191309716-d22e58f5-ae33-48a9-ba32-f8e07cb4584c.png)


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
