### PR TITLE
fix(core): replicate lodash merge behaviour with ramda

### DIFF
--- a/__tests__/utils/ObjectUtils.test.js
+++ b/__tests__/utils/ObjectUtils.test.js
@@ -1,0 +1,83 @@
+import merge from "lodash.merge";
+import { mergeDeepRight, mergeDeepRightObjectArrays } from "../../src/utils/ObjectUtils";
+
+const identifyTraitsPayloadMock = {
+  firstName: "Dummy Name",
+  phone: "1234567890",
+  email: "dummy@email.com",
+  custom_flavor: "chocolate",
+  custom_date: Date.now(),
+  address: [{
+    label: "office",
+    city: "Brussels",
+    country: "Belgium"
+  }, {
+    label: "home",
+    city: "Kolkata",
+    country: "India",
+    nested: {
+      type: "flat"
+    }
+  }, {
+    label: "work",
+    city: "Kolkata",
+    country: "India"
+  }]
+};
+
+const trackTraitsOverridePayloadMock = {
+  address: [{
+    label: "Head office",
+    city: "NYC",
+    country: "Belgium"
+  }, {
+    label: "home",
+    city: "Kolkata",
+    country: "India",
+    nested: {
+      type: "detached house"
+    }
+  }]
+};
+
+const expectedMergedTraitsPayload = {
+  firstName: "Dummy Name",
+  phone: "1234567890",
+  email: "dummy@email.com",
+  custom_flavor: "chocolate",
+  custom_date: Date.now(),
+  address: [{
+    label: "Head office",
+    city: "NYC",
+    country: "Belgium"
+  }, {
+    label: "home",
+    city: "Kolkata",
+    country: "India",
+    nested: {
+      type: "detached house"
+    }
+  }, {
+    label: "work",
+    city: "Kolkata",
+    country: "India"
+  }]
+};
+
+describe("Object utilities", () => {
+
+  it("should merge right object array items", () => {
+    const mergedArray = mergeDeepRightObjectArrays(identifyTraitsPayloadMock.address, trackTraitsOverridePayloadMock.address);
+    expect(mergedArray).toEqual(expectedMergedTraitsPayload.address);
+  });
+
+  it("should merge right nested object properties", () => {
+    const mergedArray = mergeDeepRight(identifyTraitsPayloadMock, trackTraitsOverridePayloadMock);
+    expect(mergedArray).toEqual(expectedMergedTraitsPayload);
+  });
+
+  it("should merge right nested object properties like lodash merge", () => {
+    const mergedArray = mergeDeepRight(identifyTraitsPayloadMock, trackTraitsOverridePayloadMock);
+    expect(mergedArray).toEqual(merge(identifyTraitsPayloadMock, trackTraitsOverridePayloadMock));
+  });
+});

--- a/__tests__/utils/ObjectUtils.test.js
+++ b/__tests__/utils/ObjectUtils.test.js
@@ -1,82 +1,132 @@
-import merge from "lodash.merge";
-import { mergeDeepRight, mergeDeepRightObjectArrays } from "../../src/utils/ObjectUtils";
+import merge from 'lodash.merge';
+import { mergeDeepRight, mergeDeepRightObjectArrays } from '../../src/utils/ObjectUtils';
 
 const identifyTraitsPayloadMock = {
-  firstName: "Dummy Name",
-  phone: "1234567890",
-  email: "dummy@email.com",
-  custom_flavor: "chocolate",
+  firstName: 'Dummy Name',
+  phone: '1234567890',
+  email: 'dummy@email.com',
+  custom_flavor: 'chocolate',
   custom_date: Date.now(),
-  address: [{
-    label: "office",
-    city: "Brussels",
-    country: "Belgium"
-  }, {
-    label: "home",
-    city: "Kolkata",
-    country: "India",
-    nested: {
-      type: "flat"
-    }
-  }, {
-    label: "work",
-    city: "Kolkata",
-    country: "India"
-  }]
+  address: [
+    {
+      label: 'office',
+      city: 'Brussels',
+      country: 'Belgium',
+    },
+    {
+      label: 'home',
+      city: 'Kolkata',
+      country: 'India',
+      nested: {
+        type: 'flat',
+        rooms: [
+          {
+            name: 'kitchen',
+            size: 'small',
+          },
+          {
+            // eslint-disable-next-line sonarjs/no-duplicate-string
+            name: 'living room',
+            size: 'large',
+          },
+          {
+            name: 'bedroom',
+            size: 'large',
+          },
+        ],
+      },
+    },
+    {
+      label: 'work',
+      city: 'Kolkata',
+      country: 'India',
+    },
+  ],
 };
 
 const trackTraitsOverridePayloadMock = {
-  address: [{
-    label: "Head office",
-    city: "NYC",
-    country: "Belgium"
-  }, {
-    label: "home",
-    city: "Kolkata",
-    country: "India",
-    nested: {
-      type: "detached house"
-    }
-  }]
+  address: [
+    {
+      label: 'Head office',
+      city: 'NYC',
+    },
+    {
+      label: 'home',
+      city: 'Kolkata',
+      country: 'India',
+      nested: {
+        type: 'detached house',
+        rooms: [
+          {
+            name: 'bath',
+          },
+          {
+            name: 'living room',
+            size: 'extra large',
+          },
+        ],
+      },
+    },
+  ],
 };
 
 const expectedMergedTraitsPayload = {
-  firstName: "Dummy Name",
-  phone: "1234567890",
-  email: "dummy@email.com",
-  custom_flavor: "chocolate",
+  firstName: 'Dummy Name',
+  phone: '1234567890',
+  email: 'dummy@email.com',
+  custom_flavor: 'chocolate',
   custom_date: Date.now(),
-  address: [{
-    label: "Head office",
-    city: "NYC",
-    country: "Belgium"
-  }, {
-    label: "home",
-    city: "Kolkata",
-    country: "India",
-    nested: {
-      type: "detached house"
-    }
-  }, {
-    label: "work",
-    city: "Kolkata",
-    country: "India"
-  }]
+  address: [
+    {
+      label: 'Head office',
+      city: 'NYC',
+      country: 'Belgium',
+    },
+    {
+      label: 'home',
+      city: 'Kolkata',
+      country: 'India',
+      nested: {
+        type: 'detached house',
+        rooms: [
+          {
+            name: 'bath',
+            size: 'small',
+          },
+          {
+            name: 'living room',
+            size: 'extra large',
+          },
+          {
+            name: 'bedroom',
+            size: 'large',
+          },
+        ],
+      },
+    },
+    {
+      label: 'work',
+      city: 'Kolkata',
+      country: 'India',
+    },
+  ],
 };
 
-describe("Object utilities", () => {
-
-  it("should merge right object array items", () => {
-    const mergedArray = mergeDeepRightObjectArrays(identifyTraitsPayloadMock.address, trackTraitsOverridePayloadMock.address);
+describe('Object utilities', () => {
+  it('should merge right object array items', () => {
+    const mergedArray = mergeDeepRightObjectArrays(
+      identifyTraitsPayloadMock.address,
+      trackTraitsOverridePayloadMock.address,
+    );
     expect(mergedArray).toEqual(expectedMergedTraitsPayload.address);
   });
 
-  it("should merge right nested object properties", () => {
+  it('should merge right nested object properties', () => {
     const mergedArray = mergeDeepRight(identifyTraitsPayloadMock, trackTraitsOverridePayloadMock);
     expect(mergedArray).toEqual(expectedMergedTraitsPayload);
   });
 
-  it("should merge right nested object properties like lodash merge", () => {
+  it('should merge right nested object properties like lodash merge', () => {
     const mergedArray = mergeDeepRight(identifyTraitsPayloadMock, trackTraitsOverridePayloadMock);
     expect(mergedArray).toEqual(merge(identifyTraitsPayloadMock, trackTraitsOverridePayloadMock));
   });

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -55,6 +55,7 @@ import { configToIntNames } from '../utils/config_to_integration_names';
 import CookieConsentFactory from '../features/core/cookieConsent/CookieConsentFactory';
 import * as BugsnagLib from '../features/core/metrics/error-report/Bugsnag';
 import { UserSession } from '../features/core/session';
+import { mergeDeepRight } from "../utils/ObjectUtils";
 
 /**
  * class responsible for handling core
@@ -816,11 +817,11 @@ class Analytics {
       if (topLevelElements.includes(key)) {
         rudderElement.message[key] = options[key];
       } else if (key !== 'context') {
-        rudderElement.message.context = R.mergeDeepRight(rudderElement.message.context, {
+        rudderElement.message.context = mergeDeepRight(rudderElement.message.context, {
           [key]: options[key],
         });
       } else if (typeof options[key] === 'object' && options[key] != null) {
-        rudderElement.message.context = R.mergeDeepRight(rudderElement.message.context, {
+        rudderElement.message.context = mergeDeepRight(rudderElement.message.context, {
           ...options[key],
         });
       } else {

--- a/src/utils/ObjectUtils.js
+++ b/src/utils/ObjectUtils.js
@@ -1,22 +1,20 @@
-import * as R from "ramda";
+import * as R from 'ramda';
 
 const mergeDeepRightObjectArrays = (leftValue, rightValue) => {
-  if(!Array.isArray(leftValue) || !Array.isArray(rightValue)) {
+  if (!Array.isArray(leftValue) || !Array.isArray(rightValue)) {
     return R.clone(rightValue);
   }
 
   const mergedArray = R.clone(leftValue);
-  rightValue.forEach((value , index) => {
-    mergedArray[index] = R.clone(value);
+  rightValue.forEach((value, index) => {
+    // eslint-disable-next-line no-use-before-define
+    mergedArray[index] = mergeDeepRight(mergedArray[index], value);
   });
 
   return mergedArray;
-}
+};
 
 const mergeDeepRight = (leftObject, rightObject) =>
   R.mergeDeepWith(mergeDeepRightObjectArrays, leftObject, rightObject);
 
-export {
-  mergeDeepRightObjectArrays,
-  mergeDeepRight
-}
+export { mergeDeepRightObjectArrays, mergeDeepRight };

--- a/src/utils/ObjectUtils.js
+++ b/src/utils/ObjectUtils.js
@@ -1,0 +1,22 @@
+import * as R from "ramda";
+
+const mergeDeepRightObjectArrays = (leftValue, rightValue) => {
+  if(!Array.isArray(leftValue) || !Array.isArray(rightValue)) {
+    return R.clone(rightValue);
+  }
+
+  const mergedArray = R.clone(leftValue);
+  rightValue.forEach((value , index) => {
+    mergedArray[index] = R.clone(value);
+  });
+
+  return mergedArray;
+}
+
+const mergeDeepRight = (leftObject, rightObject) =>
+  R.mergeDeepWith(mergeDeepRightObjectArrays, leftObject, rightObject);
+
+export {
+  mergeDeepRightObjectArrays,
+  mergeDeepRight
+}


### PR DESCRIPTION
## PR Description

Fixed edge case where nested object properties that hace an array of objects as values did not behave the same in lodash merge and ramda mergeDeepRight.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/745)
<!-- Reviewable:end -->
