### PR TITLE
fix(fb pixel): ecomm

### DIFF
--- a/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
+++ b/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
@@ -104,7 +104,6 @@ describe("FacebookPixel page", () => {
         },
       },
     });
-     // console.log(JSON.stringify(window.fbq.mock.calls)); // this has set with empty {} object when resetCustomDimensions
      expect(window.fbq.mock.calls[0][0]).toEqual("track");
      expect(window.fbq.mock.calls[0][1]).toEqual("PageView")
      expect(window.fbq.mock.calls[0][2]).toEqual({
@@ -231,7 +230,6 @@ describe("Facebook Pixel Track event", () => {
       },
     }
     });
-    console.log(JSON.stringify(window.fbq.mock.calls));
     expect(window.fbq.mock.calls[0][0]).toEqual("trackSingleCustom");
     expect(window.fbq.mock.calls[0][1]).toEqual("12567839");
     expect(window.fbq.mock.calls[0][2]).toEqual("Custom");

--- a/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
+++ b/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
@@ -177,10 +177,9 @@ describe("Facebook Pixel Track event", () => {
       "content_ids": [
         "abc"
       ],
-      "content_type": [
-        "product"
-      ],
+      "content_type":"product",
       "currency": "GBP",
+      "content_name": undefined,
       "value": 0,
       "contents": [
         {

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -1,4 +1,5 @@
 /* eslint-disable class-methods-use-this */
+/* eslint-disable */
 import is from "is";
 import each from "@ndhoule/each";
 import sha256 from "crypto-js/sha256";
@@ -65,7 +66,7 @@ class FacebookPixel {
           anonymousId: this.analytics.getAnonymousId()
         }
   
-        let userPayload = constructPayload(userData, traitsMapper);
+        const userPayload = constructPayload(userData, traitsMapper);
         // here we are sending other traits apart from the reserved ones.
         reserveTraits.forEach((element) => {
           delete userData.context?.traits[element];
@@ -174,7 +175,7 @@ class FacebookPixel {
       const contents = [];
 
       if (products && Array.isArray(products)) {
-        for (let i = 0; i < products.length; i++) {
+        for (let i = 0; i < products.length; i += 1) {
           const product = products[i];
           if (product) {
             const productId = product.product_id || product.sku || product.id;
@@ -190,7 +191,7 @@ class FacebookPixel {
         }
       }
 
-      if (contentIds.length) {
+      if (contentIds.length > 0) {
         contentType = "product";
       } else if (category) {
         contentIds.push(category);
@@ -340,7 +341,7 @@ class FacebookPixel {
       const contentIds = [];
       const contents = [];
       if (products) {
-        for (let i = 0; i < products.length; i++) {
+        for (let i = 0; i < products.length; i += 1) {
           const product = products[i];
           if (product) {
             const pId = product.product_id || product.sku || product.id;
@@ -449,7 +450,7 @@ class FacebookPixel {
       const contentIds = [];
       const contents = [];
       if (products) {
-        for (let i = 0; i < products.length; i++) {
+        for (let i = 0; i < products.length; i += 1) {
           const product = products[i];
           if (product) {
             const pId = product.product_id || product.sku || product.id;
@@ -566,7 +567,7 @@ class FacebookPixel {
 
     // Otherwise check if there is a replacement set for all Facebook Pixel
     // track calls of this category
-    const category = rudderElement.message.properties.category;
+    const category = rudderElement.message.properties?.category;
     if (category) {
       const categoryMapping = this.categoryToContent?.find(
         (i) => i.from === category
@@ -633,7 +634,7 @@ class FacebookPixel {
     const blacklistPiiProperties = this.blacklistPiiProperties || [];
     const eventCustomProperties = this.eventCustomProperties || [];
     const customPiiProperties = {};
-    for (let i = 0; i < blacklistPiiProperties[i]; i++) {
+    for (let i = 0; i < blacklistPiiProperties[i]; i += 1) {
       const configuration = blacklistPiiProperties[i];
       customPiiProperties[configuration.blacklistPiiProperties] =
         configuration.blacklistPiiHash;

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -1,5 +1,4 @@
 /* eslint-disable class-methods-use-this */
-/* eslint-disable */
 import is from "is";
 import each from "@ndhoule/each";
 import sha256 from "crypto-js/sha256";

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -405,7 +405,7 @@ class FacebookPixel {
         content_ids: contentIds,
         content_category: category || '',
         currency: currVal,
-        value: this.formatRevenue(properties?.value),
+        value,
         contents,
         search_string: query,
       };
@@ -421,7 +421,7 @@ class FacebookPixel {
             val,
             {
               currency: currVal,
-              value: revValue,
+              value,
             },
             {
               eventID: derivedEventID,

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -159,6 +159,7 @@ class FacebookPixel {
       contentName = properties.contentName;
     }
 
+    // check for category data type
     if (category && !getContentCategory(category)) {
       return;
     }
@@ -573,11 +574,14 @@ class FacebookPixel {
 
     // Extra properties of obj2
     Object.keys(obj2).forEach((propObj2) => {
-      if (Object.prototype.hasOwnProperty.call(obj2, propObj2) && !Object.prototype.hasOwnProperty.call(res, propObj2)) {
+      if (
+        Object.prototype.hasOwnProperty.call(obj2, propObj2) &&
+        !Object.prototype.hasOwnProperty.call(res, propObj2)
+      ) {
         res[propObj2] = obj2[propObj2];
       }
     });
-  
+
     return res;
   }
 
@@ -618,8 +622,7 @@ class FacebookPixel {
     const customPiiProperties = {};
     for (let i = 0; i < blacklistPiiProperties[i]; i += 1) {
       const configuration = blacklistPiiProperties[i];
-      customPiiProperties[configuration.blacklistPiiProperties] =
-        configuration.blacklistPiiHash;
+      customPiiProperties[configuration.blacklistPiiProperties] = configuration.blacklistPiiHash;
     }
     const payload = {};
     const { properties } = rudderElement.message;
@@ -628,9 +631,7 @@ class FacebookPixel {
         continue;
       }
 
-      const customProperties = eventCustomProperties.map(
-        (e) => e.eventCustomProperties
-      );
+      const customProperties = eventCustomProperties.map((e) => e.eventCustomProperties);
 
       if (isStandardEvent && customProperties.indexOf(property) < 0) {
         continue;
@@ -640,19 +641,18 @@ class FacebookPixel {
 
       if (dateFields.indexOf(properties) >= 0) {
         if (is.date(value)) {
-          payload[property] = value.toISOTring().split("T")[0];
+          payload[property] = value.toISOTring().split('T')[0];
           continue;
         }
       }
       if (customPiiProperties.hasOwnProperty(property)) {
-        if (customPiiProperties[property] && typeof value === "string") {
+        if (customPiiProperties[property] && typeof value === 'string') {
           payload[property] = sha256(value).toString();
         }
         continue;
       }
       const isPropertyPii = defaultPiiProperties.indexOf(property) >= 0;
-      const isProperyWhiteListed =
-        whitelistPiiProperties.indexOf(property) >= 0;
+      const isProperyWhiteListed = whitelistPiiProperties.indexOf(property) >= 0;
       if (!isPropertyPii || isProperyWhiteListed) {
         payload[property] = value;
       }

--- a/src/integrations/FacebookPixel/utils.js
+++ b/src/integrations/FacebookPixel/utils.js
@@ -1,4 +1,5 @@
 import get from "get-value";
+import logger from "../../utils/logUtil";
 
 function getEventId(message) {
   return (
@@ -8,4 +9,37 @@ function getEventId(message) {
     message.messageId
   );
 }
-export default getEventId;
+
+
+/**
+ * This method gets content category
+ *
+ * @param {*} category
+ * @returns The content category as a string
+ */
+ const getContentCategory = (category) => {
+  let contentCategory = category;
+  if (Array.isArray(contentCategory)) {
+    contentCategory = contentCategory.map(String).join(',');
+  }
+  if (
+    contentCategory &&
+    typeof contentCategory !== 'string' &&
+    typeof contentCategory !== 'object'
+  ) {
+    contentCategory = String(contentCategory);
+  }
+  if (
+    contentCategory &&
+    typeof contentCategory !== 'string' &&
+    !Array.isArray(contentCategory) &&
+    typeof contentCategory === 'object'
+  ) {
+    logger.error("'properties.category' must be either be a string or an array");
+    return;
+  }
+  // eslint-disable-next-line consistent-return
+  return contentCategory;
+};
+
+export { getEventId, getContentCategory};

--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -19,16 +19,15 @@ export default class GA4 {
     if (analytics.logLevel) {
       logger.setLogLevel(analytics.logLevel);
     }
-    this.measurementId = config.measurementId;
-    this.analytics = analytics;
-    this.extendPageViewParams = config.extendPageViewParams || false;
-    this.capturePageView = config.capturePageView || 'rs';
-    this.extendGroupPayload = config.extendGroupPayload || false;
-    this.isHybridModeEnabled = config.useNativeSDKToSend === false || false;
     this.name = NAME;
-    this.clientId = '';
     this.sessionId = '';
+    this.analytics = analytics;
+    this.measurementId = config.measurementId;
+    this.capturePageView = config.capturePageView || 'rs';
     this.addSendToParameter = config.addSendToParameter || false;
+    this.addSendToParameter = config.addSendToParameter || false;
+    this.extendPageViewParams = config.extendPageViewParams || false;
+    this.isHybridModeEnabled = config.useNativeSDKToSend === false || false;
   }
 
   loadScript(measurementId) {
@@ -276,7 +275,7 @@ export default class GA4 {
     getDestinationEventName(rudderElement.message.type).forEach((events) => {
       this.sendGAEvent(events.dest, {
         group_id: groupId,
-        ...(this.extendGroupPayload ? traits : {}),
+        ...(traits || {}),
       });
     });
   }


### PR DESCRIPTION
## PR Description

1. content_category passed as an array. Now passing it as comma(,) separated string.
2. content_type passed as an array. Now passing it as a string.
3. valueFieldIdentifier configured as `properties.value `in webapp but considering `properties.revenue` in the calculation. Now considering `properties.revenue/ properties.value` for backward compatibility.
4. Event-wise mapping changes mentioned [here](https://www.notion.so/rudderstacks/Following-E-commerce-spec-56ea62ac808c4ef880c0362b2288d2fa?pvs=4#5fe30a269f6941c6a6a139090517a0bf)

## Notion ticket

[Ticket link
](https://www.notion.so/rudderstacks/Facebook-Pixel-Ecomm-spec-fix-Device-mode-f9836b3b501040a9bdf8d1bed77dbb84)
## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
