### PR TITLE
fix: ga4- fix total to price for events

### DIFF
--- a/src/integrations/GA4/ECommerceEventConfig.js
+++ b/src/integrations/GA4/ECommerceEventConfig.js
@@ -169,7 +169,7 @@ const eventNamesConfigArray = [
     hasItem: true,
     includeList: [
       eventParametersConfigArray.Currency,
-      eventParametersConfigArray.Total,
+      eventParametersConfigArray.Price,
     ],
   },
   {
@@ -182,7 +182,7 @@ const eventNamesConfigArray = [
     hasItem: true,
     includeList: [
       eventParametersConfigArray.Currency,
-      eventParametersConfigArray.Total,
+      eventParametersConfigArray.Price,
     ],
   },
   {
@@ -195,7 +195,7 @@ const eventNamesConfigArray = [
     hasItem: true,
     includeList: [
       eventParametersConfigArray.Currency,
-      eventParametersConfigArray.Total,
+      eventParametersConfigArray.Price,
     ],
   },
   {
@@ -285,7 +285,7 @@ const eventNamesConfigArray = [
     hasItem: true,
     includeList: [
       eventParametersConfigArray.Currency,
-      eventParametersConfigArray.Total,
+      eventParametersConfigArray.Price,
     ],
   },
   //-------

--- a/src/integrations/GA4/ECommerceEventConfig.js
+++ b/src/integrations/GA4/ECommerceEventConfig.js
@@ -169,6 +169,7 @@ const eventNamesConfigArray = [
     hasItem: true,
     includeList: [
       eventParametersConfigArray.Currency,
+      eventParametersConfigArray.Total,
       eventParametersConfigArray.Price,
     ],
   },
@@ -182,6 +183,7 @@ const eventNamesConfigArray = [
     hasItem: true,
     includeList: [
       eventParametersConfigArray.Currency,
+      eventParametersConfigArray.Total,
       eventParametersConfigArray.Price,
     ],
   },
@@ -195,6 +197,7 @@ const eventNamesConfigArray = [
     hasItem: true,
     includeList: [
       eventParametersConfigArray.Currency,
+      eventParametersConfigArray.Total,
       eventParametersConfigArray.Price,
     ],
   },
@@ -285,6 +288,7 @@ const eventNamesConfigArray = [
     hasItem: true,
     includeList: [
       eventParametersConfigArray.Currency,
+      eventParametersConfigArray.Total,
       eventParametersConfigArray.Price,
     ],
   },


### PR DESCRIPTION
## PR Description

We are fixing sending price for supported events instead of total.
- product viewed
- product added
- product removed
- add to wishlist

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
