### PR TITLE
feat: onetrust for cloud mode events

### DIFF
--- a/__tests__/oneTrustCookieConsent.test.js
+++ b/__tests__/oneTrustCookieConsent.test.js
@@ -4,11 +4,17 @@ window.OneTrust = {
   GetDomainData: jest.fn(() => ({
     Groups: [
       { CustomGroupId: 'C0001', GroupName: 'Functional Cookies' },
+      { CustomGroupId: 'C0002', GroupName: 'Performance Cookies' },
       { CustomGroupId: 'C0003', GroupName: 'Analytical Cookies' },
+      { CustomGroupId: 'C0004', GroupName: 'Targeting Cookies' },
+      { CustomGroupId: 'C0005', GroupName: 'Social Media Cookies' },
+      { CustomGroupId: 'C0006', GroupName: 'Advertisement Cookies' },
     ],
   })),
 };
 window.OnetrustActiveGroups = ',C0001,C0003,';
+
+const expectedDeniedConsentIds = ['C0002','C0004', 'C0005', 'C0006'];
 
 const oneTrust = new OneTrust();
 
@@ -76,4 +82,8 @@ describe('Test suit for OneTrust cookie consent manager', () => {
     const allowEvent = oneTrust.isEnabled(destConfig);
     expect(allowEvent).toBe(false);
   });
+  it('Should return the category IDs that the user has not consented for', () => {
+    const actualDeniedConsentIds = oneTrust.getDeniedList();
+    expect(actualDeniedConsentIds).toEqual(expectedDeniedConsentIds);
+  });  
 });

--- a/__tests__/utils/utils.test.js
+++ b/__tests__/utils/utils.test.js
@@ -301,3 +301,59 @@ describe("flattenJsonPayload Tests", () => {
         expect(result).toStrictEqual({"-.prop1.prop2": "abc"});
         });
 })
+
+describe('Utilities for cookie consent management', () => {
+  it('should return false when cookie consent is not enabled for OneTrust', () => {
+    const cookieConsentOptions = {
+      oneTrust: {
+        enabled: false,
+      }
+    };
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(false);
+  });
+  it('should return false when cookie consent is not enabled for OneTrust', () => {
+    const cookieConsentOptions = {
+      oneTrust: {
+        test: false,
+      }
+    };
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(false);
+  });
+  it('should return false when cookie consent load option is set as number', () => {
+    const cookieConsentOptions = 1234567;
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(false);
+  });
+  it('should return false when cookie consent load option is set as string', () => {
+    const cookieConsentOptions = 'test';
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(false);
+  });
+  it('should return false when cookie consent load option is empty object', () => {
+    const actualState = utils.fetchCookieConsentState({});
+    expect(actualState).toEqual(false);
+  });
+  it('should return true when cookie consent is enabled for other consent management tool', () => {
+    const cookieConsentOptions = {
+      oneTrust: {
+        enabled: false,
+      },
+      cookieBot: {
+        enabled: true,
+      },
+    };
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(true);
+  });
+  it('should return true when cookie consent is enabled for OneTrust', () => {
+    const cookieConsentOptions = {
+      oneTrust: {
+        enabled: true,
+      },
+    };
+    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    expect(actualState).toEqual(true);
+  });
+})

--- a/__tests__/utils/utils.test.js
+++ b/__tests__/utils/utils.test.js
@@ -335,18 +335,6 @@ describe('Utilities for cookie consent management', () => {
     const actualState = utils.fetchCookieConsentState({});
     expect(actualState).toEqual(false);
   });
-  it('should return true when cookie consent is enabled for other consent management tool', () => {
-    const cookieConsentOptions = {
-      oneTrust: {
-        enabled: false,
-      },
-      cookieBot: {
-        enabled: true,
-      },
-    };
-    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
-    expect(actualState).toEqual(true);
-  });
   it('should return true when cookie consent is enabled for OneTrust', () => {
     const cookieConsentOptions = {
       oneTrust: {

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -41,6 +41,7 @@ import {
   DEFAULT_ERROR_REPORT_PROVIDER,
   ERROR_REPORT_PROVIDERS,
   SAMESITE_COOKIE_OPTS,
+  SYSTEM_KEYWORDS,
 } from "../utils/constants";
 import { integrations } from "../integrations";
 import RudderElementBuilder from "../utils/RudderElementBuilder";
@@ -978,7 +979,7 @@ class Analytics {
       if (toplevelElements.includes(key)) {
         rudderElement.message[key] = options[key];
       } else if (key !== "context") {
-        if (key !== "library") {
+        if (!SYSTEM_KEYWORDS.includes(key)) {
           rudderElement.message.context = merge(rudderElement.message.context, {
             [key]: options[key],
           });
@@ -986,7 +987,7 @@ class Analytics {
       } else if (typeof options[key] === "object" && options[key] !== null) {
         const tempContext = {};
         Object.keys(options[key]).forEach((e) => {
-            if (e !== "library") {
+            if (!SYSTEM_KEYWORDS.includes(e)) {
               tempContext[e] = options[key][e];
             }
         });

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -31,6 +31,7 @@ import {
   commonNames,
   get,
   getStringId,
+  fetchCookieConsentState,
 } from "../utils/utils";
 import {
   CONFIG_URL,
@@ -116,6 +117,7 @@ class Analytics {
     // flag to indicate client integrations` ready status
     this.clientIntegrationsReady = false;
     this.uSession = UserSession;
+    this.deniedConsentIds = [];
   }
 
   /**
@@ -252,6 +254,8 @@ class Analytics {
         cookieConsent = CookieConsentFactory.initialize(
           this.cookieConsentOptions
         );
+        // Fetch denied consent group Ids and pass it to cloud mode
+        this.deniedConsentIds = cookieConsent && cookieConsent.getDeniedList();
       } catch (e) {
         handleError(e);
       }
@@ -837,6 +841,12 @@ class Analytics {
         if (sessionStart) rudderElement.message.context.sessionStart = true;
       } catch (e) {
         handleError(e);
+      }
+      // If cookie consent is enabled attach the denied consent group Ids to the context
+      if (fetchCookieConsentState(this.cookieConsentOptions)) {
+        rudderElement.message.context.consentManagement = {
+          deniedConsentIds: this.deniedConsentIds
+        };
       }
 
       this.processOptionsParam(rudderElement, options);

--- a/src/features/core/cookieConsent/OneTrust/browser.js
+++ b/src/features/core/cookieConsent/OneTrust/browser.js
@@ -22,6 +22,7 @@ class OneTrust {
 
     const oneTrustAllGroupsInfo = window.OneTrust.GetDomainData().Groups;
     this.userSetConsentGroupNames = [];
+    this.userDeniedConsentGroupIds = [];
 
     // Get the names of the cookies consented by the user in the browser.
 
@@ -29,6 +30,8 @@ class OneTrust {
       const { CustomGroupId, GroupName } = group;
       if (this.userSetConsentGroupIds.includes(CustomGroupId)) {
         this.userSetConsentGroupNames.push(GroupName.toUpperCase().trim());
+      } else {
+        this.userDeniedConsentGroupIds.push(CustomGroupId);
       }
     });
 
@@ -81,6 +84,10 @@ class OneTrust {
       logger.error(`Error during onetrust cookie consent management ${e}`);
       return true;
     }
+  }
+
+  getDeniedList() {
+    return this.userDeniedConsentGroupIds;
   }
 }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -108,6 +108,8 @@ const MIN_SESSION_ID_LENGTH = 10;
 
 const SUPPORTED_CONSENT_MANAGERS = ['oneTrust'];
 
+const SYSTEM_KEYWORDS = ['library', 'consentManagement'];
+
 export {
   ReservedPropertyKeywords,
   MessageType,
@@ -130,6 +132,7 @@ export {
   MIN_SESSION_TIMEOUT,
   MIN_SESSION_ID_LENGTH,
   SUPPORTED_CONSENT_MANAGERS,
+  SYSTEM_KEYWORDS,
 };
 
 /* module.exports = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -106,6 +106,8 @@ const DEFAULT_SESSION_TIMEOUT = 30 * 60 * 1000; // 30 min in milliseconds
 const MIN_SESSION_TIMEOUT = 10 * 1000; // 10 sec in milliseconds
 const MIN_SESSION_ID_LENGTH = 10;
 
+const SUPPORTED_CONSENT_MANAGERS = ['oneTrust'];
+
 export {
   ReservedPropertyKeywords,
   MessageType,
@@ -127,6 +129,7 @@ export {
   DEFAULT_SESSION_TIMEOUT,
   MIN_SESSION_TIMEOUT,
   MIN_SESSION_ID_LENGTH,
+  SUPPORTED_CONSENT_MANAGERS,
 };
 
 /* module.exports = {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -7,7 +7,7 @@ import { LOAD_ORIGIN } from "../integrations/ScriptLoader";
 import logger from "./logUtil";
 import { commonNames } from "../integrations/integration_cname";
 import { clientToServerNames } from "../integrations/client_server_name";
-import { CONFIG_URL, ReservedPropertyKeywords } from "./constants";
+import { CONFIG_URL, ReservedPropertyKeywords, SUPPORTED_CONSENT_MANAGERS } from "./constants";
 import Storage from "./storage";
 
 /**
@@ -778,7 +778,11 @@ const fetchCookieConsentState = (cookieConsentOptions) => {
   let isEnabled = false;
   // eslint-disable-next-line consistent-return
   Object.keys(cookieConsentOptions).forEach((e) => {
-    if ( typeof(cookieConsentOptions[e].enabled) === 'boolean' && cookieConsentOptions[e].enabled === true) {
+    if ( 
+      SUPPORTED_CONSENT_MANAGERS.includes(e) && 
+      typeof(cookieConsentOptions[e].enabled) === 'boolean' && 
+      cookieConsentOptions[e].enabled === true
+    ) {
       isEnabled = true;
     }
   });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -778,11 +778,12 @@ const fetchCookieConsentState = (cookieConsentOptions) => {
   let isEnabled = false;
   // eslint-disable-next-line consistent-return
   Object.keys(cookieConsentOptions).forEach((e) => {
-    if ( 
-      SUPPORTED_CONSENT_MANAGERS.includes(e) && 
-      typeof(cookieConsentOptions[e].enabled) === 'boolean' && 
-      cookieConsentOptions[e].enabled === true
-    ) {
+    const isSupportedAndEnabled =
+      SUPPORTED_CONSENT_MANAGERS.includes(e) &&
+      typeof cookieConsentOptions[e].enabled === 'boolean' &&
+      cookieConsentOptions[e].enabled === true;
+
+    if (isSupportedAndEnabled) {
       isEnabled = true;
     }
   });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -769,6 +769,22 @@ const getStringId = (id) => {
     : JSON.stringify(id);
 };
 
+/**
+ * Function to return the state of consent management based on config passed in load options 
+ * @param {Object} cookieConsentOptions 
+ * @returns 
+ */
+const fetchCookieConsentState = (cookieConsentOptions) => {
+  let isEnabled = false;
+  // eslint-disable-next-line consistent-return
+  Object.keys(cookieConsentOptions).forEach((e) => {
+    if ( typeof(cookieConsentOptions[e].enabled) === 'boolean' && cookieConsentOptions[e].enabled === true) {
+      isEnabled = true;
+    }
+  });
+  return isEnabled;
+};
+
 export {
   replacer,
   generateUUID,
@@ -802,4 +818,5 @@ export {
   get,
   countDigits,
   getStringId,
+  fetchCookieConsentState,
 };


### PR DESCRIPTION
## PR Description

If OneTrust is enabled and consent has been given, fetch the deny list and pass it down as context property.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
