### PR TITLE
fix: refiner group call email conflicts issue

### DIFF
--- a/integrations/Refiner/browser.js
+++ b/integrations/Refiner/browser.js
@@ -78,8 +78,8 @@ class Refiner {
     logger.debug("===In Refiner Group===");
     const { message } = rudderElement;
     const { userId, groupId, traits } = message;
-    const email = message.traits?.email || message.context?.traits?.email;
-    if (!userId && !email) {
+    const userEmail = message.context?.traits?.email;
+    if (!userId && !userEmail) {
       logger.error("either one userId or email is required");
       return;
     }
@@ -90,6 +90,7 @@ class Refiner {
     );
     this._refiner("identifyUser", {
       id: userId,
+      email: userEmail,
       account: {
         id: groupId,
         ...accountTraits,


### PR DESCRIPTION
## Description of the change

- in group call if someone want to send an email for an account level then they will send in traits. basically what is happening is if we don't separate this then user level email value is replaced by an account level email. so to keep separate if we found email value in context.traits then we will send it at user level or else the email which is inside traits will be sent at account level.

## Type of change
- [ ✅] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ✅] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/699)
<!-- Reviewable:end -->
