### PR TITLE
feat: user agent client hint info added in context

### DIFF
--- a/__tests__/utils/clientHint.test.js
+++ b/__tests__/utils/clientHint.test.js
@@ -1,0 +1,79 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { getUserAgentClientHint } from '../../src/utils/clientHint';
+
+describe('User Agent Client Hint Utilities', () => {
+  const chromeDefaultUACH = {
+    brands: [
+      { brand: 'Chromium', version: '110' },
+      { brand: 'Not A(Brand', version: '24' },
+      { brand: 'Google Chrome', version: '110' },
+    ],
+    mobile: false,
+    platform: 'macOS',
+  };
+
+  const chromeFullUACH = {
+    architecture: 'x86',
+    bitness: '64',
+    brands: [
+      {
+        brand: 'Chromium',
+        version: '110',
+      },
+      {
+        brand: 'Not A(Brand',
+        version: '24',
+      },
+      {
+        brand: 'Google Chrome',
+        version: '110',
+      },
+    ],
+    fullVersionList: [
+      {
+        brand: 'Chromium',
+        version: '110.0.5481.100',
+      },
+      {
+        brand: 'Not A(Brand',
+        version: '24.0.0.0',
+      },
+      {
+        brand: 'Google Chrome',
+        version: '110.0.5481.100',
+      },
+    ],
+    mobile: false,
+    model: '',
+    platform: 'macOS',
+    platformVersion: '13.2.1',
+    uaFullVersion: '110.0.5481.100',
+    wow64: false,
+  };
+
+  afterEach(() => {
+    // Reset global.window.navigator mocks
+    global.navigator.userAgentData = undefined;
+  });
+
+  it('Should return undefined when none is passed as the level', async () => {
+    const userAgentClientHint = await getUserAgentClientHint('none');
+    expect(userAgentClientHint).toBe(undefined);
+  });
+  it('Should return undefined if no argument is passed as the level', async () => {
+    const userAgentClientHint = await getUserAgentClientHint();
+    expect(userAgentClientHint).toBe(undefined);
+  });
+  it('Should return default client-hint object if default is passed as the level', async () => {
+    global.navigator.userAgentData = chromeDefaultUACH;
+    const userAgentClientHint = await getUserAgentClientHint('default');
+    expect(userAgentClientHint).toBe(chromeDefaultUACH);
+  });
+  it('Should return default client-hint object if full is passed as the level', async () => {
+    navigator.userAgentData = {
+      getHighEntropyValues: jest.fn().mockResolvedValue(chromeFullUACH),
+    };
+    const userAgentClientHint = await getUserAgentClientHint('full');
+    expect(userAgentClientHint).toBe(chromeFullUACH);
+  });
+});

--- a/__tests__/utils/clientHint.test.js
+++ b/__tests__/utils/clientHint.test.js
@@ -56,24 +56,32 @@ describe('User Agent Client Hint Utilities', () => {
     global.navigator.userAgentData = undefined;
   });
 
-  it('Should return undefined when none is passed as the level', async () => {
-    const userAgentClientHint = await getUserAgentClientHint('none');
-    expect(userAgentClientHint).toBe(undefined);
+  it('Should return undefined when none is passed as the level', () => {
+    const callback = jest.fn((userAgentClientHint)=>{
+      expect(userAgentClientHint).toBe(undefined);
+    });
+    getUserAgentClientHint(callback, 'none');
   });
-  it('Should return undefined if no argument is passed as the level', async () => {
-    const userAgentClientHint = await getUserAgentClientHint();
-    expect(userAgentClientHint).toBe(undefined);
+  it('Should return undefined if no argument is passed as the level', () => {
+    const callback = jest.fn((userAgentClientHint)=>{
+      expect(userAgentClientHint).toBe(undefined);
+    });
+    getUserAgentClientHint(callback);
   });
-  it('Should return default client-hint object if default is passed as the level', async () => {
+  it('Should return default client-hint object if default is passed as the level', () => {
     global.navigator.userAgentData = chromeDefaultUACH;
-    const userAgentClientHint = await getUserAgentClientHint('default');
-    expect(userAgentClientHint).toBe(chromeDefaultUACH);
+    const callback = jest.fn((userAgentClientHint)=>{
+      expect(userAgentClientHint).toBe(chromeDefaultUACH);
+    });
+    getUserAgentClientHint(callback, 'default');
   });
-  it('Should return default client-hint object if full is passed as the level', async () => {
+  it('Should return default client-hint object if full is passed as the level', () => {
     navigator.userAgentData = {
       getHighEntropyValues: jest.fn().mockResolvedValue(chromeFullUACH),
     };
-    const userAgentClientHint = await getUserAgentClientHint('full');
-    expect(userAgentClientHint).toBe(chromeFullUACH);
+    const callback = jest.fn((userAgentClientHint)=>{
+      expect(userAgentClientHint).toBe(chromeFullUACH);
+    });
+    getUserAgentClientHint(callback, 'full');
   });
 });

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1155,9 +1155,12 @@ class Analytics {
     if (isUACHOptionAvailable) {
       this.uachLevel = options['ua-ch'];
     }
-    getUserAgentClientHint(this.uachLevel).then((ua) => {
-      this.uach = ua;
-    });
+
+    if (navigator.userAgentData) {
+      getUserAgentClientHint((uach) =>{
+        this.uach = uach;
+      }, this.uachLevel);
+    }
 
     if (options && options.integrations) {
       Object.assign(this.loadOnlyIntegrations, options.integrations);

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1150,16 +1150,16 @@ class Analytics {
     this.storage.options(storageOptions);
 
     const isUACHOptionAvailable =
-      options && typeof options['ua-ch'] === 'string' && UA_CH_LEVELS.includes(options['ua-ch']);
+      options && typeof options.uaChTrackLevel === 'string' && UA_CH_LEVELS.includes(options.uaChTrackLevel);
 
     if (isUACHOptionAvailable) {
-      this.uachLevel = options['ua-ch'];
+      this.uaChTrackLevel = options.uaChTrackLevel;
     }
 
     if (navigator.userAgentData) {
       getUserAgentClientHint((uach) =>{
         this.uach = uach;
-      }, this.uachLevel);
+      }, this.uaChTrackLevel);
     }
 
     if (options && options.integrations) {

--- a/src/utils/clientHint.js
+++ b/src/utils/clientHint.js
@@ -1,34 +1,27 @@
-const getUserAgentClientHint = async (level = 'none') => {
-  let uach;
-
-  switch (level) {
-    case 'none':
-      break;
-    case 'default':
-      if (navigator.userAgentData) {
-        uach = navigator.userAgentData;
-      }
-      break;
-    case 'full':
-      if (navigator.userAgentData) {
-        uach = await navigator.userAgentData.getHighEntropyValues([
-          'architecture',
-          'bitness',
-          'brands',
-          'mobile',
-          'model',
-          'platform',
-          'platformVersion',
-          'uaFullVersion',
-          'fullVersionList',
-          'wow64',
-        ]);
-      }
-      break;
-    default:
-      break;
+const getUserAgentClientHint = (callback, level = 'none') => {
+  if (level === 'none') {
+    callback(undefined);
   }
-  return uach;
+  if (level === 'default') {
+    callback(navigator.userAgentData);
+  }
+  if (level === 'full') {
+    navigator.userAgentData.getHighEntropyValues([
+      'architecture',
+      'bitness',
+      'brands',
+      'mobile',
+      'model',
+      'platform',
+      'platformVersion',
+      'uaFullVersion',
+      'fullVersionList',
+      'wow64',
+    ])
+    .then((ua) => {
+      callback(ua);
+    })
+  }
 };
 
 export { getUserAgentClientHint };

--- a/src/utils/clientHint.js
+++ b/src/utils/clientHint.js
@@ -1,0 +1,34 @@
+const getUserAgentClientHint = async (level = 'none') => {
+  let uach;
+
+  switch (level) {
+    case 'none':
+      break;
+    case 'default':
+      if (navigator.userAgentData) {
+        uach = navigator.userAgentData;
+      }
+      break;
+    case 'full':
+      if (navigator.userAgentData) {
+        uach = await navigator.userAgentData.getHighEntropyValues([
+          'architecture',
+          'bitness',
+          'brands',
+          'mobile',
+          'model',
+          'platform',
+          'platformVersion',
+          'uaFullVersion',
+          'fullVersionList',
+          'wow64',
+        ]);
+      }
+      break;
+    default:
+      break;
+  }
+  return uach;
+};
+
+export { getUserAgentClientHint };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -106,6 +106,8 @@ const DEFAULT_SESSION_TIMEOUT = 30 * 60 * 1000; // 30 min in milliseconds
 const MIN_SESSION_TIMEOUT = 10 * 1000; // 10 sec in milliseconds
 const MIN_SESSION_ID_LENGTH = 10;
 
+const UA_CH_LEVELS = ['none', 'default', 'full'];
+
 export {
   ReservedPropertyKeywords,
   MessageType,
@@ -127,6 +129,7 @@ export {
   DEFAULT_SESSION_TIMEOUT,
   MIN_SESSION_TIMEOUT,
   MIN_SESSION_ID_LENGTH,
+  UA_CH_LEVELS,
 };
 
 /* module.exports = {


### PR DESCRIPTION
## PR Description

Depending on the load option user agent client hint info is added in the event context.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
