### PR TITLE
fix(fb_pixel): add value in mapped event

### DIFF
--- a/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
+++ b/__tests__/integrations/FacebookPixel/FacebookPixel.test.js
@@ -141,7 +141,16 @@ describe('Facebook Pixel Track event', () => {
   let facebookPixel;
   beforeEach(() => {
     facebookPixel = new FacebookPixel(
-      { pixelId: '12567839', useUpdatedMapping: true },
+      {
+        pixelId: '12567839',
+        useUpdatedMapping: true,
+        eventsToEvents: [
+          {
+            from: 'ABC',
+            to: 'Purchase',
+          },
+        ],
+      },
       mockAnalytics,
     );
     facebookPixel.init();
@@ -271,6 +280,33 @@ describe('Facebook Pixel Track event', () => {
           image_url: 'https://www.example.com/product/bacon-jam.jpg',
         },
       ],
+    });
+    expect(window.fbq.mock.calls[0][4]).toEqual({
+      eventID: 'purchaseId',
+    });
+  });
+
+  test('Testing Track Custom Mapped Events', () => {
+    facebookPixel.track({
+      message: {
+        context: {},
+        event: 'ABC',
+        properties: {
+          customProp: 'testProp',
+          event_id: 'purchaseId',
+          revenue: 37,
+          shipping: 4.0,
+          coupon: 'APPARELSALE',
+          currency: 'GBP',
+        },
+      },
+    });
+    expect(window.fbq.mock.calls[0][0]).toEqual('trackSingle');
+    expect(window.fbq.mock.calls[0][1]).toEqual('12567839');
+    expect(window.fbq.mock.calls[0][2]).toEqual('Purchase');
+    expect(window.fbq.mock.calls[0][3]).toEqual({
+      value: 37,
+      currency: 'GBP',
     });
     expect(window.fbq.mock.calls[0][4]).toEqual({
       eventID: 'purchaseId',

--- a/src/integrations/FacebookPixel/browser.js
+++ b/src/integrations/FacebookPixel/browser.js
@@ -504,6 +504,7 @@ class FacebookPixel {
         each((val, key) => {
           if (key === event.toLowerCase()) {
             payload.currency = currVal;
+            payload.value = revValue;
 
             window.fbq('trackSingle', self.pixelId, val, payload, {
               eventID: derivedEventID,


### PR DESCRIPTION
## PR Description

Add value parameter in custom-mapped events.

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Facebook-pixel-missing-value-parameter-in-custom-mapped-event-78a621f5e7b84de58dfaf5e334ca1447)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
