### PR TITLE
fix(destination): updated bing ads syntax as per the updated Microsoft syntax

### DIFF
--- a/src/integrations/BingAds/browser.js
+++ b/src/integrations/BingAds/browser.js
@@ -56,30 +56,31 @@ class BingAds {
   /*
     Visit here(for details Parameter details): https://help.ads.microsoft.com/#apex/3/en/53056/2
     Under: What data does UET collect once I install it on my website?
-    It conatins info about parameters ea,ec,gc,gv,el
+    It conatins info about parameters ea,ec,gc,gv,el (refer below link for updated parameter names)
+    Updated syntax doc ref - https://help.ads.microsoft.com/#apex/ads/en/56916/2-500
   */
 
   track = (rudderElement) => {
     const { type, properties, event } = rudderElement.message;
     const { category, currency, value, revenue, total } = properties;
     const payload = {
-      ea: type,
-      el: event,
+      event: type,
+      event_label: event,
     };
     if (category) {
-      payload.ec = category;
+      payload.event_category = category;
     }
     if (currency) {
-      payload.gc = currency;
+      payload.currency = currency;
     }
     if (value) {
-      payload.gv = value;
+      payload.revenue_value = value;
     }
     if (revenue) {
-      payload.gv = revenue;
+      payload.revenue_value = revenue;
     }
     if (total) {
-      payload.gv = total;
+      payload.revenue_value = total;
     }
     window.uetq.push(payload);
   };

--- a/src/integrations/BingAds/browser.js
+++ b/src/integrations/BingAds/browser.js
@@ -62,7 +62,7 @@ class BingAds {
 
   track = (rudderElement) => {
     const { type, properties, event } = rudderElement.message;
-    const { category, currency, value, revenue, total } = properties;
+    const { category, currency, value, revenue, total, eventValue } = properties;
     const payload = {
       event: type,
       event_label: event,
@@ -81,6 +81,9 @@ class BingAds {
     }
     if (total) {
       payload.revenue_value = total;
+    }
+    if (eventValue) {
+      payload.event_value = eventValue;
     }
     window.uetq.push(payload);
   };


### PR DESCRIPTION
## PR Description

- Microsoft updated the syntax for the javascript UET tracking library. Ref [doc](https://help.ads.microsoft.com/#apex/ads/en/56916/2-500). So made changes in bind ads destination reflecting the same.
- Added support for tracking Event value, added event_value field in bing ads payload. Refer this [link](https://help.ads.microsoft.com/#apex/ads/en/56709/2/#exp33) for more info regarding event_value.

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Bing-Ads-Device-mode-debugging-ee8e3b11b53e4288b872de1c4e40506a)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/751)
<!-- Reviewable:end -->
