### PR TITLE
fix(destination): adding custom properties for ga4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "get-value": "3.0.1",
         "is": "3.3.0",
         "lodash.clonedeep": "4.5.0",
+        "lodash.difference": "^4.5.0",
         "lodash.get": "4.4.2",
         "lodash.isempty": "4.4.0",
         "lodash.isstring": "4.0.1",
@@ -16996,6 +16997,11 @@
       "version": "4.0.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -35015,6 +35021,11 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "dev": true
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
     },
     "lodash.get": {
       "version": "4.4.2"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "get-value": "3.0.1",
     "is": "3.3.0",
     "lodash.clonedeep": "4.5.0",
-    "lodash.difference": "^4.5.0",
+    "lodash.difference": "4.5.0",
     "lodash.get": "4.4.2",
     "lodash.isempty": "4.4.0",
     "lodash.isstring": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "get-value": "3.0.1",
     "is": "3.3.0",
     "lodash.clonedeep": "4.5.0",
+    "lodash.difference": "^4.5.0",
     "lodash.get": "4.4.2",
     "lodash.isempty": "4.4.0",
     "lodash.isstring": "4.0.1",

--- a/src/integrations/GA4/ECommerceEventConfig.js
+++ b/src/integrations/GA4/ECommerceEventConfig.js
@@ -1,3 +1,48 @@
+const ITEM_PROP_EXCLUSION_LIST = [
+    "item_id",
+    "item_name",
+    "coupon",
+    "item_category",
+    "item_brand",
+    "item_variant",
+    "price",
+    "quantity",
+    "index",
+    "product_id",
+    "name",
+    "category",
+    "brand",
+    "variant",
+    "position",
+  ];
+
+  const EVENT_PROP_EXCLUSION_LIST = [
+    "promotion_id",
+    "promotion_name",
+    "search_term",
+    "item_id",
+    "item_name",
+    "item_list_id",
+    "item_list_name",
+    "value",
+    "currency",
+    "coupon",
+    "affiliation",
+    "shipping",
+    "tax",
+    "transaction_id",
+    "shipping_tier",
+    "payment_type",
+    "list_id",
+    "category",
+    "price",
+    "total",
+    "order_id",
+    "shipping_method",
+    "payment_method",
+    "products",
+  ];
+
 const requiredEventParameters = {
   PromotionId: 'promotion_id',
   PromotionName: 'promotion_name',
@@ -219,4 +264,10 @@ const eventNamesConfigArray = [
   },
 ];
 
-export { eventNamesConfigArray, eventParametersConfigArray, itemParametersConfigArray };
+export { 
+   eventNamesConfigArray,
+   eventParametersConfigArray, 
+   itemParametersConfigArray, 
+   ITEM_PROP_EXCLUSION_LIST,
+   EVENT_PROP_EXCLUSION_LIST, 
+  };

--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -90,13 +90,20 @@ export default class GA4 {
    */
   getdestinationProperties(properties, hasItem, products, includeList) {
     let destinationProperties = {};
-    destinationProperties = getDestinationEventProperties(properties, includeList, hasItem);
+    destinationProperties = getDestinationEventProperties(
+       properties,
+       includeList,
+       "properties",
+       hasItem);
 
     if (hasItem) {
       // only for events where GA requires an items array to be sent
       // get the product related destination keys || if products is not present use the rudder message properties to get the product related destination keys
+      if (products && type(products) !== "array") {
+        logger.debug("Event payload doesn't have products array");
+      }
       destinationProperties.items = getDestinationItemProperties(
-        products || [properties],
+        products || properties,
         destinationProperties.items,
       );
     }

--- a/src/integrations/GA4/utils.js
+++ b/src/integrations/GA4/utils.js
@@ -1,4 +1,10 @@
-import { eventNamesConfigArray, itemParametersConfigArray } from './ECommerceEventConfig';
+import _difference from "lodash.difference";
+import {
+  eventNamesConfigArray,
+  itemParametersConfigArray,
+  ITEM_PROP_EXCLUSION_LIST,
+  EVENT_PROP_EXCLUSION_LIST,
+} from "./ECommerceEventConfig";
 
 import { pageEventParametersConfigArray } from './PageEventConfig';
 import { type } from '../../utils/utils';
@@ -92,27 +98,64 @@ function hasRequiredParameters(props, eventMappingObj) {
 }
 
 /**
+ * screens custom variables from rootObj by excluding exclusionFields and adds
+ * those to destination object
+ * @param {*} rootObj
+ * @param {*} destination
+ * @param {*} exclusionFields
+ * @returns
+ */
+ function extractCustomVariables(rootObj, destination, exclusionFields) {
+  const mappingKeys = _difference(Object.keys(rootObj), exclusionFields);
+  mappingKeys.map((mappingKey) => {
+    if (typeof rootObj[mappingKey] !== "undefined") {
+      destination[mappingKey] = rootObj[mappingKey];
+    }
+  });
+  return destination;
+}
+
+/**
+ *
+ * @param {*} destinationProperties
+ * @param {*} props
+ * @param {*} contextOp "properties" or "products"
+ * @returns decides the exclusion criteria for adding custom variables
+ * in properties or product type objects and returns the final output.
+ */
+function addCustomVariables(destinationProperties, props, contextOp) {
+  logger.debug("within addCustomVariables");
+  if (contextOp === "product") {
+    return extractCustomVariables(
+      props,
+      destinationProperties,
+      ITEM_PROP_EXCLUSION_LIST
+    );
+  } else if (contextOp === "properties") {
+    return extractCustomVariables(
+      props,
+      destinationProperties,
+      EVENT_PROP_EXCLUSION_LIST
+    );
+  }
+  return destinationProperties;
+}
+
+/**
  * TO DO Future Improvement ::::
  * Here we only support mapping single level object mapping.
  * Implement using recursion to handle multi level prop mapping.
  * @param {*} props { product_id: 123456_abcdef, name: "chess-board", list_id: "ls_abcdef", category: games }
  * @param {*} destParameterConfig
  * Defined Parameter present GA4/utils.js ex: [{ src: "category", dest: "item_list_name", inItems: true }]
- * @param {*} includeRequiredParams contains object of required parameter to be mapped from source payload
- * output: {
-  "item_list_id": "ls_abcdef",
-  "items": [
-    {
-      "item_id": "123456_abcdef",
-      "item_name": "chess-board",
-      "item_list_id": "ls_abc",
-      "item_list_name": "games"
-    }
-  ],
-  "item_list_name": "games"
-}
+ * @param {*} contextOp "properties" or "product"
 */
-function getDestinationEventProperties(props, destParameterConfig, hasItem = true) {
+function getDestinationEventProperties(
+  props,
+  destParameterConfig,
+  contextOp,
+  hasItem = true
+) {
   let destinationProperties = {};
   Object.keys(props).forEach((key) => {
     destParameterConfig.forEach((param) => {
@@ -125,7 +168,12 @@ function getDestinationEventProperties(props, destParameterConfig, hasItem = tru
       }
     });
   });
-  return destinationProperties;
+  const propsWithCustomFields = addCustomVariables(
+    destinationProperties,
+    props,
+    contextOp
+  );
+  return propsWithCustomFields;
 }
 
 /**
@@ -133,22 +181,26 @@ function getDestinationEventProperties(props, destParameterConfig, hasItem = tru
  * @param {*} products
  * @param {*} item
  */
-function getDestinationItemProperties(products, item) {
+ function getDestinationItemProperties(products, item) {
   const items = [];
   let obj = {};
-  if (type(products) !== 'array') {
-    logger.debug("Event payload doesn't have products array");
-  } else {
-    // get the dest keys from itemParameters config
-    // append the already created item object keys (this is done to get the keys that are actually top level props in Rudder payload but GA expects them under items too)
-    products.forEach((p) => {
-      obj = {
-        ...getDestinationEventProperties(p, itemParametersConfigArray),
-        ...((item && type(item) === 'array' && item[0]) || {}),
-      };
-      items.push(obj);
-    });
-  }
+  const contextOp = type(products) !== "array" ? "properties" : "product";
+  const finalProducts = type(products) !== "array" ? [products] : products;
+  const finalItemObj = item && type(item) === "array" && item[0] ? item[0] : {};
+  // get the dest keys from itemParameters config
+  // append the already created item object keys (this is done to get the keys that are actually top level props in Rudder payload but GA expects them under items too)
+  finalProducts.forEach((product) => {
+    obj = {
+      ...getDestinationEventProperties(
+        product,
+        itemParametersConfigArray,
+        contextOp,
+        true
+      ),
+      ...finalItemObj,
+    };
+    items.push(obj);
+  });
   return items;
 }
 
@@ -156,8 +208,12 @@ function getDestinationItemProperties(products, item) {
  * Generate ga4 page_view events payload
  * @param {*} props
  */
-function getPageViewProperty(props) {
-  return getDestinationEventProperties(props, pageEventParametersConfigArray);
+ function getPageViewProperty(props) {
+  return getDestinationEventProperties(
+    props,
+    pageEventParametersConfigArray,
+    "properties"
+  );
 }
 
 export {


### PR DESCRIPTION
## PR Description
related to github issue raised to support ga4 custom properties
Now we are sending custom properties sent by the user, in property and product level.

Only the below properties were getting mapped in items and event properties.

<img width="292" alt="Screenshot 2022-12-02 at 9 04 40 AM" src="https://user-images.githubusercontent.com/60211312/205209142-2e70f6ed-7b52-442e-aa1d-08e45ae42f20.png">

By this PR we are accommod
<img width="1438" alt="Screenshot 2022-12-02 at 9 05 14 AM" src="https://user-images.githubusercontent.com/60211312/205209189-1e0a70bd-9984-42bc-9893-9208d6963488.png">
ating any other properties sent by the users along with these.


## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/750)
<!-- Reviewable:end -->
