### PR TITLE
feat(destination): onboard satismeter

### DIFF
--- a/src/integrations/Satismeter/browser.js
+++ b/src/integrations/Satismeter/browser.js
@@ -1,0 +1,106 @@
+/* eslint-disable no-var */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable class-methods-use-this */
+import { NAME } from "./constants";
+import Logger from "../../utils/logger";
+import { recordSatismeterEvents } from "./util";
+import { LOAD_ORIGIN } from '../../utils/ScriptLoader';
+
+const logger = new Logger(NAME);
+class Satismeter {
+  constructor(config, analytics) {
+    this.analytics = analytics;
+    if (analytics.logLevel) {
+      logger.setLogLevel(analytics.logLevel);
+    }
+    this.name = NAME;
+    this.writeKey = config.writeKey;
+    this.identifyAnonymousUsers = config.identifyAnonymousUsers;
+    this.recordSatismeterEvents = config.recordSatismeterEvents;
+    this.eventsToStandard = config.eventsToStandard;
+    this.updateEventNames = config.updateEventNames;
+    this.eventsList = config.eventsList;
+  }
+
+  init() {
+    logger.debug("===In init Satismeter===");
+    (function () {
+      window.satismeter =
+        window.satismeter ||
+        function () {
+          (window.satismeter.q = window.satismeter.q || []).push(arguments);
+        };
+      window.satismeter.l = 1 * new Date();
+      var script = document.createElement("script");
+      var parent = document.getElementsByTagName("script")[0].parentNode;
+      script.async = 1;
+      script.src = "https://app.satismeter.com/js";
+      script.setAttribute("data-loader", LOAD_ORIGIN),
+        parent.appendChild(script);
+    })();
+
+    window.satismeter({
+      writeKey: this.writeKey,
+    });
+  }
+
+  isLoaded() {
+    logger.debug("===In isLoaded Satismeter===");
+    return !!window.satismeter;
+  }
+
+  isReady() {
+    logger.debug("===In isReady Satismeter===");
+    if (this.recordSatismeterEvents) {
+      recordSatismeterEvents(
+        this.updateEventNames,
+        this.eventsList,
+        this.eventsToStandard
+      );
+    }
+    return !!window.satismeter;
+  }
+
+  identify(rudderElement) {
+    logger.debug("===In Satismeter identify===");
+    const { message } = rudderElement;
+    const { traits } = message.context;
+    let userId = message.userId || traits.userId;
+    if (!userId && this.identifyAnonymousUsers) {
+      userId = message.anonymousId || traits?.anonymousId;
+    }
+    if (userId) {
+      if (!traits?.createdAt) {
+        window.satismeter({
+          writeKey: this.writeKey,
+          userId,
+          type: "identify",
+          traits: { ...traits, createdAt: message.sentAt },
+        });
+      }
+      window.satismeter({
+        writeKey: this.writeKey,
+        userId,
+        type: "identify",
+        traits,
+      });
+    }
+  }
+
+  track(rudderElement) {
+    logger.debug("===In Satismeter track===");
+    const { message } = rudderElement;
+    const { event, context } = message;
+    if (!event) {
+      logger.error("[Satismeter]:: event is required for track call");
+    }
+    const integrationName = context.integration?.name;
+    if (integrationName && integrationName.toLowerCase() === "satismeter") {
+      logger.info(`[Satismeter]:: dropping callback event: ${event}`);
+      return;
+    }
+    window.satismeter("track", { event });
+  }
+}
+
+export default Satismeter;

--- a/src/integrations/Satismeter/constants.js
+++ b/src/integrations/Satismeter/constants.js
@@ -1,0 +1,9 @@
+const NAME = "SATISMETER";
+const CNameMapping = {
+  [NAME]: NAME,
+  Satismeter: NAME,
+  SatisMeter: NAME,
+  SATISMETER: NAME,
+};
+
+export { NAME, CNameMapping };

--- a/src/integrations/Satismeter/index.js
+++ b/src/integrations/Satismeter/index.js
@@ -1,0 +1,3 @@
+import Satismeter from "./browser";
+
+export default Satismeter;

--- a/src/integrations/Satismeter/util.js
+++ b/src/integrations/Satismeter/util.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-underscore-dangle */
+import { getHashFromArray } from '../../utils/commonUtils';
+
+const integrationContext = {
+  name: "Satismeter",
+  version: "1.0.0",
+};
+
+// supported callback events
+const standardEventsList = ["display", "progress", "complete", "dismiss"];
+
+/**
+ * This function is used to trigger a callback
+ * @param {*} standardEventsMap mapping of events done by the user
+ * @param {*} eventName standard event name
+ * @param {*} updateEventNames boolean variable to change eventName
+ */
+const triggerCallback = (
+  standardEventsMap,
+  eventName,
+  updateEventNames,
+  events
+) => {
+  const updatedEvent =
+    standardEventsMap[eventName] && updateEventNames
+      ? standardEventsMap[eventName]
+      : eventName;
+  const updatedEvents = events;
+  updatedEvents[eventName] = (event) => {
+    window.rudderanalytics.track(`${updatedEvent}`, event, {
+      context: { integration: integrationContext },
+    });
+  };
+  return updatedEvents;
+};
+/**
+ * This function has event listeners for the occurring events and to make a call for the event after collecting the data.
+ * @param {*} updateEventNames boolean variable to change eventName
+ * @param {*} userDefinedEventsList list of requested events by the user
+ * @param {*} userDefinedEventsMapping mapping of events in the webapp by the user
+ */
+const recordSatismeterEvents = (
+  updateEventNames,
+  userDefinedEventsList,
+  userDefinedEventsMapping
+) => {
+  const standardEventsMap = getHashFromArray(userDefinedEventsMapping);
+  let events = {};
+  standardEventsList.forEach((eventName) => {
+    if (userDefinedEventsList.includes(eventName)) {
+      events = triggerCallback(
+        standardEventsMap,
+        eventName,
+        updateEventNames,
+        events
+      );
+    }
+  });
+  window.satismeter({ events });
+};
+
+export { recordSatismeterEvents };

--- a/src/utils/client_server_name.js
+++ b/src/utils/client_server_name.js
@@ -65,6 +65,7 @@ const clientToServerNames = {
   REFINER: 'Refiner',
   QUALAROO: 'Qualaroo',
   PODSIGHTS: 'Podsights',
+  SATISMETER: 'Satismeter'
 };
 
 export { clientToServerNames };

--- a/src/utils/integration_cname.js
+++ b/src/utils/integration_cname.js
@@ -64,6 +64,7 @@ import { CNameMapping as YandexMetrica } from '../integrations/YandexMetrica/con
 import { CNameMapping as Refiner } from '../integrations/Refiner/constants';
 import { CNameMapping as Qualaroo } from '../integrations/Qualaroo/constants';
 import { CNameMapping as Podsights } from '../integrations/Podsights/constants';
+import { CNameMapping as SatisMeter } from '../integrations/SatisMeter/constants';
 
 // for sdk side native integration identification
 // add a mapping from common names to index.js exported key names as identified by Rudder
@@ -135,6 +136,7 @@ const commonNames = {
   ...Refiner,
   ...Qualaroo,
   ...Podsights,
+  ...SatisMeter
 };
 
 export { commonNames };


### PR DESCRIPTION
## PR Description

Onboarding new Survey Type Destination "Satismeter" supporting track and Identify Call.
Identify Call - To Get the user Traits 
Track Call - To trigger Survey based on Event.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
