### PR TITLE
ci: tag releases on producton branch instead of release, fix slack msg

### DIFF
--- a/.github/workflows/draft-new-release-v1.yml
+++ b/.github/workflows/draft-new-release-v1.yml
@@ -39,10 +39,13 @@ jobs:
           git fetch origin v1-production --depth=1
           git merge origin/v1-production
           current_version=$(jq -r .version package.json)
+          
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(jq -r .version package.json)
           git reset --hard
+          
           branch_name="${release_type}/${new_version}"
+          
           echo "Source branch for new release is $source_branch_name"
           echo "Current version is $current_version"
           echo "Release type is $release_type"
@@ -50,6 +53,7 @@ jobs:
           echo "New release branch name is $branch_name"
           git checkout -b "$branch_name"
           git push --set-upstream origin "$branch_name"
+          
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
@@ -61,11 +65,11 @@ jobs:
         env:
           HUSKY: 0
         run: |
-          npx standard-version -a
+          npx standard-version -a --skip-tag
 
       - name: Push new version in release branch & tag
         run: |
-          git push --follow-tags
+          git push
 
       - name: Create pull request into v1-production
         uses: repo-sync/pull-request@v2

--- a/.github/workflows/publish-new-release-v1.yml
+++ b/.github/workflows/publish-new-release-v1.yml
@@ -33,14 +33,24 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Create GitHub Release
+      # In order to make a commit, we need to initialize a user.
+      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub actions"
+          git config user.email noreply@github.com
+
+      - name: Create GitHub Release & Tag
         id: create_release
         env:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
+          git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
           npm run release:github
+          echo "DATE=$(date)" >> $GITHUB_ENV
 
       - name: Create pull request into v1-staging
         uses: repo-sync/pull-request@v2
@@ -74,6 +84,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'JS SDK (v1)'
+          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/'
         with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
@@ -93,7 +104,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Release: <${{ github.event.release.html_url }}|${{ github.event.release.tag_name }}>*\n${{ github.event.release.created_at }}"
+                    "text": "*Release: <${{env.RELEASES_URL}}${{ steps.extract-version.outputs.release_version }}|v${{ steps.extract-version.outputs.release_version }}>*\n${{ env.DATE }}"
                   }
                 }
               ]


### PR DESCRIPTION
## PR Description

Change the branch of the release annotated tag to be on production and not the release candidate.
Fix issue with slack notification message details missing after moving the action as a step in the release action instead of standalone post release create one.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-js/802)
<!-- Reviewable:end -->
