### PR TITLE
fix: enable debug_mode for GA4 device mode

### DIFF
--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -24,11 +24,10 @@ export default class GA4 {
     this.blockPageView = config.blockPageViewEvent || false;
     this.extendPageViewParams = config.extendPageViewParams || false;
     this.extendGroupPayload = config.extendGroupPayload || false;
-    this.debugMode = config.debugMode || false;
     this.isHybridModeEnabled = config.useNativeSDKToSend === false || false;
     this.name = NAME;
-    this.clientId = "";
-    this.sessionId = "";
+    this.clientId = '';
+    this.sessionId = '';
   }
 
   loadScript(measurementId, userId) {
@@ -49,23 +48,22 @@ export default class GA4 {
     if (this.sendUserId) {
       gtagParameterObject.user_id = userId;
     }
-    if (this.debugMode) {
-      gtagParameterObject.debug_mode = true;
-    }
     if (Object.keys(gtagParameterObject).length === 0) {
       window.gtag('config', measurementId);
     } else {
       window.gtag('config', measurementId, gtagParameterObject);
     }
 
+    gtagParameterObject.debug_mode = true;
+
     /**
      * Setting the parameter clientId and sessionId using gtag api
      * Ref: https://developers.google.com/tag-platform/gtagjs/reference
      */
-    window.gtag("get", this.measurementId, "client_id", (clientId) => {
+    window.gtag('get', this.measurementId, 'client_id', (clientId) => {
       this.clientId = clientId;
     });
-    window.gtag("get", this.measurementId, "session_id", (sessionId) => {
+    window.gtag('get', this.measurementId, 'session_id', (sessionId) => {
       this.sessionId = sessionId;
     });
 
@@ -91,11 +89,11 @@ export default class GA4 {
    * If the gtag is successfully initialized, client ID and session ID fields will have valid values for the given GA4 configuration
    */
   isLoaded() {
-   return !!(this.clientId && this.sessionId);
+    return !!(this.clientId && this.sessionId);
   }
 
   isReady() {
-   return this.isLoaded();
+    return this.isLoaded();
   }
 
   /* utility functions --- Ends here ---  */
@@ -113,13 +111,14 @@ export default class GA4 {
     destinationProperties = getDestinationEventProperties(
       properties,
       includeList,
-       "properties",
-       hasItem);
+      'properties',
+      hasItem,
+    );
 
     if (hasItem) {
       // only for events where GA requires an items array to be sent
       // get the product related destination keys || if products is not present use the rudder message properties to get the product related destination keys
-      if (products && type(products) !== "array") {
+      if (products && type(products) !== 'array') {
         logger.debug("Event payload doesn't have products array");
       }
       destinationProperties.items = getDestinationItemProperties(
@@ -156,7 +155,7 @@ export default class GA4 {
 
   sendGAEvent(event, parameters, checkRequiredParameters, eventMappingObj) {
     if (checkRequiredParameters && !hasRequiredParameters(parameters, eventMappingObj)) {
-        throw Error('Payload must have required parameters..');
+      throw Error('Payload must have required parameters..');
     }
     window.gtag('event', event, parameters);
   }
@@ -199,7 +198,7 @@ export default class GA4 {
     }
     // get GA4 event name and corresponding configs defined to add properties to that event
     const eventMappingArray = getDestinationEventName(event);
-    if (eventMappingArray && eventMappingArray.length) {
+    if (eventMappingArray && eventMappingArray.length > 0) {
       eventMappingArray.forEach((events) => {
         this.handleEventMapper(events, properties, products);
       });

--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -48,13 +48,14 @@ export default class GA4 {
     if (this.sendUserId) {
       gtagParameterObject.user_id = userId;
     }
+
+    gtagParameterObject.debug_mode = true;
+
     if (Object.keys(gtagParameterObject).length === 0) {
       window.gtag('config', measurementId);
     } else {
       window.gtag('config', measurementId, gtagParameterObject);
     }
-
-    gtagParameterObject.debug_mode = true;
 
     /**
      * Setting the parameter clientId and sessionId using gtag api


### PR DESCRIPTION
## PR Description

- we decided to enable debug_mode by default for GA4 device mode. 

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
