### PR TITLE
fix: use uuid secure (using crypto) for supported browsers

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -2,6 +2,7 @@
 import { parse } from "component-url";
 import get from "get-value";
 import { v4 as uuid } from "@lukeed/uuid";
+import { v4 as uuidSecure } from "@lukeed/uuid/secure";
 import { LOAD_ORIGIN } from "../integrations/ScriptLoader";
 import logger from "./logUtil";
 import { commonNames } from "../integrations/integration_cname";
@@ -25,10 +26,14 @@ function replacer(key, value) {
 
 /**
  *
- * Utility function for UUID genration
+ * Utility function for UUID generation
  * @returns
  */
 function generateUUID() {
+  if(window.crypto && typeof window.crypto.getRandomValues === 'function') {
+    return uuidSecure();
+  }
+
   return uuid();
 }
 


### PR DESCRIPTION
## PR Description

In an attempt to fix uuid collisions, use crypto.getRandomValues to create random values used in uuid generation.

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Different-events-with-same-messageId-bbe169ffc3654869853ef142e1067811)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
