### PR TITLE
fix(fb pixel): ecomm

### DIFF
--- a/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
+++ b/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
@@ -1,270 +1,279 @@
-import FacebookPixel from "../../../src/integrations/FacebookPixel/browser";
+import FacebookPixel from '../../../src/integrations/FacebookPixel/browser';
 
-beforeAll(() => { });
+beforeAll(() => {});
 
 afterAll(() => {
   jest.restoreAllMocks();
 });
 
-describe("FacebookPixel init tests", () => {
+describe('FacebookPixel init tests', () => {
   let facebookPixel;
 
-  test("Testing init call of Facebook Pixel with identified user and updated mapping true", () => {
+  test('Testing init call of Facebook Pixel with identified user and updated mapping true', () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => ({
-        firstName: "rudder",
-        lastName: "stack",
-        email: "abc@rudderstack.com"
+        firstName: 'rudder',
+        lastName: 'stack',
+        email: 'abc@rudderstack.com',
       })),
-      getAnonymousId: jest.fn(() => "testAnonymousID"),
-      getUserId: jest.fn(() => "testUserID")
+      getAnonymousId: jest.fn(() => 'testAnonymousID'),
+      getUserId: jest.fn(() => 'testUserID'),
     };
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: true },
+      mockAnalytics,
+    );
     facebookPixel.init();
-    expect(typeof window.fbq).toBe("function");
+    expect(typeof window.fbq).toBe('function');
     expect(facebookPixel.userPayload).toStrictEqual({
-        "db": undefined,
-        "em": "abc@rudderstack.com",
-        "external_id": "d06773e1bf4b8a96a4786fbb8e3444092438ad29401769613ae9e0e3e1e08a84",
-        "fn": "rudder",
-        "ge": undefined,
-        "ln": "stack", 
-        "ph": undefined
+      db: undefined,
+      em: 'abc@rudderstack.com',
+      external_id: 'd06773e1bf4b8a96a4786fbb8e3444092438ad29401769613ae9e0e3e1e08a84',
+      fn: 'rudder',
+      ge: undefined,
+      ln: 'stack',
+      ph: undefined,
     });
   });
 
-  test("Testing init call of Facebook Pixel with anonymous user updated mapping true", () => {
+  test('Testing init call of Facebook Pixel with anonymous user updated mapping true', () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => null),
-      getAnonymousId: jest.fn(() => "testAnonymousID"),
-      getUserId: jest.fn(() => null)
+      getAnonymousId: jest.fn(() => 'testAnonymousID'),
+      getUserId: jest.fn(() => null),
     };
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
-    facebookPixel.init();
-    expect(typeof window.fbq).toBe("function");
-    expect(facebookPixel.userPayload).toStrictEqual(
-        {"db": undefined, "em": undefined, "external_id": "d4e669b42293a60cc65b22830a922824e6e9c7736c6058fbbb3de780d2f4a17f", "ge": undefined, "ph": undefined}
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: true },
+      mockAnalytics,
     );
+    facebookPixel.init();
+    expect(typeof window.fbq).toBe('function');
+    expect(facebookPixel.userPayload).toStrictEqual({
+      db: undefined,
+      em: undefined,
+      external_id: 'd4e669b42293a60cc65b22830a922824e6e9c7736c6058fbbb3de780d2f4a17f',
+      ge: undefined,
+      ph: undefined,
+    });
   });
 
-  test("Testing init call of Facebook Pixel with identified user and updated mapping false", () => {
+  test('Testing init call of Facebook Pixel with identified user and updated mapping false', () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => ({
-        firstName: "rudder",
-        lastName: "stack",
-        email: "abc@rudderstack.com"
+        firstName: 'rudder',
+        lastName: 'stack',
+        email: 'abc@rudderstack.com',
       })),
-      getAnonymousId: jest.fn(() => "testAnonymousID"),
-      getUserId: jest.fn(() => "testUserID")
+      getAnonymousId: jest.fn(() => 'testAnonymousID'),
+      getUserId: jest.fn(() => 'testUserID'),
     };
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: false }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: false },
+      mockAnalytics,
+    );
     facebookPixel.init();
-    expect(typeof window.fbq).toBe("function");
+    expect(typeof window.fbq).toBe('function');
     expect(facebookPixel.userPayload).toStrictEqual({
-        "email": "abc@rudderstack.com",
-        "firstName": "rudder",
-        "lastName": "stack"
+      email: 'abc@rudderstack.com',
+      firstName: 'rudder',
+      lastName: 'stack',
     });
   });
 });
 
-describe("FacebookPixel page", () => {
+describe('FacebookPixel page', () => {
   let facebookPixel;
   const mockAnalytics = {
     getUserTraits: jest.fn(() => ({
-      firstName: "rudder",
-      lastName: "stack",
-      email: "abc@rudderstack.com"
+      firstName: 'rudder',
+      lastName: 'stack',
+      email: 'abc@rudderstack.com',
     })),
-    getAnonymousId: jest.fn(() => "testAnonymousID"),
-    getUserId: jest.fn(() => "testUserID")
+    getAnonymousId: jest.fn(() => 'testAnonymousID'),
+    getUserId: jest.fn(() => 'testUserID'),
   };
   beforeEach(() => {
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: true },
+      mockAnalytics,
+    );
     facebookPixel.init();
     window.fbq = jest.fn();
   });
 
-  test("send pageview", () => {
+  test('send pageview', () => {
     facebookPixel.page({
       message: {
         context: {},
         properties: {
-          category: "test cat",
-          path: "/test",
-          url: "http://localhost",
-          referrer: "",
-          title: "test page",
-          testDimension: "abc"
+          category: 'test cat',
+          path: '/test',
+          url: 'http://localhost',
+          referrer: '',
+          title: 'test page',
+          testDimension: 'abc',
         },
       },
     });
-     // console.log(JSON.stringify(window.fbq.mock.calls)); // this has set with empty {} object when resetCustomDimensions
-     expect(window.fbq.mock.calls[0][0]).toEqual("track");
-     expect(window.fbq.mock.calls[0][1]).toEqual("PageView")
-     expect(window.fbq.mock.calls[0][2]).toEqual({
-      "category": "test cat",
-      "path": "/test",
-      "url": "http://localhost",
-      "referrer": "",
-      "title": "test page",
-      "testDimension": "abc"
+    expect(window.fbq.mock.calls[0][0]).toEqual('track');
+    expect(window.fbq.mock.calls[0][1]).toEqual('PageView');
+    expect(window.fbq.mock.calls[0][2]).toEqual({
+      category: 'test cat',
+      path: '/test',
+      url: 'http://localhost',
+      referrer: '',
+      title: 'test page',
+      testDimension: 'abc',
     });
   });
 });
 
-describe("Facebook Pixel Track event", () => {
+describe('Facebook Pixel Track event', () => {
   const mockAnalytics = {
     getUserTraits: jest.fn(() => ({
-      firstName: "rudder",
-      lastName: "stack",
-      email: "abc@rudderstack.com"
+      firstName: 'rudder',
+      lastName: 'stack',
+      email: 'abc@rudderstack.com',
     })),
-    getAnonymousId: jest.fn(() => "testAnonymousID"),
-    getUserId: jest.fn(() => "testUserID")
+    getAnonymousId: jest.fn(() => 'testAnonymousID'),
+    getUserId: jest.fn(() => 'testUserID'),
   };
   let facebookPixel;
   beforeEach(() => {
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', useUpdatedMapping: true },
+      mockAnalytics,
+    );
     facebookPixel.init();
     window.fbq = jest.fn();
   });
 
-  test("Testing Ecommerce Track Events", () => {
+  test('Testing Ecommerce Track Events', () => {
     facebookPixel.track({
       message: {
         context: {},
-        event: "Order Completed",
+        event: 'Order Completed',
         properties: {
-          "customProp": "testProp",
+          customProp: 'testProp',
           checkout_id: 'what is checkout id here??',
           event_id: 'purchaseId',
-          order_id: "transactionId",
-          value: 35.00,
-          shipping: 4.00,
+          order_id: 'transactionId',
+          value: 35.0,
+          shipping: 4.0,
           coupon: 'APPARELSALE',
           currency: 'GBP',
           products: [
-              {
-                "customPropProd": "testPropProd",
-                product_id: 'abc',
-                  category: 'Merch',
-                  name: 'Food/Drink',
-                  brand: '',
-                  variant: 'Extra topped',
-                  price: 3.00,
-                  quantity: 2,
-                  currency: 'GBP',
-                  position: 1,
-                  value: 6.00,
-                  typeOfProduct: 'Food',
-                  url: 'https://www.example.com/product/bacon-jam',
-                  image_url: 'https://www.example.com/product/bacon-jam.jpg'
-              }
-           ]
+            {
+              customPropProd: 'testPropProd',
+              product_id: 'abc',
+              category: 'Merch',
+              name: 'Food/Drink',
+              brand: '',
+              variant: 'Extra topped',
+              price: 3.0,
+              quantity: 2,
+              currency: 'GBP',
+              position: 1,
+              value: 6.0,
+              typeOfProduct: 'Food',
+              url: 'https://www.example.com/product/bacon-jam',
+              image_url: 'https://www.example.com/product/bacon-jam.jpg',
+            },
+          ],
+        },
       },
-    }
     });
-    expect(window.fbq.mock.calls[0][0]).toEqual("trackSingle");
-    expect(window.fbq.mock.calls[0][1]).toEqual("12567839");
-    expect(window.fbq.mock.calls[0][2]).toEqual("Purchase");
+    expect(window.fbq.mock.calls[0][0]).toEqual('trackSingle');
+    expect(window.fbq.mock.calls[0][1]).toEqual('12567839');
+    expect(window.fbq.mock.calls[0][2]).toEqual('Purchase');
     expect(window.fbq.mock.calls[0][3]).toEqual({
-      "content_ids": [
-        "abc"
-      ],
-      "content_type": [
-        "product"
-      ],
-      "currency": "GBP",
-      "value": 0,
-      "contents": [
+      content_ids: ['abc'],
+      content_type: 'product',
+      currency: 'GBP',
+      content_name: undefined,
+      value: 0,
+      contents: [
         {
-          "id": "abc",
-          "quantity": 2,
-          "item_price": 3
-        }
+          id: 'abc',
+          quantity: 2,
+          item_price: 3,
+        },
       ],
-      "num_items": 1
+      num_items: 1,
     });
     expect(window.fbq.mock.calls[0][4]).toEqual({
-      "eventID": "purchaseId"
+      eventID: 'purchaseId',
     });
-
   });
 
-  test("Testing Track Custom Events", () => {
+  test('Testing Track Custom Events', () => {
     facebookPixel.track({
       message: {
         context: {},
-        event: "Custom",
+        event: 'Custom',
         properties: {
-          "customProp": "testProp",
+          customProp: 'testProp',
           checkout_id: 'what is checkout id here??',
           event_id: 'purchaseId',
-          order_id: "transactionId",
-          value: 35.00,
-          shipping: 4.00,
+          order_id: 'transactionId',
+          value: 35.0,
+          shipping: 4.0,
           coupon: 'APPARELSALE',
           currency: 'GBP',
           products: [
-              {
-                "customPropProd": "testPropProd",
-                product_id: 'abc',
-                  category: 'Merch',
-                  name: 'Food/Drink',
-                  brand: '',
-                  variant: 'Extra topped',
-                  price: 3.00,
-                  quantity: 2,
-                  currency: 'GBP',
-                  position: 1,
-                  value: 6.00,
-                  typeOfProduct: 'Food',
-                  url: 'https://www.example.com/product/bacon-jam',
-                  image_url: 'https://www.example.com/product/bacon-jam.jpg'
-              }
-           ]
+            {
+              customPropProd: 'testPropProd',
+              product_id: 'abc',
+              category: 'Merch',
+              name: 'Food/Drink',
+              brand: '',
+              variant: 'Extra topped',
+              price: 3.0,
+              quantity: 2,
+              currency: 'GBP',
+              position: 1,
+              value: 6.0,
+              typeOfProduct: 'Food',
+              url: 'https://www.example.com/product/bacon-jam',
+              image_url: 'https://www.example.com/product/bacon-jam.jpg',
+            },
+          ],
+        },
       },
-    }
     });
-    console.log(JSON.stringify(window.fbq.mock.calls));
-    expect(window.fbq.mock.calls[0][0]).toEqual("trackSingleCustom");
-    expect(window.fbq.mock.calls[0][1]).toEqual("12567839");
-    expect(window.fbq.mock.calls[0][2]).toEqual("Custom");
-    expect(window.fbq.mock.calls[0][3]).toEqual( {
-      "customProp": "testProp",
-      "checkout_id": "what is checkout id here??",
-      "event_id": "purchaseId",
-      "order_id": "transactionId",
-      "value": 0,
-      "shipping": 4,
-      "coupon": "APPARELSALE",
-      "currency": "GBP",
-      "products": [
+    expect(window.fbq.mock.calls[0][0]).toEqual('trackSingleCustom');
+    expect(window.fbq.mock.calls[0][1]).toEqual('12567839');
+    expect(window.fbq.mock.calls[0][2]).toEqual('Custom');
+    expect(window.fbq.mock.calls[0][3]).toEqual({
+      customProp: 'testProp',
+      checkout_id: 'what is checkout id here??',
+      event_id: 'purchaseId',
+      order_id: 'transactionId',
+      value: 0,
+      shipping: 4,
+      coupon: 'APPARELSALE',
+      currency: 'GBP',
+      products: [
         {
-          "customPropProd": "testPropProd",
-          "product_id": "abc",
-          "category": "Merch",
-          "name": "Food/Drink",
-          "brand": "",
-          "variant": "Extra topped",
-          "price": 3,
-          "quantity": 2,
-          "currency": "GBP",
-          "position": 1,
-          "value": 6,
-          "typeOfProduct": "Food",
-          "url": "https://www.example.com/product/bacon-jam",
-          "image_url": "https://www.example.com/product/bacon-jam.jpg"
-        }
-      ]
+          customPropProd: 'testPropProd',
+          product_id: 'abc',
+          category: 'Merch',
+          name: 'Food/Drink',
+          brand: '',
+          variant: 'Extra topped',
+          price: 3,
+          quantity: 2,
+          currency: 'GBP',
+          position: 1,
+          value: 6,
+          typeOfProduct: 'Food',
+          url: 'https://www.example.com/product/bacon-jam',
+          image_url: 'https://www.example.com/product/bacon-jam.jpg',
+        },
+      ],
     });
     expect(window.fbq.mock.calls[0][4]).toEqual({
-      "eventID": "purchaseId"
+      eventID: 'purchaseId',
     });
-
   });
 });
-
-
-

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -2,10 +2,9 @@
 import is from 'is';
 import each from '@ndhoule/each';
 import sha256 from 'crypto-js/sha256';
-import get from 'get-value';
 import ScriptLoader from '../../utils/ScriptLoader';
 import logger from '../../utils/logUtil';
-import getEventId from './utils';
+import { getEventId, getContentCategory } from './utils';
 import { getHashFromArray, isDefined } from '../../utils/commonUtils';
 import { NAME, traitsMapper, reserveTraits } from './constants';
 import { constructPayload } from '../../utils/utils';
@@ -63,29 +62,29 @@ class FacebookPixel {
       if (this.useUpdatedMapping) {
         const userData = {
           context: {
-            traits: { ...this.analytics.getUserTraits() }
+            traits: { ...this.analytics.getUserTraits() },
           },
           userId: this.analytics.getUserId(),
-          anonymousId: this.analytics.getAnonymousId()
-        }
-  
-        let userPayload = constructPayload(userData, traitsMapper);
+          anonymousId: this.analytics.getAnonymousId(),
+        };
+
+        const userPayload = constructPayload(userData, traitsMapper);
         // here we are sending other traits apart from the reserved ones.
         reserveTraits.forEach((element) => {
           delete userData.context?.traits[element];
         });
-  
+
         this.userPayload = { ...userPayload, ...userData.context.traits };
-  
+
         if (this.userPayload.external_id) {
           this.userPayload.external_id = sha256(this.userPayload.external_id).toString();
         }
       } else {
-        this.userPayload = {...this.analytics.getUserTraits()};
+        this.userPayload = { ...this.analytics.getUserTraits() };
       }
       window.fbq('init', this.pixelId, this.userPayload);
     } else {
-      window.fbq('init', this.pixelId );
+      window.fbq('init', this.pixelId);
     }
     ScriptLoader('fbpixel-integration', 'https://connect.facebook.net/en_US/fbevents.js');
   }
@@ -101,7 +100,7 @@ class FacebookPixel {
   }
 
   identify(rudderElement) {
-    logger.error("Identify is deprecated for Facebook Pixel");
+    logger.error('Identify is deprecated for Facebook Pixel');
     return;
   }
 
@@ -114,7 +113,7 @@ class FacebookPixel {
 
   track(rudderElement) {
     const self = this;
-    const { event, properties, messageId } = rudderElement.message;
+    const { event, properties } = rudderElement.message;
     let revValue;
     let currVal;
     if (properties) {
@@ -137,7 +136,6 @@ class FacebookPixel {
       this.userIdAsPixelId = [];
     }
 
-    payload.value = revValue;
     const standard = this.eventsToEvents;
     const legacy = this.legacyConversionPixelId;
     const standardTo = getHashFromArray(standard);
@@ -151,16 +149,23 @@ class FacebookPixel {
     let value;
     let price;
     let query;
+    let contentName;
     if (properties) {
       products = properties.products;
       quantity = properties.quantity;
       category = properties.category;
-      prodId = properties.product_id || properties.id || properties.sku;
-      prodName = properties.product_name;
-      value = properties.value;
+      prodId = properties.product_id || properties.sku || properties.id;
+      prodName = properties.product_name || properties.name;
+      value = revValue || this.formatRevenue(properties.value);
       price = properties.price;
       query = properties.query;
+      contentName = properties.contentName;
     }
+
+    if (category && !getContentCategory(category)) {
+      return;
+    }
+    category = getContentCategory(category);
     const customProperties = this.buildPayLoad(rudderElement, true);
     const derivedEventID = getEventId(rudderElement.message);
     if (event === 'Product List Viewed') {
@@ -169,7 +174,7 @@ class FacebookPixel {
       const contents = [];
 
       if (products && Array.isArray(products)) {
-        for (let i = 0; i < products.length; i++) {
+        for (let i = 0; i < products.length; i += 1) {
           const product = products[i];
           if (product) {
             const productId = product.product_id || product.sku || product.id;
@@ -185,15 +190,15 @@ class FacebookPixel {
         }
       }
 
-      if (contentIds.length) {
-        contentType = ['product'];
+      if (contentIds.length > 0) {
+        contentType = 'product';
       } else if (category) {
         contentIds.push(category);
         contents.push({
           id: category,
           quantity: 1,
         });
-        contentType = ['product_group'];
+        contentType = 'product_group';
       }
 
       window.fbq(
@@ -205,6 +210,10 @@ class FacebookPixel {
             content_ids: contentIds,
             content_type: this.getContentType(rudderElement, contentType),
             contents,
+            content_category: category || '',
+            content_name: contentName,
+            value,
+            currency: currVal,
           },
           customProperties,
         ),
@@ -236,11 +245,11 @@ class FacebookPixel {
         this.merge(
           {
             content_ids: [prodId],
-            content_type: this.getContentType(rudderElement, ['product']),
+            content_type: this.getContentType(rudderElement, 'product'),
             content_name: prodName || '',
             content_category: category || '',
             currency: currVal,
-            value: useValue ? this.formatRevenue(value) : this.formatRevenue(price),
+            value: useValue ? value : this.formatRevenue(price),
             contents: [
               {
                 id: prodId,
@@ -264,7 +273,7 @@ class FacebookPixel {
             val,
             {
               currency: currVal,
-              value: useValue ? this.formatRevenue(value) : this.formatRevenue(price),
+              value: useValue ? value : this.formatRevenue(price),
             },
             {
               eventID: derivedEventID,
@@ -286,12 +295,11 @@ class FacebookPixel {
       }
       const productInfo = {
         content_ids: contentIds,
-        content_type: this.getContentType(rudderElement, ['product']),
-
+        content_type: this.getContentType(rudderElement, 'product'),
         content_name: prodName || '',
         content_category: category || '',
         currency: currVal,
-        value: useValue ? this.formatRevenue(value) : this.formatRevenue(price),
+        value: useValue ? value : this.formatRevenue(price),
         contents,
       };
       window.fbq(
@@ -312,7 +320,7 @@ class FacebookPixel {
             val,
             {
               currency: currVal,
-              value: useValue ? this.formatRevenue(value) : this.formatRevenue(price),
+              value: useValue ? value : this.formatRevenue(price),
             },
             {
               eventID: derivedEventID,
@@ -322,11 +330,11 @@ class FacebookPixel {
       }, legacyTo);
       this.merge(productInfo, customProperties);
     } else if (event === 'Order Completed') {
-      const contentType = this.getContentType(rudderElement, ['product']);
+      const contentType = this.getContentType(rudderElement, 'product');
       const contentIds = [];
       const contents = [];
       if (products) {
-        for (let i = 0; i < products.length; i++) {
+        for (let i = 0; i < products.length; i += 1) {
           const product = products[i];
           if (product) {
             const pId = product.product_id || product.sku || product.id;
@@ -355,6 +363,7 @@ class FacebookPixel {
         value: revValue,
         contents,
         num_items: contentIds.length,
+        content_name: contentName,
       };
 
       window.fbq(
@@ -384,20 +393,28 @@ class FacebookPixel {
         }
       }, legacyTo);
     } else if (event === 'Products Searched') {
-      window.fbq(
-        'trackSingle',
-        self.pixelId,
-        'Search',
-        this.merge(
-          {
-            search_string: query,
-          },
-          customProperties,
-        ),
-        {
-          eventID: derivedEventID,
-        },
-      );
+      const contentIds = [];
+      const contents = [];
+
+      if (prodId) {
+        contentIds.push(prodId);
+        contents.push({
+          id: prodId,
+          quantity,
+          item_price: price,
+        });
+      }
+      const productInfo = {
+        content_ids: contentIds,
+        content_category: category || '',
+        currency: currVal,
+        value,
+        contents,
+        search_string: query,
+      };
+      window.fbq('trackSingle', self.pixelId, 'Search', this.merge(productInfo, customProperties), {
+        eventID: derivedEventID,
+      });
 
       each((val, key) => {
         if (key === event.toLowerCase()) {
@@ -407,7 +424,7 @@ class FacebookPixel {
             val,
             {
               currency: currVal,
-              value: revValue,
+              value,
             },
             {
               eventID: derivedEventID,
@@ -420,7 +437,7 @@ class FacebookPixel {
       const contentIds = [];
       const contents = [];
       if (products) {
-        for (let i = 0; i < products.length; i++) {
+        for (let i = 0; i < products.length; i += 1) {
           const product = products[i];
           if (product) {
             const pId = product.product_id || product.sku || product.id;
@@ -443,7 +460,8 @@ class FacebookPixel {
 
       const productInfo = {
         content_ids: contentIds,
-        content_type: this.getContentType(rudderElement, ['product']),
+        content_type: this.getContentType(rudderElement, 'product'),
+        content_category: contentCategory,
         currency: currVal,
         value: revValue,
         contents,
@@ -532,14 +550,14 @@ class FacebookPixel {
     // Get the message-specific override if it exists in the options parameter of `track()`
     const contentTypeMessageOverride =
       rudderElement.message.integrations?.FACEBOOK_PIXEL?.contentType;
-    if (contentTypeMessageOverride) return [contentTypeMessageOverride];
+    if (contentTypeMessageOverride) return contentTypeMessageOverride;
 
     // Otherwise check if there is a replacement set for all Facebook Pixel
     // track calls of this category
     const { category } = rudderElement.message.properties;
     if (category) {
       const categoryMapping = this.categoryToContent?.find((i) => i.from === category);
-      if (categoryMapping?.to) return [categoryMapping.to];
+      if (categoryMapping?.to) return categoryMapping.to;
     }
 
     // Otherwise return the default value
@@ -550,18 +568,21 @@ class FacebookPixel {
     const res = {};
 
     // All properties of obj1
-    for (const propObj1 in obj1) {
-      if (obj1.hasOwnProperty(propObj1)) {
+    Object.keys(obj1).forEach((propObj1) => {
+      if (Object.prototype.hasOwnProperty.call(obj1, propObj1)) {
         res[propObj1] = obj1[propObj1];
       }
-    }
+    });
 
     // Extra properties of obj2
-    for (const propObj2 in obj2) {
-      if (obj2.hasOwnProperty(propObj2) && !res.hasOwnProperty(propObj2)) {
+    Object.keys(obj2).forEach((propObj2) => {
+      if (
+        Object.prototype.hasOwnProperty.call(obj2, propObj2) &&
+        !Object.prototype.hasOwnProperty.call(res, propObj2)
+      ) {
         res[propObj2] = obj2[propObj2];
       }
-    }
+    });
 
     return res;
   }
@@ -601,7 +622,7 @@ class FacebookPixel {
     const blacklistPiiProperties = this.blacklistPiiProperties || [];
     const eventCustomProperties = this.eventCustomProperties || [];
     const customPiiProperties = {};
-    for (let i = 0; i < blacklistPiiProperties[i]; i++) {
+    for (let i = 0; i < blacklistPiiProperties[i]; i += 1) {
       const configuration = blacklistPiiProperties[i];
       customPiiProperties[configuration.blacklistPiiProperties] = configuration.blacklistPiiHash;
     }
@@ -642,4 +663,4 @@ class FacebookPixel {
   }
 }
 
-export default FacebookPixel ;
+export default FacebookPixel;

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -162,6 +162,7 @@ class FacebookPixel {
       contentName = properties.contentName;
     }
 
+    // check for category data type
     if (category && !getContentCategory(category)) {
       return;
     }

--- a/src/integrations/FacebookPixel/utils.js
+++ b/src/integrations/FacebookPixel/utils.js
@@ -1,4 +1,5 @@
 import get from 'get-value';
+import logger from '../../utils/logUtil';
 
 function getEventId(message) {
   return (
@@ -8,4 +9,36 @@ function getEventId(message) {
     message.messageId
   );
 }
-export default getEventId;
+
+/**
+ * This method gets content category
+ *
+ * @param {*} category
+ * @returns The content category as a string
+ */
+const getContentCategory = (category) => {
+  let contentCategory = category;
+  if (Array.isArray(contentCategory)) {
+    contentCategory = contentCategory.map(String).join(',');
+  }
+  if (
+    contentCategory &&
+    typeof contentCategory !== 'string' &&
+    typeof contentCategory !== 'object'
+  ) {
+    contentCategory = String(contentCategory);
+  }
+  if (
+    contentCategory &&
+    typeof contentCategory !== 'string' &&
+    !Array.isArray(contentCategory) &&
+    typeof contentCategory === 'object'
+  ) {
+    logger.error("'properties.category' must be either be a string or an array");
+    return;
+  }
+  // eslint-disable-next-line consistent-return
+  return contentCategory;
+};
+
+export { getEventId, getContentCategory };


### PR DESCRIPTION
## PR Description

1. content_category passed as an array. Now passing it as comma(,) separated string.
2. content_type passed as an array. Now passing it as a string.
3. valueFieldIdentifier configured as properties.value in webapp but considering properties.revenue in the calculation. Now considering properties.revenue/ properties.value for backward compatibility.
4. Event-wise mapping changes mentioned [here](https://www.notion.so/rudderstacks/Following-E-commerce-spec-56ea62ac808c4ef880c0362b2288d2fa?pvs=4#5fe30a269f6941c6a6a139090517a0bf)

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Facebook-Pixel-Ecomm-spec-fix-Device-mode-f9836b3b501040a9bdf8d1bed77dbb84)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
