### PR TITLE
fix: googleads config order

### DIFF
--- a/__tests__/integrations/GoogleAds/utils.test.js
+++ b/__tests__/integrations/GoogleAds/utils.test.js
@@ -53,7 +53,7 @@ describe('GoogleAds utilities shouldSendEvent function tests', () => {
 
   test('event tracking is enabled and event filtering is enabled but event is not added to events list', () => {
     const eventToSend = shouldSendConversionEvent(
-      'Cart Checkout',
+      'Product Added',
       true,
       true,
       mockEvents,
@@ -73,12 +73,12 @@ describe('GoogleAds utilities shouldSendEvent function tests', () => {
     expect(eventToSend).toEqual(true);
   });
 
-  test('when both config (new + old) is present, old config should be given first priority', () => {
-    const eventToSend = shouldSendConversionEvent(orderCompleted, true, true, mockEvents, false);
-    expect(eventToSend).toEqual(true);
+  test('when both config (new + old) is present, new config should be given first priority', () => {
+    const eventToSend = shouldSendConversionEvent('Cart Checkout', true, true, mockEvents, false);
+    expect(eventToSend).toEqual(false);
   });
 
-  test('when both config (new + old) is present, old config should be given first priority', () => {
+  test('when both config (new + old) is present, new config should be given first priority', () => {
     const eventToSend = shouldSendDynamicRemarketingEvent(
       orderCompleted,
       true,

--- a/src/integrations/GoogleAds/browser.js
+++ b/src/integrations/GoogleAds/browser.js
@@ -26,8 +26,8 @@ class GoogleAds {
     this.sendPageView = config.sendPageView || true;
     this.conversionLinker = config.conversionLinker || true;
     this.disableAdPersonalization = config.disableAdPersonalization || false;
-    this.trackConversions = config.trackConversions || false;
-    this.trackDynamicRemarketing = config.trackDynamicRemarketing || false;
+    this.trackConversions = config.trackConversions;
+    this.trackDynamicRemarketing = config.trackDynamicRemarketing;
     this.enableConversionEventsFiltering = config.enableConversionEventsFiltering || false;
     this.enableDynamicRemarketingEventsFiltering =
       config.enableDynamicRemarketingEventsFiltering || false;

--- a/src/integrations/GoogleAds/utils.js
+++ b/src/integrations/GoogleAds/utils.js
@@ -49,15 +49,15 @@ function shouldSendConversionEvent(
   eventsToTrackConversions,
   dynamicRemarketing,
 ) {
-  if (isDefinedAndNotNull(dynamicRemarketing)) {
-    return !dynamicRemarketing;
+  if (isDefinedAndNotNull(trackConversions)) {
+    return shouldSendEvent(
+      eventName,
+      trackConversions,
+      enableConversionEventsFiltering,
+      eventsToTrackConversions,
+    );
   }
-  return shouldSendEvent(
-    eventName,
-    trackConversions,
-    enableConversionEventsFiltering,
-    eventsToTrackConversions,
-  );
+  return !dynamicRemarketing;
 }
 
 /**
@@ -76,15 +76,15 @@ function shouldSendDynamicRemarketingEvent(
   eventsToTrackDynamicRemarketing,
   dynamicRemarketing,
 ) {
-  if (isDefinedAndNotNull(dynamicRemarketing)) {
-    return dynamicRemarketing;
+  if (isDefinedAndNotNull(trackDynamicRemarketing)) {
+    return shouldSendEvent(
+      eventName,
+      trackDynamicRemarketing,
+      enableDynamicRemarketingEventsFiltering,
+      eventsToTrackDynamicRemarketing,
+    );
   }
-  return shouldSendEvent(
-    eventName,
-    trackDynamicRemarketing,
-    enableDynamicRemarketingEventsFiltering,
-    eventsToTrackDynamicRemarketing,
-  );
+  return dynamicRemarketing;
 }
 
 /**


### PR DESCRIPTION
## PR Description

- for any event in google ads, we will check first for the new config values. if new config values are present then we will proceed with that else we will fall back to old config

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
