### PR TITLE
feat: onetrust for cloud mode events

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -19,7 +19,7 @@ module.exports = [
     name: 'Core - NPM',
     path: 'dist/npm-lib/index.js',
     gzip: true,
-    limit: '37.5 kB',
+    limit: '37.7 kB',
   },
   {
     name: 'Service Worker - NPM',

--- a/__tests__/oneTrustCookieConsent.test.js
+++ b/__tests__/oneTrustCookieConsent.test.js
@@ -4,11 +4,17 @@ window.OneTrust = {
   GetDomainData: jest.fn(() => ({
     Groups: [
       { CustomGroupId: 'C0001', GroupName: 'Functional Cookies' },
+      { CustomGroupId: 'C0002', GroupName: 'Performance Cookies' },
       { CustomGroupId: 'C0003', GroupName: 'Analytical Cookies' },
+      { CustomGroupId: 'C0004', GroupName: 'Targeting Cookies' },
+      { CustomGroupId: 'C0005', GroupName: 'Social Media Cookies' },
+      { CustomGroupId: 'C0006', GroupName: 'Advertisement Cookies' },
     ],
   })),
 };
 window.OnetrustActiveGroups = ',C0001,C0003,';
+
+const expectedDeniedConsentIds = ['C0002','C0004', 'C0005', 'C0006'];
 
 const oneTrust = new OneTrust();
 
@@ -76,4 +82,8 @@ describe('Test suit for OneTrust cookie consent manager', () => {
     const allowEvent = oneTrust.isEnabled(destConfig);
     expect(allowEvent).toBe(false);
   });
+  it('Should return the category IDs that the user has not consented for', () => {
+    const actualDeniedConsentIds = oneTrust.getDeniedList();
+    expect(actualDeniedConsentIds).toEqual(expectedDeniedConsentIds);
+  });  
 });

--- a/__tests__/utils/utils.test.js
+++ b/__tests__/utils/utils.test.js
@@ -336,18 +336,6 @@ describe('Utilities for cookie consent management', () => {
     const actualState = utils.fetchCookieConsentState({});
     expect(actualState).toEqual(false);
   });
-  it('should return true when cookie consent is enabled for other consent management tool', () => {
-    const cookieConsentOptions = {
-      oneTrust: {
-        enabled: false,
-      },
-      cookieBot: {
-        enabled: true,
-      },
-    };
-    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
-    expect(actualState).toEqual(true);
-  });
   it('should return true when cookie consent is enabled for OneTrust', () => {
     const cookieConsentOptions = {
       oneTrust: {

--- a/__tests__/utils/utils.test.js
+++ b/__tests__/utils/utils.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import * as utils from '../../src/utils/utils';
 
 describe("extractCustomFields Tests", () => {
@@ -300,4 +301,60 @@ describe("flattenJsonPayload Tests", () => {
         const result = utils.flattenJsonPayload(testObj, '-');
         expect(result).toStrictEqual({"-.prop1.prop2": "abc"});
         });
+})
+
+describe('Utilities for cookie consent management', () => {
+  it('should return false when cookie consent is not enabled for OneTrust', () => {
+    const cookieConsentOptions = {
+      oneTrust: {
+        enabled: false,
+      }
+    };
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(false);
+  });
+  it('should return false when cookie consent is not enabled for OneTrust', () => {
+    const cookieConsentOptions = {
+      oneTrust: {
+        test: false,
+      }
+    };
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(false);
+  });
+  it('should return false when cookie consent load option is set as number', () => {
+    const cookieConsentOptions = 1234567;
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(false);
+  });
+  it('should return false when cookie consent load option is set as string', () => {
+    const cookieConsentOptions = 'test';
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(false);
+  });
+  it('should return false when cookie consent load option is empty object', () => {
+    const actualState = utils.fetchCookieConsentState({});
+    expect(actualState).toEqual(false);
+  });
+  it('should return true when cookie consent is enabled for other consent management tool', () => {
+    const cookieConsentOptions = {
+      oneTrust: {
+        enabled: false,
+      },
+      cookieBot: {
+        enabled: true,
+      },
+    };
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(true);
+  });
+  it('should return true when cookie consent is enabled for OneTrust', () => {
+    const cookieConsentOptions = {
+      oneTrust: {
+        enabled: true,
+      },
+    };
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(true);
+  });
 })

--- a/src/features/core/cookieConsent/OneTrust/browser.js
+++ b/src/features/core/cookieConsent/OneTrust/browser.js
@@ -22,6 +22,7 @@ class OneTrust {
 
     const oneTrustAllGroupsInfo = window.OneTrust.GetDomainData().Groups;
     this.userSetConsentGroupNames = [];
+    this.userDeniedConsentGroupIds = [];
 
     // Get the names of the cookies consented by the user in the browser.
 
@@ -29,6 +30,8 @@ class OneTrust {
       const { CustomGroupId, GroupName } = group;
       if (this.userSetConsentGroupIds.includes(CustomGroupId)) {
         this.userSetConsentGroupNames.push(GroupName.toUpperCase().trim());
+      } else {
+        this.userDeniedConsentGroupIds.push(CustomGroupId);
       }
     });
 
@@ -81,6 +84,10 @@ class OneTrust {
       logger.error(`Error during onetrust cookie consent management ${e}`);
       return true;
     }
+  }
+
+  getDeniedList() {
+    return this.userDeniedConsentGroupIds;
   }
 }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -42,6 +42,8 @@ const RESIDENCY_SERVERS = [DEFAULT_REGION, 'EU'];
 
 const SUPPORTED_CONSENT_MANAGERS = ['oneTrust'];
 
+const SYSTEM_KEYWORDS = ['library', 'consentManagement'];
+
 export {
   RESERVED_KEYS,
   CONFIG_URL,
@@ -65,4 +67,5 @@ export {
   DEFAULT_DATAPLANE_URL,
   RESIDENCY_SERVERS,
   SUPPORTED_CONSENT_MANAGERS,
+  SYSTEM_KEYWORDS,
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -40,6 +40,8 @@ const DEFAULT_DATAPLANE_URL = 'https://hosted.rudderlabs.com';
 
 const RESIDENCY_SERVERS = [DEFAULT_REGION, 'EU'];
 
+const SUPPORTED_CONSENT_MANAGERS = ['oneTrust'];
+
 export {
   RESERVED_KEYS,
   CONFIG_URL,
@@ -62,4 +64,5 @@ export {
   DEFAULT_REGION,
   DEFAULT_DATAPLANE_URL,
   RESIDENCY_SERVERS,
+  SUPPORTED_CONSENT_MANAGERS,
 };

--- a/src/utils/eventProcessorUtils.js
+++ b/src/utils/eventProcessorUtils.js
@@ -1,5 +1,6 @@
 import logger from './logUtil';
 import { mergeDeepRight } from './ObjectUtils';
+import { SYSTEM_KEYWORDS } from './constants';
 
 const defaultTopLevelElements = ['integrations', 'anonymousId', 'originalTimestamp'];
 
@@ -24,19 +25,17 @@ const mergeContext = (rudderElementMessage, options = {}) => {
   }
 
   Object.keys(options).forEach((key) => {
-    if (!defaultTopLevelElements.includes(key)) {
+    if (!defaultTopLevelElements.includes(key) && !SYSTEM_KEYWORDS.includes(key)) {
       if (key !== 'context') {
-        if (key !== "library") {
-          context = mergeDeepRight(context, {
-            [key]: options[key],
-          });
-        }
+        context = mergeDeepRight(context, {
+          [key]: options[key],
+        });
       } else if (typeof options[key] === 'object' && options[key] !== null) {
         const tempContext = {};
         Object.keys(options[key]).forEach((e) => {
-            if (e !== "library") {
-              tempContext[e] = options[key][e];
-            }
+          if (!SYSTEM_KEYWORDS.includes(e)) {
+            tempContext[e] = options[key][e];
+          }
         });
         context = mergeDeepRight(context, {
           ...tempContext,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -11,6 +11,7 @@ import {
   RESERVED_KEYS,
   DEFAULT_REGION,
   RESIDENCY_SERVERS,
+  SUPPORTED_CONSENT_MANAGERS,
 } from './constants';
 import Storage from './storage';
 import { handleError } from './errorHandler';
@@ -766,7 +767,11 @@ const fetchCookieConsentState = (cookieConsentOptions) => {
   let isEnabled = false;
   // eslint-disable-next-line consistent-return
   Object.keys(cookieConsentOptions).forEach((e) => {
-    if ( typeof(cookieConsentOptions[e].enabled) === 'boolean' && cookieConsentOptions[e].enabled === true) {
+    if ( 
+      SUPPORTED_CONSENT_MANAGERS.includes(e) && 
+      typeof(cookieConsentOptions[e].enabled) === 'boolean' && 
+      cookieConsentOptions[e].enabled === true
+    ) {
       isEnabled = true;
     }
   });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -2,7 +2,7 @@
 import { parse } from 'component-url';
 import get from 'get-value';
 import { v4 as uuid } from '@lukeed/uuid';
-import { v4 as uuidSecure } from "@lukeed/uuid/secure";
+import { v4 as uuidSecure } from '@lukeed/uuid/secure';
 import logger from './logUtil';
 import { commonNames } from './integration_cname';
 import { clientToServerNames } from './client_server_name';
@@ -44,7 +44,7 @@ function removeTrailingSlashes(inURL) {
  * @returns
  */
 function generateUUID() {
-  if(window.crypto && typeof window.crypto.getRandomValues === 'function') {
+  if (window.crypto && typeof window.crypto.getRandomValues === 'function') {
     return uuidSecure();
   }
 
@@ -759,19 +759,20 @@ const resolveDataPlaneUrl = (response, serverUrl, options) => {
 };
 
 /**
- * Function to return the state of consent management based on config passed in load options 
- * @param {Object} cookieConsentOptions 
- * @returns 
+ * Function to return the state of consent management based on config passed in load options
+ * @param {Object} cookieConsentOptions
+ * @returns
  */
 const fetchCookieConsentState = (cookieConsentOptions) => {
   let isEnabled = false;
   // eslint-disable-next-line consistent-return
   Object.keys(cookieConsentOptions).forEach((e) => {
-    if ( 
-      SUPPORTED_CONSENT_MANAGERS.includes(e) && 
-      typeof(cookieConsentOptions[e].enabled) === 'boolean' && 
-      cookieConsentOptions[e].enabled === true
-    ) {
+    const isSupportedAndEnabled =
+      SUPPORTED_CONSENT_MANAGERS.includes(e) &&
+      typeof cookieConsentOptions[e].enabled === 'boolean' &&
+      cookieConsentOptions[e].enabled === true;
+
+    if (isSupportedAndEnabled) {
       isEnabled = true;
     }
   });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -757,6 +757,22 @@ const resolveDataPlaneUrl = (response, serverUrl, options) => {
   }
 };
 
+/**
+ * Function to return the state of consent management based on config passed in load options 
+ * @param {Object} cookieConsentOptions 
+ * @returns 
+ */
+const fetchCookieConsentState = (cookieConsentOptions) => {
+  let isEnabled = false;
+  // eslint-disable-next-line consistent-return
+  Object.keys(cookieConsentOptions).forEach((e) => {
+    if ( typeof(cookieConsentOptions[e].enabled) === 'boolean' && cookieConsentOptions[e].enabled === true) {
+      isEnabled = true;
+    }
+  });
+  return isEnabled;
+};
+
 export {
   replacer,
   generateUUID,
@@ -790,4 +806,5 @@ export {
   countDigits,
   getStringId,
   resolveDataPlaneUrl,
+  fetchCookieConsentState,
 };


### PR DESCRIPTION
## PR Description

If OneTrust is enabled and consent has been given, fetch the deny list and pass it down as context property.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
