### PR TITLE
fix: ga4- fix total to price for events

### DIFF
--- a/src/integrations/GA4/ECommerceEventConfig.js
+++ b/src/integrations/GA4/ECommerceEventConfig.js
@@ -152,21 +152,21 @@ const eventNamesConfigArray = [
     dest: 'view_item',
     requiredParams: [requiredEventParameters.ProductId, requiredEventParameters.ProductName],
     hasItem: true,
-    includeList: [eventParametersConfigArray.Currency, eventParametersConfigArray.Total],
+    includeList: [eventParametersConfigArray.Currency, eventParametersConfigArray.Total, eventParametersConfigArray.Price],
   },
   {
     src: ['product added'],
     dest: 'add_to_cart',
     requiredParams: [requiredEventParameters.ProductId, requiredEventParameters.ProductName],
     hasItem: true,
-    includeList: [eventParametersConfigArray.Currency, eventParametersConfigArray.Total],
+    includeList: [eventParametersConfigArray.Currency, eventParametersConfigArray.Total, eventParametersConfigArray.Price],
   },
   {
     src: ['product removed'],
     dest: 'remove_from_cart',
     requiredParams: [requiredEventParameters.ProductId, requiredEventParameters.ProductName],
     hasItem: true,
-    includeList: [eventParametersConfigArray.Currency, eventParametersConfigArray.Total],
+    includeList: [eventParametersConfigArray.Currency, eventParametersConfigArray.Total, eventParametersConfigArray.Price],
   },
   {
     src: ['cart viewed'],
@@ -238,7 +238,7 @@ const eventNamesConfigArray = [
     dest: 'add_to_wishlist',
     requiredParams: [requiredEventParameters.ProductId, requiredEventParameters.ProductName],
     hasItem: true,
-    includeList: [eventParametersConfigArray.Currency, eventParametersConfigArray.Total],
+    includeList: [eventParametersConfigArray.Currency, eventParametersConfigArray.Total, eventParametersConfigArray.Price],
   },
   //-------
 


### PR DESCRIPTION
## PR Description

We are fixing sending price for supported events instead of total.

- product viewed
- product added
- product removed
- add to wishlist

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
