### PR TITLE
fix(integrations): facebook pixel advanced matching condition added

### DIFF
--- a/__tests__/integrations/FacebookPixel.test.js
+++ b/__tests__/integrations/FacebookPixel.test.js
@@ -19,7 +19,7 @@ describe("FacebookPixel init tests", () => {
       getAnonymousId: jest.fn(() => "testAnonymousID"),
       getUserId: jest.fn(() => "testUserID")
     };
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
     facebookPixel.init();
     expect(typeof window.fbq).toBe("function");
     expect(facebookPixel.userPayload).toStrictEqual({
@@ -39,7 +39,7 @@ describe("FacebookPixel init tests", () => {
       getAnonymousId: jest.fn(() => "testAnonymousID"),
       getUserId: jest.fn(() => null)
     };
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
     facebookPixel.init();
     expect(typeof window.fbq).toBe("function");
     expect(facebookPixel.userPayload).toStrictEqual(
@@ -60,7 +60,7 @@ describe("FacebookPixel page", () => {
     getUserId: jest.fn(() => "testUserID")
   };
   beforeEach(() => {
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
     facebookPixel.init();
     window.fbq = jest.fn();
   });

--- a/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
+++ b/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
@@ -1,4 +1,4 @@
-import FacebookPixel from "../../src/integrations/FacebookPixel/browser";
+import FacebookPixel from "../../../src/integrations/FacebookPixel/browser";
 
 beforeAll(() => { });
 
@@ -9,7 +9,7 @@ afterAll(() => {
 describe("FacebookPixel init tests", () => {
   let facebookPixel;
 
-  test("Testing init call of Facebook Pixel with identified user", () => {
+  test("Testing init call of Facebook Pixel with identified user and updated mapping true", () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => ({
         firstName: "rudder",
@@ -33,7 +33,7 @@ describe("FacebookPixel init tests", () => {
     });
   });
 
-  test("Testing init call of Facebook Pixel with anonymous user", () => {
+  test("Testing init call of Facebook Pixel with anonymous user updated mapping true", () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => null),
       getAnonymousId: jest.fn(() => "testAnonymousID"),
@@ -45,6 +45,26 @@ describe("FacebookPixel init tests", () => {
     expect(facebookPixel.userPayload).toStrictEqual(
         {"db": undefined, "em": undefined, "external_id": "d4e669b42293a60cc65b22830a922824e6e9c7736c6058fbbb3de780d2f4a17f", "ge": undefined, "ph": undefined}
     );
+  });
+
+  test("Testing init call of Facebook Pixel with identified user and updated mapping false", () => {
+    const mockAnalytics = {
+      getUserTraits: jest.fn(() => ({
+        firstName: "rudder",
+        lastName: "stack",
+        email: "abc@rudderstack.com"
+      })),
+      getAnonymousId: jest.fn(() => "testAnonymousID"),
+      getUserId: jest.fn(() => "testUserID")
+    };
+    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: false }, mockAnalytics);
+    facebookPixel.init();
+    expect(typeof window.fbq).toBe("function");
+    expect(facebookPixel.userPayload).toStrictEqual({
+        "email": "abc@rudderstack.com",
+        "firstName": "rudder",
+        "lastName": "stack"
+    });
   });
 });
 

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -59,25 +59,29 @@ class FacebookPixel {
     window.fbq.allowDuplicatePageViews = true; // enables fb
     window.fbq.version = '2.0';
     window.fbq.queue = [];
-    if (this.useUpdatedMapping) {
-      const userData = {
-        context: {
-          traits: { ...this.analytics.getUserTraits() }
-        },
-        userId: this.analytics.getUserId(),
-        anonymousId: this.analytics.getAnonymousId()
-      }
-
-      let userPayload = constructPayload(userData, traitsMapper);
-      // here we are sending other traits apart from the reserved ones.
-      reserveTraits.forEach((element) => {
-        delete userData.context?.traits[element];
-      });
-
-      this.userPayload = { ...userPayload, ...userData.context.traits };
-
-      if (this.userPayload.external_id) {
-        this.userPayload.external_id = sha256(this.userPayload.external_id).toString();
+    if (this.advancedMapping) {
+      if (this.useUpdatedMapping) {
+        const userData = {
+          context: {
+            traits: { ...this.analytics.getUserTraits() }
+          },
+          userId: this.analytics.getUserId(),
+          anonymousId: this.analytics.getAnonymousId()
+        }
+  
+        let userPayload = constructPayload(userData, traitsMapper);
+        // here we are sending other traits apart from the reserved ones.
+        reserveTraits.forEach((element) => {
+          delete userData.context?.traits[element];
+        });
+  
+        this.userPayload = { ...userPayload, ...userData.context.traits };
+  
+        if (this.userPayload.external_id) {
+          this.userPayload.external_id = sha256(this.userPayload.external_id).toString();
+        }
+      } else {
+        this.userPayload = {...this.analytics.getUserTraits()};
       }
       window.fbq('init', this.pixelId, this.userPayload);
     } else {


### PR DESCRIPTION
## PR Description

Advanced matching condition was missed while deprecating identify call and moving userData capture from SDK initialization. Added that condition.

Our previous Identify implementation was:

```
 identify(rudderElement) {
    if (this.advancedMapping) {
      let payload = {};
      const traits = rudderElement.message.context
        ? rudderElement.message.context.traits
        : undefined;
      if (this.useUpdatedMapping) {
        const reserve = [
          'email',
          'lastName',
          'firstName',
          'phone',
          'external_id',
          'city',
          'birthday',
          'gender',
          'street',
          'zip',
          'country',
        ];
        // this construcPayload will help to map the traits in the same way as cloud mode
        payload = constructPayload(rudderElement.message, traitsMapper);
        if (payload.external_id) {
          payload.external_id = sha256(payload.external_id).toString();
        }

        // here we are sending other traits apart from the reserved ones.
        reserve.forEach((element) => {
          delete traits[element];
        });
      }
      payload = { ...payload, ...traits };
      window.fbq('init', this.pixelId, payload);
    }
  }
```

## Notion ticket

https://www.notion.so/rudderstacks/Facebook-Pixel-Advanced-Mapping-condition-omitted-issue-72f8f160d7804c3f9287a1fb8dc83c28

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
