### PR TITLE
fix: name `onLoaded` callback parameter

### DIFF
--- a/packages/npm/index.d.ts
+++ b/packages/npm/index.d.ts
@@ -103,7 +103,7 @@ declare module 'rudder-sdk-js' {
     // Defaults to true
     polyfillIfRequired?: boolean;
     uaChTrackLevel?: 'none' | 'default' | 'full';
-    onLoaded?: (any) => void;
+    onLoaded?: (analytics: any) => void;
   }
 
   /**


### PR DESCRIPTION
## PR Description

This PR fixes a TypeScript compilation error caused by the type definition

```typescript
onLoaded?: (any) => void;
```

which is interpreted as a parameter named `any`, rather than a parameter typed as `any`.

```
node_modules/rudder-sdk-js/index.d.ts(106,17): error TS7051: Parameter has a name but no type. Did you mean 'arg0: any'?
```

## Notion ticket

N/A

## Screenshots

N/A

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
