### PR TITLE
feat: delaying cloud mode events based on flag provided in options

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -7,7 +7,7 @@ module.exports = [
     name: 'Core - CDN',
     path: 'dist/legacy/rudder-analytics.min.js',
     gzip: true,
-    limit: '39.6 kB',
+    limit: '39.7 kB',
   },
   {
     name: 'All Integrations - CDN',
@@ -19,7 +19,7 @@ module.exports = [
     name: 'Core - NPM',
     path: 'dist/npm-lib/index.js',
     gzip: true,
-    limit: '39.6 kB',
+    limit: '39.7 kB',
   },
   {
     name: 'Service Worker - NPM',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -7,7 +7,7 @@ module.exports = [
     name: 'Core - CDN',
     path: 'dist/legacy/rudder-analytics.min.js',
     gzip: true,
-    limit: '39.7 kB',
+    limit: '39.705 kB',
   },
   {
     name: 'All Integrations - CDN',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -7,7 +7,7 @@ module.exports = [
     name: 'Core - CDN',
     path: 'dist/legacy/rudder-analytics.min.js',
     gzip: true,
-    limit: '39.72 kB',
+    limit: '39.9 kB',
   },
   {
     name: 'All Integrations - CDN',
@@ -19,7 +19,7 @@ module.exports = [
     name: 'Core - NPM',
     path: 'dist/npm-lib/index.js',
     gzip: true,
-    limit: '39.7 kB',
+    limit: '39.8 kB',
   },
   {
     name: 'Service Worker - NPM',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -7,7 +7,7 @@ module.exports = [
     name: 'Core - CDN',
     path: 'dist/legacy/rudder-analytics.min.js',
     gzip: true,
-    limit: '39.705 kB',
+    limit: '39.72 kB',
   },
   {
     name: 'All Integrations - CDN',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -7,7 +7,7 @@ module.exports = [
     name: 'Core - CDN',
     path: 'dist/legacy/rudder-analytics.min.js',
     gzip: true,
-    limit: '39.9 kB',
+    limit: '39.98 kB',
   },
   {
     name: 'All Integrations - CDN',
@@ -19,7 +19,7 @@ module.exports = [
     name: 'Core - NPM',
     path: 'dist/npm-lib/index.js',
     gzip: true,
-    limit: '39.8 kB',
+    limit: '39.9 kB',
   },
   {
     name: 'Service Worker - NPM',

--- a/__tests__/utils/preProcessQueue.test.js
+++ b/__tests__/utils/preProcessQueue.test.js
@@ -1,0 +1,79 @@
+import PreProcessQueue from '../../src/utils/PreProcessQueue';
+import RudderElement from '../../src/utils/RudderElement';
+
+describe('PreProcessQueue', () => {
+  let preProcessQueue;
+
+  beforeEach(() => {
+    preProcessQueue = new PreProcessQueue();
+  });
+
+  afterEach(() => {
+    preProcessQueue = null;
+  });
+
+  describe('init()', () => {
+    it('should initialize the payloadQueue with default options', () => {
+      preProcessQueue.init();
+
+      expect(preProcessQueue.payloadQueue).toBeDefined();
+    });
+
+    it('should initialize the payloadQueue with custom options', () => {
+      const options = {
+        maxRetryDelay: 360000,
+        minRetryDelay: 1000,
+        backoffFactor: 2,
+        maxAttempts: Infinity,
+        maxItems: 100,
+      };
+      preProcessQueue.init(options);
+
+      expect(preProcessQueue.payloadQueue.backoff.FACTOR).toEqual(options.backoffFactor);
+      expect(preProcessQueue.payloadQueue.backoff.MAX_RETRY_DELAY).toEqual(options.maxRetryDelay);
+      expect(preProcessQueue.payloadQueue.backoff.MIN_RETRY_DELAY).toEqual(options.minRetryDelay);
+      expect(preProcessQueue.payloadQueue.maxAttempts).toEqual(options.maxAttempts);
+      expect(preProcessQueue.payloadQueue.maxItems).toEqual(options.maxItems);
+    });
+
+    it('should set the callback', () => {
+      const callback = jest.fn();
+      preProcessQueue.init(null, callback);
+
+      expect(preProcessQueue.callback).toEqual(callback);
+    });
+  });
+
+  describe('activateProcessor()', () => {
+    it('should set processQueueElements to true', () => {
+      preProcessQueue.activateProcessor();
+      expect(preProcessQueue.processQueueElements).toBe(true);
+    });
+  });
+
+  describe('processQueueElement()', () => {
+    it('should call the queueFn with null if processQueueElements is true', () => {
+      const type = 'track';
+      const rudderElement = new RudderElement();
+      const queueFn = jest.fn();
+      const callback = jest.fn();
+      preProcessQueue.init({}, callback);
+
+      preProcessQueue.processQueueElements = true;
+      preProcessQueue.processQueueElement(type, rudderElement, queueFn);
+      expect(queueFn).toHaveBeenCalledWith(null);
+    });
+
+    it('should call the queueFn with an error if processQueueElements is false', () => {
+      const type = 'track';
+      const rudderElement = new RudderElement();
+      const queueFn = jest.fn();
+
+      preProcessQueue.processQueueElements = false;
+      preProcessQueue.processQueueElement(type, rudderElement, queueFn);
+      expect(queueFn).toHaveBeenCalledWith(
+        new Error('The queue elements are not ready to be processed yet'),
+      );
+    });
+  });
+});

--- a/__tests__/utils/preProcessQueue.test.js
+++ b/__tests__/utils/preProcessQueue.test.js
@@ -33,7 +33,6 @@ describe('PreProcessQueue', () => {
       expect(preProcessQueue.payloadQueue.backoff.MAX_RETRY_DELAY).toEqual(options.maxRetryDelay);
       expect(preProcessQueue.payloadQueue.backoff.MIN_RETRY_DELAY).toEqual(options.minRetryDelay);
       expect(preProcessQueue.payloadQueue.maxAttempts).toEqual(options.maxAttempts);
-      expect(preProcessQueue.payloadQueue.maxItems).toEqual(options.maxItems);
     });
 
     it('should set the callback', () => {

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -470,7 +470,6 @@ class Analytics {
    *
    * @param {*} type
    * @param {*} rudderElement
-   * @param {*} clientSuppliedIntegrations
    * Sends cloud mode events to server
    */
   queueEventForDataPlane(type, rudderElement) {

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -912,7 +912,9 @@ class Analytics {
       transformToServerNames(clonedRudderElement.message.integrations);
 
       // Holding the cloud mode events based on flag and integrations load check
-      if (!this.bufferDataPlaneEventsUntilReady || this.clientIntegrationObjects) {
+      const shouldNotBufferDataPlaneEvents =
+        !this.bufferDataPlaneEventsUntilReady || this.clientIntegrationObjects;
+      if (shouldNotBufferDataPlaneEvents) {
         this.queueEventForDataPlane(type, clonedRudderElement);
       } else {
         this.preProcessQueue.enqueue(type, clonedRudderElement);

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -523,10 +523,6 @@ class Analytics {
       cloudModeEvents.forEach((event) => {
         const methodName = event[0];
         event.shift();
-        // convert common names to sdk identified name
-        if (Object.keys(event[0].message.integrations).length > 0) {
-          transformToRudderNames(event[0].message.integrations);
-        }
 
         // if not specified at event level, All: true is default
         const clientSuppliedIntegrations = event[0].message.integrations;

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -899,7 +899,7 @@ class Analytics {
       if (!this.clientIntegrationObjects) {
         // logger.debug("pushing in replay queue")
         // new event processing after analytics initialized  but integrations not fetched from BE
-        this.toBeProcessedByIntegrationArray.push([type, rudderElement, callback]);
+        this.toBeProcessedByIntegrationArray.push([type, rudderElement]);
       } else {
         // get intersection between config plane native enabled destinations
         // (which were able to successfully load on the page) vs user supplied integrations

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -490,7 +490,7 @@ class Analytics {
    */
   processBufferedCloudModeEvents() {
     if (this.bufferDataPlaneEventsUntilReady) {
-      this.preProcessQueue.processCloudModeIntegrationsObjData(this.integrationsData);
+      this.preProcessQueue.setCloudModeEventsIntegrationObjData(this.integrationsData);
     }
   }
 

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -61,6 +61,7 @@ import { getIntegrationsCDNPath } from '../utils/cdnPaths';
 import { ErrorReportingService } from '../features/core/metrics/errorReporting/ErrorReportingService';
 import { getUserAgentClientHint } from '../utils/clientHint';
 import { DeviceModeTransformations } from '../features/core/deviceModeTransformation/transformationHandler';
+import RudderElement from '../utils/RudderElement';
 
 /**
  * class responsible for handling core
@@ -529,6 +530,9 @@ class Analytics {
 
         // if not specified at event level, All: true is default
         const clientSuppliedIntegrations = event[0].message.integrations;
+
+        // Adding the RudderElement class prototype as it's got detached while storing in localStorage
+        Object.setPrototypeOf(event[0], RudderElement.prototype);
 
         // event[0] -> rudderElement, event[1] -> callback
         this.processCloudModeEvents(methodName, event[0], event[1], clientSuppliedIntegrations);

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -41,10 +41,10 @@ import {
   POLYFILL_URL,
   SAMESITE_COOKIE_OPTS,
   UA_CH_LEVELS,
+  MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS,
 } from '../utils/constants';
 import RudderElementBuilder from '../utils/RudderElementBuilder';
 import Storage from '../utils/storage';
-import { Store } from '../utils/storage/store';
 import { EventRepository } from '../utils/EventRepository';
 import PreProcessQueue from '../utils/PreProcessQueue';
 import logger from '../utils/logUtil';
@@ -82,7 +82,6 @@ class Analytics {
     this.toBeProcessedArray = [];
     this.toBeProcessedByIntegrationArray = [];
     this.storage = Storage;
-    this.store = Store;
     this.eventRepository = EventRepository;
     this.preProcessQueue = new PreProcessQueue();
     this.sendAdblockPage = false;
@@ -302,7 +301,7 @@ class Analytics {
         // Fallback logic to process buffered cloud mode events if integrations are failed to load in given interval
         setTimeout(() => {
           this.processBufferedCloudModeEvents();
-        }, 5000);
+        }, MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS);
       }
 
       this.errorReporting.leaveBreadcrumb('Starting device-mode initialization');

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1188,7 +1188,7 @@ class Analytics {
       this.loadIntegration = !!options.loadIntegration;
     }
 
-    if (options && options.bufferDataPlaneEventsUntilReady != undefined) {
+    if (options && typeof options.bufferDataPlaneEventsUntilReady === 'boolean') {
       this.bufferDataPlaneEventsUntilReady = options.bufferDataPlaneEventsUntilReady === true;
       if (this.bufferDataPlaneEventsUntilReady) {
         this.preProcessQueue.init(this.options, this.queueEventForDataPlane.bind(this));

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -539,7 +539,7 @@ class Analytics {
       }
 
       // if not specified at event level, All: true is default
-      const clientSuppliedIntegrations = event[0].message.integrations;
+      const clientSuppliedIntegrations = event[0].message.integrations || { All: true };
 
       // get intersection between config plane native enabled destinations
       // (which were able to successfully load on the page) vs user supplied integrations

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -538,7 +538,7 @@ class Analytics {
       }
 
       // if not specified at event level, All: true is default
-      const clientSuppliedIntegrations = event[0].message.integrations || { All: true };
+      const clientSuppliedIntegrations = event[0].message.integrations;
 
       // get intersection between config plane native enabled destinations
       // (which were able to successfully load on the page) vs user supplied integrations

--- a/src/utils/EventRepository.js
+++ b/src/utils/EventRepository.js
@@ -27,6 +27,7 @@ class EventRepository {
     let targetUrl = removeTrailingSlashes(url);
     if (options && options.useBeacon && navigator.sendBeacon) {
       if (
+        options &&
         options.beaconQueueOptions &&
         options.beaconQueueOptions != null &&
         typeof options.beaconQueueOptions === 'object'
@@ -61,7 +62,7 @@ class EventRepository {
    * @memberof EventRepository
    */
   enqueue(rudderElement, type) {
-    const message = rudderElement.message || rudderElement.getElementContent();
+    const message = rudderElement.getElementContent();
     message.originalTimestamp = message.originalTimestamp || getCurrentTimeFormatted();
     message.sentAt = getCurrentTimeFormatted(); // add this, will get modified when actually being sent
 

--- a/src/utils/EventRepository.js
+++ b/src/utils/EventRepository.js
@@ -27,7 +27,6 @@ class EventRepository {
     let targetUrl = removeTrailingSlashes(url);
     if (options && options.useBeacon && navigator.sendBeacon) {
       if (
-        options &&
         options.beaconQueueOptions &&
         options.beaconQueueOptions != null &&
         typeof options.beaconQueueOptions === 'object'
@@ -62,7 +61,7 @@ class EventRepository {
    * @memberof EventRepository
    */
   enqueue(rudderElement, type) {
-    const message = rudderElement.getElementContent();
+    const message = rudderElement.message || rudderElement.getElementContent();
     message.originalTimestamp = message.originalTimestamp || getCurrentTimeFormatted();
     message.sentAt = getCurrentTimeFormatted(); // add this, will get modified when actually being sent
 

--- a/src/utils/PreProcessQueue.js
+++ b/src/utils/PreProcessQueue.js
@@ -4,7 +4,7 @@ import Queue from '@segment/localstorage-retry';
 import RudderElement from './RudderElement';
 
 /**
- * Keeping maxAttempts to Infinity to retry cloud mode events until processQueueElements flag is not set to true
+ * Keeping maxAttempts to Infinity to retry cloud mode events and throw an error until processQueueElements flag is not set to true
  */
 const queueOptions = {
   maxRetryDelay: 360000,

--- a/src/utils/PreProcessQueue.js
+++ b/src/utils/PreProcessQueue.js
@@ -1,32 +1,30 @@
-/* eslint-disable no-param-reassign */
 /* eslint-disable consistent-return */
+
 import Queue from '@segment/localstorage-retry';
-import * as R from 'ramda';
-import { EventRepository } from './EventRepository';
-import { getMergedClientSuppliedIntegrations } from './IntegrationsData';
-import { transformToServerNames } from './utils';
-import RudderElement from './RudderElement';
 
 const queueOptions = {
   maxRetryDelay: 360000,
   minRetryDelay: 1000,
   backoffFactor: 2,
-  maxAttempts: 10,
+  maxAttempts: Infinity,
   maxItems: 100,
 };
 
 class PreProcessQueue {
   constructor() {
     this.data = undefined;
-    this.eventRepository = EventRepository;
+    this.callback = undefined;
   }
 
-  init(options) {
+  init(options, callback) {
     if (options) {
       // TODO: add checks for value - has to be +ve?
       Object.assign(queueOptions, options);
     }
-    this.payloadQueue = new Queue('rudder_events', queueOptions, (item, done) => {
+    if (callback) {
+      this.callback = callback;
+    }
+    this.payloadQueue = new Queue('rs_events', queueOptions, (item, done) => {
       const { type, rudderElement } = item;
       this.processQueueElement(type, rudderElement, (err, res) => {
         if (err) {
@@ -35,27 +33,24 @@ class PreProcessQueue {
         done(null, res);
       });
     });
+    this.payloadQueue.start();
   }
 
-  execute(integrationsData) {
+  processCloudModeIntegrationsObjData(integrationsData) {
+    // An indicator to process elements in queue
     this.data = integrationsData;
-    this.payloadQueue.start();
   }
 
   processQueueElement(type, rudderElement, queueFn) {
     try {
-      // if not specified at event level, All: true is default
-      const clientSuppliedIntegrations = rudderElement.message.integrations || { All: true };
-      // convert integrations object to server identified names, kind of hack now!
-      transformToServerNames(rudderElement.message.integrations);
-      rudderElement.message.integrations = getMergedClientSuppliedIntegrations(
-        this.data,
-        clientSuppliedIntegrations,
-      );
-      Object.setPrototypeOf(rudderElement, RudderElement.prototype);
-      // self analytics process, send to rudder
-      this.eventRepository.enqueue(rudderElement, type);
-      queueFn(null);
+      if (this.data) {
+        // if not specified at event level, All: true is default
+        const clientSuppliedIntegrations = rudderElement.message.integrations || { All: true };
+        this.callback(type, rudderElement, clientSuppliedIntegrations);
+        queueFn(null);
+      } else {
+        queueFn(new Error("Events can't be process without integrationsData"));
+      }
     } catch (error) {
       queueFn(error);
     }
@@ -63,8 +58,7 @@ class PreProcessQueue {
 
   enqueue(type, rudderElement) {
     // add items to the queue
-    const clonedRudderElement = R.clone(rudderElement);
-    this.payloadQueue.addItem({ type, rudderElement: clonedRudderElement });
+    this.payloadQueue.addItem({ type, rudderElement });
   }
 }
 

--- a/src/utils/PreProcessQueue.js
+++ b/src/utils/PreProcessQueue.js
@@ -11,7 +11,6 @@ const queueOptions = {
   minRetryDelay: 1000,
   backoffFactor: 2,
   maxAttempts: Infinity,
-  maxItems: 100,
 };
 
 class PreProcessQueue {

--- a/src/utils/PreProcessQueue.js
+++ b/src/utils/PreProcessQueue.js
@@ -36,7 +36,7 @@ class PreProcessQueue {
     this.payloadQueue.start();
   }
 
-  processCloudModeIntegrationsObjData(integrationsData) {
+  setCloudModeEventsIntegrationObjData(integrationsData) {
     // An indicator to process elements in queue
     this.data = integrationsData;
   }

--- a/src/utils/PreProcessQueue.js
+++ b/src/utils/PreProcessQueue.js
@@ -1,7 +1,11 @@
 /* eslint-disable consistent-return */
 
 import Queue from '@segment/localstorage-retry';
+import RudderElement from './RudderElement';
 
+/**
+ * Keeping maxAttempts to Infinity to retry cloud mode events until processQueueElements flag is not set to true
+ */
 const queueOptions = {
   maxRetryDelay: 360000,
   minRetryDelay: 1000,
@@ -12,8 +16,8 @@ const queueOptions = {
 
 class PreProcessQueue {
   constructor() {
-    this.data = undefined;
     this.callback = undefined;
+    this.processQueueElements = false;
   }
 
   init(options, callback) {
@@ -25,8 +29,7 @@ class PreProcessQueue {
       this.callback = callback;
     }
     this.payloadQueue = new Queue('rs_events', queueOptions, (item, done) => {
-      const { type, rudderElement } = item;
-      this.processQueueElement(type, rudderElement, (err, res) => {
+      this.processQueueElement(item.type, item.rudderElement, (err, res) => {
         if (err) {
           return done(err);
         }
@@ -36,20 +39,19 @@ class PreProcessQueue {
     this.payloadQueue.start();
   }
 
-  setCloudModeEventsIntegrationObjData(integrationsData) {
+  activateProcessor() {
     // An indicator to process elements in queue
-    this.data = integrationsData;
+    this.processQueueElements = true;
   }
 
   processQueueElement(type, rudderElement, queueFn) {
     try {
-      if (this.data) {
-        // if not specified at event level, All: true is default
-        const clientSuppliedIntegrations = rudderElement.message.integrations || { All: true };
-        this.callback(type, rudderElement, clientSuppliedIntegrations);
+      if (this.processQueueElements) {
+        Object.setPrototypeOf(rudderElement, RudderElement.prototype);
+        this.callback(type, rudderElement);
         queueFn(null);
       } else {
-        queueFn(new Error("Events can't be process without integrationsData"));
+        queueFn(new Error('The queue elements are not ready to be processed yet'));
       }
     } catch (error) {
       queueFn(error);

--- a/src/utils/PreProcessQueue.js
+++ b/src/utils/PreProcessQueue.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable consistent-return */
+import Queue from '@segment/localstorage-retry';
+import * as R from 'ramda';
+import { EventRepository } from './EventRepository';
+import { getMergedClientSuppliedIntegrations } from './IntegrationsData';
+import { transformToServerNames } from './utils';
+import RudderElement from './RudderElement';
+
+const queueOptions = {
+  maxRetryDelay: 360000,
+  minRetryDelay: 1000,
+  backoffFactor: 2,
+  maxAttempts: 10,
+  maxItems: 100,
+};
+
+class PreProcessQueue {
+  constructor() {
+    this.data = undefined;
+    this.eventRepository = EventRepository;
+  }
+
+  init(options) {
+    if (options) {
+      // TODO: add checks for value - has to be +ve?
+      Object.assign(queueOptions, options);
+    }
+    this.payloadQueue = new Queue('rudder_events', queueOptions, (item, done) => {
+      const { type, rudderElement } = item;
+      this.processQueueElement(type, rudderElement, (err, res) => {
+        if (err) {
+          return done(err);
+        }
+        done(null, res);
+      });
+    });
+  }
+
+  execute(integrationsData) {
+    this.data = integrationsData;
+    this.payloadQueue.start();
+  }
+
+  processQueueElement(type, rudderElement, queueFn) {
+    try {
+      // if not specified at event level, All: true is default
+      const clientSuppliedIntegrations = rudderElement.message.integrations || { All: true };
+      // convert integrations object to server identified names, kind of hack now!
+      transformToServerNames(rudderElement.message.integrations);
+      rudderElement.message.integrations = getMergedClientSuppliedIntegrations(
+        this.data,
+        clientSuppliedIntegrations,
+      );
+      Object.setPrototypeOf(rudderElement, RudderElement.prototype);
+      // self analytics process, send to rudder
+      this.eventRepository.enqueue(rudderElement, type);
+      queueFn(null);
+    } catch (error) {
+      queueFn(error);
+    }
+  }
+
+  enqueue(type, rudderElement) {
+    // add items to the queue
+    const clonedRudderElement = R.clone(rudderElement);
+    this.payloadQueue.addItem({ type, rudderElement: clonedRudderElement });
+  }
+}
+
+export default PreProcessQueue;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -19,6 +19,7 @@ const DEST_SDK_BASE_URL = `${SDK_CDN_BASE_URL}/${CDN_ARCH_VERSION_DIR}/${CDN_INT
 
 const MAX_WAIT_FOR_INTEGRATION_LOAD = 10000;
 const INTEGRATION_LOAD_CHECK_INTERVAL = 1000;
+const MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS = 5000;
 const INTG_SUFFIX = '_RS';
 const POLYFILL_URL =
   'https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll';
@@ -70,4 +71,5 @@ export {
   SUPPORTED_CONSENT_MANAGERS,
   SYSTEM_KEYWORDS,
   UA_CH_LEVELS,
+  MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS,
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -19,7 +19,7 @@ const DEST_SDK_BASE_URL = `${SDK_CDN_BASE_URL}/${CDN_ARCH_VERSION_DIR}/${CDN_INT
 
 const MAX_WAIT_FOR_INTEGRATION_LOAD = 10000;
 const INTEGRATION_LOAD_CHECK_INTERVAL = 1000;
-const MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS = 5000;
+const MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS = 10000;
 const INTG_SUFFIX = '_RS';
 const POLYFILL_URL =
   'https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll';


### PR DESCRIPTION
## PR Description

- this is a pr to delaying cloud mode events based on flag called `bufferDataPlaneEventsUntilReady`
- if that flag is enabled then we are buffering cloud mode events in local storage and waiting for device mode integrations to get loaded and post that processing events to cloud mode
- for buffering cloud mode events we are using Queue to store it in `localStorage`
- once device mode integrations are successfully loaded, we are processing buffered cloud mode events and sending it to server

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
