### PR TITLE
fix: support bingAds for multiple tagIds

### DIFF
--- a/src/integrations/BingAds/browser.js
+++ b/src/integrations/BingAds/browser.js
@@ -9,8 +9,10 @@ class BingAds {
     }
     this.tagID = config.tagID;
     this.name = NAME;
+    this.uniqueId = `bing${this.tagID}`;
   }
 
+  /* eslint-disable */
   loadBingadsScript = () => {
     ((w, d, t, r, u) => {
       let f;
@@ -35,8 +37,9 @@ class BingAds {
           }),
         (i = d.getElementsByTagName(t)[0]),
         i.parentNode.insertBefore(n, i);
-    })(window, document, 'script', 'https://bat.bing.com/bat.js', 'uetq');
+    })(window, document, 'script', 'https://bat.bing.com/bat.js', this.uniqueId);
   };
+  /* eslint-enable */
 
   init = () => {
     this.loadBingadsScript();
@@ -45,12 +48,12 @@ class BingAds {
 
   isLoaded = () => {
     logger.debug('in BingAds isLoaded');
-    return !!window.uetq && window.uetq.push !== Array.prototype.push;
+    return !!window[this.uniqueId] && window[this.uniqueId].push !== Array.prototype.push;
   };
 
   isReady = () => {
     logger.debug('in BingAds isReady');
-    return !!(window.uetq && window.uetq.push !== Array.prototype.push);
+    return !!(window[this.uniqueId] && window[this.uniqueId].push !== Array.prototype.push);
   };
 
   /*
@@ -82,11 +85,11 @@ class BingAds {
     if (total) {
       payload.gv = total;
     }
-    window.uetq.push(payload);
+    window[this.uniqueId].push(payload);
   };
 
   page = () => {
-    window.uetq.push('pageLoad');
+    window[this.uniqueId].push('pageLoad');
   };
 }
 


### PR DESCRIPTION
## PR Description

When multiple instances of bing tags are added to the same page, they all end up sharing the same global array(window.uetq). Thus all tags are fired using same tagID. Now by overriding the name of the global variable to tagId, multiple instances of UET tag can be supported in a same page.

Imp links:
https://help.ads.microsoft.com/#apex/3/en/56714/2
https://help.ads.microsoft.com/apex/index/3/en/56685

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
