### PR TITLE
ci: fetch all commit history in draft new release action

### DIFF
--- a/.github/workflows/draft-new-release-v1.yml
+++ b/.github/workflows/draft-new-release-v1.yml
@@ -36,7 +36,8 @@ jobs:
           source_branch_name=${GITHUB_REF##*/}
           release_type=v1-release
           grep -q "v1-hotfix" <<< "${GITHUB_REF}" && release_type=v1-hotfix-release
-          git fetch origin v1-production --depth=1
+          git fetch origin v1-production
+          git fetch --tags origin
           git merge origin/v1-production
           current_version=$(jq -r .version package.json)
           npx standard-version --skip.commit --skip.tag --skip.changelog

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -36,7 +36,8 @@ jobs:
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
           grep -q "hotfix/" <<< "${GITHUB_REF}" && release_type=hotfix-release
-          git fetch origin production --depth=1
+          git fetch origin production
+          git fetch --tags origin
           git merge origin/production
           current_version=$(jq -r .version package.json)
 


### PR DESCRIPTION
## PR Description

Attempt to resolve the issue with incorrect changelog generation in release drafts by fetching all commit history to ensure previous version tagged commit hash exists

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Fix-Changelog-generation-issue-7bce1f8bb53d4009acb82b755d6c2b51?pvs=4)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
