### PR TITLE
fix(fb_pixel): add value in mapped event

### DIFF
--- a/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
+++ b/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
@@ -1,27 +1,28 @@
-import FacebookPixel from "../../../src/integrations/FacebookPixel";
-
-beforeAll(() => { });
+import FacebookPixel from '../../../src/integrations/FacebookPixel';
 
 afterAll(() => {
   jest.restoreAllMocks();
 });
 
-describe("FacebookPixel init tests", () => {
+describe('FacebookPixel init tests', () => {
   let facebookPixel;
 
-  test("Testing init call of Facebook Pixel with identified user and updated mapping true", () => {
+  test('Testing init call of Facebook Pixel with identified user and updated mapping true', () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => ({
-        firstName: "rudder",
-        lastName: "stack",
-        email: "abc@rudderstack.com"
+        firstName: 'rudder',
+        lastName: 'stack',
+        email: 'abc@rudderstack.com',
       })),
-      getAnonymousId: jest.fn(() => "testAnonymousID"),
-      getUserId: jest.fn(() => "testUserID")
+      getAnonymousId: jest.fn(() => 'testAnonymousID'),
+      getUserId: jest.fn(() => 'testUserID'),
     };
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: true },
+      mockAnalytics,
+    );
     facebookPixel.init();
-    expect(typeof window.fbq).toBe("function");
+    expect(typeof window.fbq).toBe('function');
     expect(facebookPixel.userPayload).toStrictEqual({
       external_id: 'd06773e1bf4b8a96a4786fbb8e3444092438ad29401769613ae9e0e3e1e08a84',
       em: 'abc@rudderstack.com',
@@ -29,244 +30,285 @@ describe("FacebookPixel init tests", () => {
       ge: undefined,
       db: undefined,
       ln: 'stack',
-      fn: 'rudder'
+      fn: 'rudder',
     });
   });
 
-  test("Testing init call of Facebook Pixel with anonymous user and updated mapping true", () => {
+  test('Testing init call of Facebook Pixel with anonymous user and updated mapping true', () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => null),
-      getAnonymousId: jest.fn(() => "testAnonymousID"),
-      getUserId: jest.fn(() => null)
+      getAnonymousId: jest.fn(() => 'testAnonymousID'),
+      getUserId: jest.fn(() => null),
     };
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: true },
+      mockAnalytics,
+    );
     facebookPixel.init();
-    expect(typeof window.fbq).toBe("function");
+    expect(typeof window.fbq).toBe('function');
     expect(facebookPixel.userPayload).toStrictEqual({
       external_id: 'd4e669b42293a60cc65b22830a922824e6e9c7736c6058fbbb3de780d2f4a17f',
       em: undefined,
       ph: undefined,
       ge: undefined,
-      db: undefined
-    }
-    );
+      db: undefined,
+    });
   });
 
-  test("Testing init call of Facebook Pixel with identified user and updated mapping false", () => {
+  test('Testing init call of Facebook Pixel with identified user and updated mapping false', () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => ({
-        firstName: "rudder",
-        lastName: "stack",
-        email: "abc@rudderstack.com"
+        firstName: 'rudder',
+        lastName: 'stack',
+        email: 'abc@rudderstack.com',
       })),
-      getAnonymousId: jest.fn(() => "testAnonymousID"),
-      getUserId: jest.fn(() => "testUserID")
+      getAnonymousId: jest.fn(() => 'testAnonymousID'),
+      getUserId: jest.fn(() => 'testUserID'),
     };
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: false }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: false },
+      mockAnalytics,
+    );
     facebookPixel.init();
-    expect(typeof window.fbq).toBe("function");
+    expect(typeof window.fbq).toBe('function');
     expect(facebookPixel.userPayload).toStrictEqual({
       email: 'abc@rudderstack.com',
       lastName: 'stack',
-      firstName: 'rudder'
+      firstName: 'rudder',
     });
   });
 });
 
-describe("FacebookPixel page", () => {
+describe('FacebookPixel page', () => {
   const mockAnalytics = {
     getUserTraits: jest.fn(() => ({
-      firstName: "rudder",
-      lastName: "stack",
-      email: "abc@rudderstack.com"
+      firstName: 'rudder',
+      lastName: 'stack',
+      email: 'abc@rudderstack.com',
     })),
-    getAnonymousId: jest.fn(() => "testAnonymousID"),
-    getUserId: jest.fn(() => "testUserID")
+    getAnonymousId: jest.fn(() => 'testAnonymousID'),
+    getUserId: jest.fn(() => 'testUserID'),
   };
   let facebookPixel;
   beforeEach(() => {
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: true },
+      mockAnalytics,
+    );
     facebookPixel.init();
     window.fbq = jest.fn();
   });
 
-  test("send pageview", () => {
+  test('send pageview', () => {
     facebookPixel.page({
       message: {
         context: {},
         properties: {
-          category: "test cat",
-          path: "/test",
-          url: "http://localhost",
-          referrer: "",
-          title: "test page",
-          testDimension: "abc"
+          category: 'test cat',
+          path: '/test',
+          url: 'http://localhost',
+          referrer: '',
+          title: 'test page',
+          testDimension: 'abc',
         },
       },
     });
-     expect(window.fbq.mock.calls[0][0]).toEqual("track");
-     expect(window.fbq.mock.calls[0][1]).toEqual("PageView")
-     expect(window.fbq.mock.calls[0][2]).toEqual({
-      "category": "test cat",
-      "path": "/test",
-      "url": "http://localhost",
-      "referrer": "",
-      "title": "test page",
-      "testDimension": "abc"
+    expect(window.fbq.mock.calls[0][0]).toEqual('track');
+    expect(window.fbq.mock.calls[0][1]).toEqual('PageView');
+    expect(window.fbq.mock.calls[0][2]).toEqual({
+      category: 'test cat',
+      path: '/test',
+      url: 'http://localhost',
+      referrer: '',
+      title: 'test page',
+      testDimension: 'abc',
     });
   });
 });
 
-describe("Facebook Pixel Track event", () => {
+describe('Facebook Pixel Track event', () => {
   const mockAnalytics = {
     getUserTraits: jest.fn(() => ({
-      firstName: "rudder",
-      lastName: "stack",
-      email: "abc@rudderstack.com"
+      firstName: 'rudder',
+      lastName: 'stack',
+      email: 'abc@rudderstack.com',
     })),
-    getAnonymousId: jest.fn(() => "testAnonymousID"),
-    getUserId: jest.fn(() => "testUserID")
+    getAnonymousId: jest.fn(() => 'testAnonymousID'),
+    getUserId: jest.fn(() => 'testUserID'),
   };
   let facebookPixel;
   beforeEach(() => {
-    facebookPixel = new FacebookPixel({ pixelId: "12567839", advancedMapping: true, useUpdatedMapping: true }, mockAnalytics);
+    facebookPixel = new FacebookPixel(
+      {
+        pixelId: '12567839',
+        advancedMapping: true,
+        useUpdatedMapping: true,
+        eventsToEvents: [
+          {
+            from: 'ABC',
+            to: 'Purchase',
+          },
+        ],
+      },
+      mockAnalytics,
+    );
     facebookPixel.init();
     window.fbq = jest.fn();
   });
 
-  test("Testing Ecommerce Track Events", () => {
+  test('Testing Ecommerce Track Events', () => {
     facebookPixel.track({
       message: {
         context: {},
-        event: "Order Completed",
+        event: 'Order Completed',
         properties: {
-          "customProp": "testProp",
+          customProp: 'testProp',
           checkout_id: 'what is checkout id here??',
           event_id: 'purchaseId',
-          order_id: "transactionId",
-          value: 35.00,
-          shipping: 4.00,
+          order_id: 'transactionId',
+          value: 35.0,
+          shipping: 4.0,
           coupon: 'APPARELSALE',
           currency: 'GBP',
           products: [
-              {
-                "customPropProd": "testPropProd",
-                product_id: 'abc',
-                  category: 'Merch',
-                  name: 'Food/Drink',
-                  brand: '',
-                  variant: 'Extra topped',
-                  price: 3.00,
-                  quantity: 2,
-                  currency: 'GBP',
-                  position: 1,
-                  value: 6.00,
-                  typeOfProduct: 'Food',
-                  url: 'https://www.example.com/product/bacon-jam',
-                  image_url: 'https://www.example.com/product/bacon-jam.jpg'
-              }
-           ]
+            {
+              customPropProd: 'testPropProd',
+              product_id: 'abc',
+              category: 'Merch',
+              name: 'Food/Drink',
+              brand: '',
+              variant: 'Extra topped',
+              price: 3.0,
+              quantity: 2,
+              currency: 'GBP',
+              position: 1,
+              value: 6.0,
+              typeOfProduct: 'Food',
+              url: 'https://www.example.com/product/bacon-jam',
+              image_url: 'https://www.example.com/product/bacon-jam.jpg',
+            },
+          ],
+        },
       },
-    }
     });
-    expect(window.fbq.mock.calls[0][0]).toEqual("trackSingle");
-    expect(window.fbq.mock.calls[0][1]).toEqual("12567839");
-    expect(window.fbq.mock.calls[0][2]).toEqual("Purchase");
+    expect(window.fbq.mock.calls[0][0]).toEqual('trackSingle');
+    expect(window.fbq.mock.calls[0][1]).toEqual('12567839');
+    expect(window.fbq.mock.calls[0][2]).toEqual('Purchase');
     expect(window.fbq.mock.calls[0][3]).toEqual({
-      "content_ids": [
-        "abc"
-      ],
-      "content_type":"product",
-      "currency": "GBP",
-      "content_name": undefined,
-      "value": 0,
-      "contents": [
+      content_ids: ['abc'],
+      content_type: 'product',
+      currency: 'GBP',
+      content_name: undefined,
+      value: 0,
+      contents: [
         {
-          "id": "abc",
-          "quantity": 2,
-          "item_price": 3
-        }
+          id: 'abc',
+          quantity: 2,
+          item_price: 3,
+        },
       ],
-      "num_items": 1
+      num_items: 1,
     });
     expect(window.fbq.mock.calls[0][4]).toEqual({
-      "eventID": "purchaseId"
+      eventID: 'purchaseId',
     });
-
   });
 
-  test("Testing Track Custom Events", () => {
+  test('Testing Track Custom Events', () => {
     facebookPixel.track({
       message: {
         context: {},
-        event: "Custom",
+        event: 'Custom',
         properties: {
-          "customProp": "testProp",
+          customProp: 'testProp',
           checkout_id: 'what is checkout id here??',
           event_id: 'purchaseId',
-          order_id: "transactionId",
-          value: 35.00,
-          shipping: 4.00,
+          order_id: 'transactionId',
+          value: 35.0,
+          shipping: 4.0,
           coupon: 'APPARELSALE',
           currency: 'GBP',
           products: [
-              {
-                "customPropProd": "testPropProd",
-                product_id: 'abc',
-                  category: 'Merch',
-                  name: 'Food/Drink',
-                  brand: '',
-                  variant: 'Extra topped',
-                  price: 3.00,
-                  quantity: 2,
-                  currency: 'GBP',
-                  position: 1,
-                  value: 6.00,
-                  typeOfProduct: 'Food',
-                  url: 'https://www.example.com/product/bacon-jam',
-                  image_url: 'https://www.example.com/product/bacon-jam.jpg'
-              }
-           ]
+            {
+              customPropProd: 'testPropProd',
+              product_id: 'abc',
+              category: 'Merch',
+              name: 'Food/Drink',
+              brand: '',
+              variant: 'Extra topped',
+              price: 3.0,
+              quantity: 2,
+              currency: 'GBP',
+              position: 1,
+              value: 6.0,
+              typeOfProduct: 'Food',
+              url: 'https://www.example.com/product/bacon-jam',
+              image_url: 'https://www.example.com/product/bacon-jam.jpg',
+            },
+          ],
+        },
       },
-    }
     });
-    expect(window.fbq.mock.calls[0][0]).toEqual("trackSingleCustom");
-    expect(window.fbq.mock.calls[0][1]).toEqual("12567839");
-    expect(window.fbq.mock.calls[0][2]).toEqual("Custom");
-    expect(window.fbq.mock.calls[0][3]).toEqual( {
-      "customProp": "testProp",
-      "checkout_id": "what is checkout id here??",
-      "event_id": "purchaseId",
-      "order_id": "transactionId",
-      "value": 0,
-      "shipping": 4,
-      "coupon": "APPARELSALE",
-      "currency": "GBP",
-      "products": [
+    expect(window.fbq.mock.calls[0][0]).toEqual('trackSingleCustom');
+    expect(window.fbq.mock.calls[0][1]).toEqual('12567839');
+    expect(window.fbq.mock.calls[0][2]).toEqual('Custom');
+    expect(window.fbq.mock.calls[0][3]).toEqual({
+      customProp: 'testProp',
+      checkout_id: 'what is checkout id here??',
+      event_id: 'purchaseId',
+      order_id: 'transactionId',
+      value: 0,
+      shipping: 4,
+      coupon: 'APPARELSALE',
+      currency: 'GBP',
+      products: [
         {
-          "customPropProd": "testPropProd",
-          "product_id": "abc",
-          "category": "Merch",
-          "name": "Food/Drink",
-          "brand": "",
-          "variant": "Extra topped",
-          "price": 3,
-          "quantity": 2,
-          "currency": "GBP",
-          "position": 1,
-          "value": 6,
-          "typeOfProduct": "Food",
-          "url": "https://www.example.com/product/bacon-jam",
-          "image_url": "https://www.example.com/product/bacon-jam.jpg"
-        }
-      ]
+          customPropProd: 'testPropProd',
+          product_id: 'abc',
+          category: 'Merch',
+          name: 'Food/Drink',
+          brand: '',
+          variant: 'Extra topped',
+          price: 3,
+          quantity: 2,
+          currency: 'GBP',
+          position: 1,
+          value: 6,
+          typeOfProduct: 'Food',
+          url: 'https://www.example.com/product/bacon-jam',
+          image_url: 'https://www.example.com/product/bacon-jam.jpg',
+        },
+      ],
     });
     expect(window.fbq.mock.calls[0][4]).toEqual({
-      "eventID": "purchaseId"
+      eventID: 'purchaseId',
     });
+  });
 
+  test('Testing Track Custom Mapped Events', () => {
+    facebookPixel.track({
+      message: {
+        context: {},
+        event: 'ABC',
+        properties: {
+          customProp: 'testProp',
+          event_id: 'purchaseId',
+          revenue: 37,
+          shipping: 4.0,
+          coupon: 'APPARELSALE',
+          currency: 'GBP',
+        },
+      },
+    });
+    expect(window.fbq.mock.calls[0][0]).toEqual('trackSingle');
+    expect(window.fbq.mock.calls[0][1]).toEqual('12567839');
+    expect(window.fbq.mock.calls[0][2]).toEqual('Purchase');
+    expect(window.fbq.mock.calls[0][3]).toEqual({
+      value: 37,
+      currency: 'GBP',
+    });
+    expect(window.fbq.mock.calls[0][4]).toEqual({
+      eventID: 'purchaseId',
+    });
   });
 });
-
-
-

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -501,6 +501,7 @@ class FacebookPixel {
         each((val, key) => {
           if (key === event.toLowerCase()) {
             payload.currency = currVal;
+            payload.value = revValue;
 
             window.fbq('trackSingle', self.pixelId, val, payload, {
               eventID: derivedEventID,


### PR DESCRIPTION
## PR Description

Add value parameter in custom-mapped events.

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Facebook-pixel-missing-value-parameter-in-custom-mapped-event-78a621f5e7b84de58dfaf5e334ca1447)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
