### PR TITLE
fix: bugsnag typo in rollup config

### DIFF
--- a/rollup-configs/rollup.utilities.js
+++ b/rollup-configs/rollup.utilities.js
@@ -49,7 +49,7 @@ export function getDefaultConfig(distName) {
         __PACKAGE_VERSION__: version,
         __MODULE_TYPE__: moduleType,
         __RS_BUGSNAG_API_KEY__: process.env.BUGSNAG_API_KEY || '{{__RS_BUGSNAG_API_KEY__}}',
-        __RS_BUGSNUG_RELEASE_STAGE__: process.env.BUGSNAG_RELEASE_STAGE || 'production',
+        __RS_BUGSNAG_RELEASE_STAGE__: process.env.BUGSNAG_RELEASE_STAGE || 'production',
       }),
       resolve({
         jsnext: true,


### PR DESCRIPTION
## PR Description

Fixed the typo in the rollup configuration file without which the release stage is set to default.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
