### PR TITLE
enhancement [integration] :: pinterest tag user defined event support

### DIFF
--- a/integrations/PinterestTag/browser.js
+++ b/integrations/PinterestTag/browser.js
@@ -201,9 +201,10 @@ export default class PinterestTag {
     }
 
     /*
-    Step 3: In case both of the above stated cases fail, will mark the event as "custom"
+    Step 3: In case both of the above stated cases fail, will send the event name as it is.
+          This is going to be reflected as "unknown" event in pinterest tag dashboard.
    */
-    return ['custom'];
+    return [event];
   }
 
   track(rudderElement) {


### PR DESCRIPTION
## Description of the change

> Previously any user-defined event was defaulted to "custom" event, now, we are sending back the exact event name, if no mapping is found. This will show up as "unknown" event in Pinterest dashboard

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/717)
<!-- Reviewable:end -->
