### PR TITLE
feat: added event_value field in bing ads payload

### DIFF
--- a/integrations/BingAds/browser.js
+++ b/integrations/BingAds/browser.js
@@ -58,7 +58,7 @@ class BingAds {
 
   track = (rudderElement) => {
     const { type, properties, event } = rudderElement.message;
-    const { category, currency, value, revenue, total } = properties;
+    const { category, currency, value, revenue, total, eventValue } = properties;
     const payload = {
       event: type,
       event_label: event,
@@ -78,6 +78,10 @@ class BingAds {
     if (total) {
       payload.revenue_value = total;
     }
+    if (eventValue) {
+      payload.event_value = eventValue;
+    }
+
     window.uetq.push(payload);
   };
 


### PR DESCRIPTION
## PR Description

Added support for tracking Event value, added `event_value` field in bing ads payload. Refer this [link](https://help.ads.microsoft.com/#apex/ads/en/56709/2/#exp33) for more info regarding event_value.


## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/746)
<!-- Reviewable:end -->
