### PR TITLE
ci: fetch all commit history in draft new release action

### DIFF
--- a/.github/workflows/draft-new-release-v1.yml
+++ b/.github/workflows/draft-new-release-v1.yml
@@ -36,16 +36,14 @@ jobs:
           source_branch_name=${GITHUB_REF##*/}
           release_type=v1-release
           grep -q "v1-hotfix" <<< "${GITHUB_REF}" && release_type=v1-hotfix-release
-          git fetch origin v1-production --depth=1
+          git fetch origin v1-production
+          git fetch --tags origin
           git merge origin/v1-production
           current_version=$(jq -r .version package.json)
-          
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(jq -r .version package.json)
           git reset --hard
-          
           branch_name="${release_type}/${new_version}"
-          
           echo "Source branch for new release is $source_branch_name"
           echo "Current version is $current_version"
           echo "Release type is $release_type"
@@ -53,7 +51,6 @@ jobs:
           echo "New release branch name is $branch_name"
           git checkout -b "$branch_name"
           git push --set-upstream origin "$branch_name"
-          
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
@@ -65,7 +62,7 @@ jobs:
         env:
           HUSKY: 0
         run: |
-          npx standard-version -a --skip-tag
+          npx standard-version -a --skip.tag
 
       - name: Push new version in release branch & tag
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-analytics",
-  "version": "1.24.0",
+  "version": "1.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-analytics",
-      "version": "1.24.0",
+      "version": "1.27.0",
       "license": "MIT",
       "dependencies": {
         "@lukeed/uuid": "2.0.0",
@@ -24287,9 +24287,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
+      "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -28315,7 +28315,7 @@
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
-        "webpack": "^5.75.0"
+        "webpack": "5.76.0"
       }
     },
     "@tootallnate/once": {
@@ -43216,9 +43216,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
+      "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
     "semver": "7.3.8",
     "semver-regex": "3.1.4",
     "shelljs": "^0.8.4",
-    "trim-newlines": "3.0.1"
+    "trim-newlines": "3.0.1",
+    "webpack": "5.76.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## PR Description

Attempt to resolve the issue with incorrect changelog generation in release drafts by fetching all commit history to ensure previous version tagged commit hash exists

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Fix-Changelog-generation-issue-7bce1f8bb53d4009acb82b755d6c2b51?pvs=4)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
