### PR TITLE
feat: onLoaded callback option

### DIFF
--- a/packages/npm/index.d.ts
+++ b/packages/npm/index.d.ts
@@ -102,6 +102,7 @@ declare module 'rudder-sdk-js' {
     // Controls whether the SDK should polyfill unsupported browser API's if they are detected as missing
     // Defaults to true
     polyfillIfRequired?: boolean;
+    onLoaded?: () => void;
   }
 
   /**

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -249,7 +249,7 @@ class Analytics {
 
       // Execute onLoaded callback if provided in load options
       if (this.options && typeof this.options.onLoaded === 'function') {
-        this.options.onLoaded();
+        this.options.onLoaded(this);
       }
 
       // Execute any pending buffered requests

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -246,6 +246,12 @@ class Analytics {
       // Initialize event repository
       this.eventRepository.initialize(this.writeKey, this.serverUrl, this.options);
       this.loaded = true;
+
+      // Execute onLoaded callback if provided in load options
+      if (this.options && typeof this.options.onLoaded === 'function') {
+        this.options.onLoaded();
+      }
+
       // Execute any pending buffered requests
       // (needed if the load call was not previously buffered)
       processDataInAnalyticsArray(this);


### PR DESCRIPTION
## PR Description

A new load option added: `onLoaded` - This expects to be a function and will be executed once the SDK is done loading and before the device mode destinations start to load.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
