### PR TITLE
Revert "feat: add utility to generate integration common names automatically"

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -28,6 +28,7 @@ import {
   checkReservedKeywords,
   getReferrer,
   getReferringDomain,
+  commonNames,
   get,
   getStringId,
 } from "./utils/utils";
@@ -733,7 +734,10 @@ class Analytics {
     if (!eventName || !(typeof eventName === "string")) {
       return false;
     }
-    const intg = this.clientIntegrations.find((intg) => intg.name === intgName);
+    const sdkIntgName = commonNames[intgName];
+    const intg = this.clientIntegrations.find(
+      (intg) => intg.name === sdkIntgName
+    );
 
     const { blacklistedEvents, whitelistedEvents, eventFilteringOption } =
       intg.config;

--- a/integrations/AdobeAnalytics/constants.js
+++ b/integrations/AdobeAnalytics/constants.js
@@ -1,5 +1,14 @@
 const NAME = "ADOBE_ANALYTICS";
-const DISPLAY_NAME = "Adobe Analytics";
-const CNameMapping = {};
+const CNameMapping = {
+  "Adobe Analytics": NAME,
+  ADOBEANALYTICS: NAME,
+  "ADOBE ANALYTICS": NAME,
+  [NAME]: NAME,
+  AdobeAnalytics: NAME,
+  adobeanalytics: NAME,
+  "adobe analytics": NAME,
+  "Adobe analytics": NAME,
+  "adobe Analytics": NAME,
+};
 
-export { NAME, CNameMapping, DISPLAY_NAME };
+export { NAME, CNameMapping };

--- a/integrations/client_server_name.js
+++ b/integrations/client_server_name.js
@@ -1,10 +1,7 @@
-import * as AdobeAnalytics from "./AdobeAnalytics/constants";
-
 // from client native integration name to server identified display name
 // add a mapping from Rudder identified key names to Rudder server recognizable names
 const clientToServerNames = {
   All: "All",
-  [AdobeAnalytics.NAME]: AdobeAnalytics.DISPLAY_NAME,
   GA: "Google Analytics",
   GOOGLEADS: "Google Ads",
   BRAZE: "Braze",

--- a/integrations/integration_cname.js
+++ b/integrations/integration_cname.js
@@ -1,4 +1,4 @@
-import * as AdobeAnalytics from "./AdobeAnalytics/constants";
+import { CNameMapping as AdobeAnalytics } from "./AdobeAnalytics/constants";
 import { CNameMapping as Amplitude } from "./Amplitude/constants";
 import { CNameMapping as Appcues } from "./Appcues/constants";
 import { CNameMapping as BingAds } from "./BingAds/constants";
@@ -65,12 +65,11 @@ import { CNameMapping as YandexMetrica } from "./YandexMetrica/constants";
 import { CNameMapping as Podsights } from "./Podsights/constants";
 import { CNameMapping as Qualaroo } from "./Qualaroo/constants";
 
-import { getIntgCommonNames } from "./utils/commonUtils";
-
 // for sdk side native integration identification
 // add a mapping from common names to index.js exported key names as identified by Rudder
 const commonNames = {
-  ...getIntgCommonNames(AdobeAnalytics),
+  All: "All",
+  ...AdobeAnalytics,
   ...Adroll,
   ...Amplitude,
   ...Appcues,
@@ -136,7 +135,6 @@ const commonNames = {
   ...Refiner,
   ...YandexMetrica,
   ...Qualaroo,
-  all: "All",
 };
 
 export { commonNames };

--- a/integrations/utils/commonUtils.js
+++ b/integrations/utils/commonUtils.js
@@ -163,45 +163,6 @@ function getDestinationExternalID(message, type) {
   return destinationExternalId;
 }
 
-function getIntgCommonNames(intg) {
-  const cNamesMap = {};
-  const { NAME, DISPLAY_NAME, CNameMapping } = intg;
-
-  let nameSanitized;
-  if (NAME) {
-    nameSanitized = NAME.trim();
-    cNamesMap[nameSanitized.toLowerCase()] = nameSanitized;
-  }
-
-  if (DISPLAY_NAME) {
-    const displayNameSanitized = DISPLAY_NAME.toLowerCase().trim();
-    // Add the sanitized display name
-    cNamesMap[displayNameSanitized] = nameSanitized;
-
-    const words = displayNameSanitized.split(" ");
-
-    cNamesMap[words.join("_")] = nameSanitized;
-    cNamesMap[words.join("")] = nameSanitized;
-  }
-
-  // add the hard-coded common names
-  if (CNameMapping) {
-    // convert the keys to lower case to
-    // match the existing common names
-    Object.keys(CNameMapping).forEach((name) => {
-      const sanitizedName = name.toLowerCase().trim();
-      cNamesMap[sanitizedName] = CNameMapping[name];
-    });
-  }
-
-  // Filter entries where key === value
-  Object.keys(cNamesMap).forEach((cName) => {
-    if (cNamesMap[cName] === cName) delete cNamesMap[cName];
-  });
-
-  return cNamesMap;
-}
-
 /**
  * Function to check if value is Defined, Not null and Not Empty.
  * Created this function, Because existing isDefinedAndNotNullAndNotEmpty(123) is returning false due to lodash _.isEmpty function.
@@ -239,5 +200,4 @@ export {
   isDefinedNotNullNotEmpty,
   isBlank,
   pick,
-  getIntgCommonNames,
 };

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -286,24 +286,12 @@ function getRevenue(properties, eventName) {
 function tranformToRudderNames(integrationObject) {
   Object.keys(integrationObject).forEach((key) => {
     if (integrationObject.hasOwnProperty(key)) {
-      // TODO: Clean the raw key lookup logic
-      // once all the destinations move to consistent common
-      // names generation format
-      const sanitizedIntgName = key.toLowerCase().trim();
       if (commonNames[key]) {
         integrationObject[commonNames[key]] = integrationObject[key];
-      } else if (commonNames[sanitizedIntgName]) {
-        integrationObject[commonNames[sanitizedIntgName]] =
-          integrationObject[key];
       }
-
-      if (key !== "All") {
+      if (key != "All") {
         // delete user supplied keys except All and if except those where oldkeys are not present or oldkeys are same as transformed keys
-        if (
-          (commonNames[key] !== undefined && commonNames[key] !== key) ||
-          (commonNames[sanitizedIntgName] !== undefined &&
-            commonNames[sanitizedIntgName] !== key)
-        ) {
+        if (commonNames[key] != undefined && commonNames[key] != key) {
           delete integrationObject[key];
         }
       }


### PR DESCRIPTION
Reverts rudderlabs/rudder-sdk-js#685

Due to the import structure differences b/w v1 and v1.1 SDK architectures, if the changes are directly pulled into v1.1 SDK, it incurs a heavy SDK size cost. Hence, for the time being, reverting the changes to redo the approach.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/725)
<!-- Reviewable:end -->
