### PR TITLE
feat(ga4): add sent_to parameter in gtag event call

### DIFF
--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
-import ScriptLoader from "../ScriptLoader";
-import Logger from "../../utils/logger";
+import ScriptLoader from '../ScriptLoader';
+import Logger from '../../utils/logger';
 
 import {
   isReservedName,
@@ -8,10 +8,10 @@ import {
   getDestinationEventProperties,
   getDestinationItemProperties,
   getPageViewProperty,
-  hasRequiredParameters
-} from "./utils";
-import { type, flattenJsonPayload } from "../../utils/utils";
-import { NAME } from "./constants";
+  hasRequiredParameters,
+} from './utils';
+import { type, flattenJsonPayload } from '../../utils/utils';
+import { NAME } from './constants';
 
 const logger = new Logger(NAME);
 export default class GA4 {
@@ -28,8 +28,9 @@ export default class GA4 {
     this.debugMode = config.debugMode || false;
     this.isHybridModeEnabled = config.useNativeSDKToSend === false || false;
     this.name = NAME;
-    this.clientId = "";
-    this.sessionId = "";
+    this.clientId = '';
+    this.sessionId = '';
+    this.addSendToParameter = config.addSendToParameter || false;
   }
 
   loadScript(measurementId, userId) {
@@ -40,7 +41,7 @@ export default class GA4 {
         // eslint-disable-next-line prefer-rest-params
         window.dataLayer.push(arguments);
       };
-    window.gtag("js", new Date());
+    window.gtag('js', new Date());
     const gtagParameterObject = {};
     // This condition is not working, even after disabling page view
     // page_view is even getting called on page load
@@ -54,19 +55,19 @@ export default class GA4 {
       gtagParameterObject.debug_mode = true;
     }
     if (Object.keys(gtagParameterObject).length === 0) {
-      window.gtag("config", measurementId);
+      window.gtag('config', measurementId);
     } else {
-      window.gtag("config", measurementId, gtagParameterObject);
+      window.gtag('config', measurementId, gtagParameterObject);
     }
 
     /**
      * Setting the parameter clientId and sessionId using gtag api
      * Ref: https://developers.google.com/tag-platform/gtagjs/reference
      */
-    window.gtag("get", this.measurementId, "client_id", (clientId) => {
+    window.gtag('get', this.measurementId, 'client_id', (clientId) => {
       this.clientId = clientId;
     });
-    window.gtag("get", this.measurementId, "session_id", (sessionId) => {
+    window.gtag('get', this.measurementId, 'session_id', (sessionId) => {
       this.sessionId = sessionId;
     });
 
@@ -75,8 +76,8 @@ export default class GA4 {
     // Ref: https://support.google.com/analytics/answer/7201382?hl=en#zippy=%2Cglobal-site-tag-websites
 
     ScriptLoader(
-      "google-analytics 4",
-      `https://www.googletagmanager.com/gtag/js?id=${measurementId}`
+      'google-analytics 4',
+      `https://www.googletagmanager.com/gtag/js?id=${measurementId}`,
     );
   }
 
@@ -114,19 +115,19 @@ export default class GA4 {
     destinationProperties = getDestinationEventProperties(
       properties,
       includeList,
-      "properties",
-      hasItem
+      'properties',
+      hasItem,
     );
 
     if (hasItem) {
       // only for events where GA requires an items array to be sent
       // get the product related destination keys || if products is not present use the rudder message properties to get the product related destination keys
-      if (products && type(products) !== "array") {
+      if (products && type(products) !== 'array') {
         logger.debug("Event payload doesn't have products array");
       }
       destinationProperties.items = getDestinationItemProperties(
         products || properties,
-        destinationProperties.items
+        destinationProperties.items,
       );
     }
 
@@ -140,14 +141,14 @@ export default class GA4 {
    */
   getIncludedParameters(params, properties) {
     const destinationProperties = {};
-    if (type(params) === "object") {
+    if (type(params) === 'object') {
       const { defaults, mappings } = params;
-      if (type(defaults) === "object") {
+      if (type(defaults) === 'object') {
         Object.keys(defaults).forEach((key) => {
           destinationProperties[key] = defaults[key];
         });
       }
-      if (type(mappings) === "object") {
+      if (type(mappings) === 'object') {
         Object.keys(mappings).forEach((key) => {
           destinationProperties[mappings[key]] = properties[key];
         });
@@ -160,7 +161,11 @@ export default class GA4 {
     if (checkRequiredParameters && !hasRequiredParameters(parameters, eventMappingObj)) {
       throw Error('Payload must have required parameters..');
     }
-    window.gtag("event", event, parameters);
+    const params = { ...parameters };
+    if (this.addSendToParameter) {
+      params.send_to = this.measurementId;
+    }
+    window.gtag('event', event, params);
   }
 
   handleEventMapper(eventMappingObj, properties, products) {
@@ -170,16 +175,13 @@ export default class GA4 {
       /* Only include params that are present in given mapping config for things like Cart/Product shared, Product/Products shared
        */
       const includeParams = eventMappingObj.onlyIncludeParams;
-      destinationProperties = this.getIncludedParameters(
-        includeParams,
-        properties
-      );
+      destinationProperties = this.getIncludedParameters(includeParams, properties);
     } else {
       destinationProperties = this.getdestinationProperties(
         properties,
         eventMappingObj.hasItem,
         products,
-        eventMappingObj.includeList
+        eventMappingObj.includeList,
       );
     }
     this.sendGAEvent(event, destinationProperties, true, eventMappingObj);
@@ -200,11 +202,11 @@ export default class GA4 {
     const { properties } = rudderElement.message;
     const { products } = properties;
     if (!event || isReservedName(event)) {
-      throw Error("Cannot call un-named/reserved named track event");
+      throw Error('Cannot call un-named/reserved named track event');
     }
     // get GA4 event name and corresponding configs defined to add properties to that event
     const eventMappingArray = getDestinationEventName(event);
-    if (eventMappingArray && eventMappingArray.length) {
+    if (eventMappingArray && eventMappingArray.length > 0) {
       eventMappingArray.forEach((events) => {
         this.handleEventMapper(events, properties, products);
       });
@@ -220,20 +222,16 @@ export default class GA4 {
     }
 
     logger.debug('In GoogleAnalyticsManager Identify');
-    window.gtag(
-      "set",
-      "user_properties",
-      flattenJsonPayload(this.analytics.userTraits)
-    );
+    window.gtag('set', 'user_properties', flattenJsonPayload(this.analytics.userTraits));
     if (this.sendUserId && rudderElement.message.userId) {
       const userId = this.analytics.userId || this.analytics.anonymousId;
       if (this.blockPageView) {
-        window.gtag("config", this.measurementId, {
+        window.gtag('config', this.measurementId, {
           user_id: userId,
           send_page_view: false,
         });
       } else {
-        window.gtag("config", this.measurementId, {
+        window.gtag('config', this.measurementId, {
           user_id: userId,
         });
       }
@@ -245,13 +243,17 @@ export default class GA4 {
     let pageProps = rudderElement.message.properties;
     if (!pageProps) return;
     pageProps = flattenJsonPayload(pageProps);
+    const properties = { ...getPageViewProperty(pageProps) };
+    if (this.addSendToParameter) {
+      properties.send_to = this.measurementId;
+    }
     if (this.extendPageViewParams) {
-      window.gtag("event", "page_view", {
+      window.gtag('event', 'page_view', {
         ...pageProps,
-        ...getPageViewProperty(pageProps),
+        ...properties,
       });
     } else {
-      window.gtag("event", "page_view", getPageViewProperty(pageProps));
+      window.gtag('event', 'page_view', properties);
     }
   }
 


### PR DESCRIPTION
## PR Description

- Adding the `send_to` parameter in gtag event call to ensure that event will only be sent to the GA4 property with the measurement id configured in webapp.
- send_to parameter helps in routing data to a patricular GA4 property when more than one instance/properties are loaded.

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/GA4-Send-send_to-parameter-with-gtag-during-event-calls-d4b077c737004a5f86b1fd22eb756695)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
