### PR TITLE
feat: onLoaded callback option

### DIFF
--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1188,6 +1188,12 @@ class Analytics {
     this.initializeUser(options ? options.anonymousIdOptions : undefined);
     this.setInitialPageProperties();
     this.loaded = true;
+
+    // Execute onLoaded callback if provided in load options
+    if (options && typeof options.onLoaded === 'function') {
+      options.onLoaded();
+    }
+
     if (
       options &&
       options.valTrackingList &&

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1191,7 +1191,7 @@ class Analytics {
 
     // Execute onLoaded callback if provided in load options
     if (options && typeof options.onLoaded === 'function') {
-      options.onLoaded();
+      options.onLoaded(this);
     }
 
     if (


### PR DESCRIPTION
## PR Description

A new load option added: onLoaded - This expects to be a function and will be executed once the SDK is done loading and before the device mode destinations start to load.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
