### PR TITLE
feat: delaying cloud mode events based on flag provided in options

### DIFF
--- a/__tests__/utils/preProcessQueue.test.js
+++ b/__tests__/utils/preProcessQueue.test.js
@@ -33,7 +33,6 @@ describe('PreProcessQueue', () => {
             expect(preProcessQueue.payloadQueue.backoff.MAX_RETRY_DELAY).toEqual(options.maxRetryDelay);
             expect(preProcessQueue.payloadQueue.backoff.MIN_RETRY_DELAY).toEqual(options.minRetryDelay);
             expect(preProcessQueue.payloadQueue.maxAttempts).toEqual(options.maxAttempts);
-            expect(preProcessQueue.payloadQueue.maxItems).toEqual(options.maxItems);
         });
 
         it('should set the callback', () => {

--- a/__tests__/utils/preProcessQueue.test.js
+++ b/__tests__/utils/preProcessQueue.test.js
@@ -1,0 +1,79 @@
+import PreProcessQueue from '../../src/utils/PreProcessQueue';
+import RudderElement from '../../src/utils/RudderElement';
+
+describe('PreProcessQueue', () => {
+    let preProcessQueue;
+
+    beforeEach(() => {
+        preProcessQueue = new PreProcessQueue();
+    });
+
+    afterEach(() => {
+        preProcessQueue = null;
+    });
+
+    describe('init()', () => {
+        it('should initialize the payloadQueue with default options', () => {
+            preProcessQueue.init();
+
+            expect(preProcessQueue.payloadQueue).toBeDefined();
+        });
+
+        it('should initialize the payloadQueue with custom options', () => {
+            const options = {
+                maxRetryDelay: 360000,
+                minRetryDelay: 1000,
+                backoffFactor: 2,
+                maxAttempts: Infinity,
+                maxItems: 100,
+            };
+            preProcessQueue.init(options);
+
+            expect(preProcessQueue.payloadQueue.backoff.FACTOR).toEqual(options.backoffFactor);
+            expect(preProcessQueue.payloadQueue.backoff.MAX_RETRY_DELAY).toEqual(options.maxRetryDelay);
+            expect(preProcessQueue.payloadQueue.backoff.MIN_RETRY_DELAY).toEqual(options.minRetryDelay);
+            expect(preProcessQueue.payloadQueue.maxAttempts).toEqual(options.maxAttempts);
+            expect(preProcessQueue.payloadQueue.maxItems).toEqual(options.maxItems);
+        });
+
+        it('should set the callback', () => {
+            const callback = jest.fn();
+            preProcessQueue.init(null, callback);
+
+            expect(preProcessQueue.callback).toEqual(callback);
+        });
+    });
+
+    describe('activateProcessor()', () => {
+        it('should set processQueueElements to true', () => {
+            preProcessQueue.activateProcessor();
+            expect(preProcessQueue.processQueueElements).toBe(true);
+        });
+    });
+
+    describe('processQueueElement()', () => {
+        it('should call the queueFn with null if processQueueElements is true', () => {
+            const type = 'track';
+            const rudderElement = new RudderElement();
+            const queueFn = jest.fn();
+            const callback = jest.fn();
+            preProcessQueue.init({}, callback);
+
+            preProcessQueue.processQueueElements = true;
+            preProcessQueue.processQueueElement(type, rudderElement, queueFn);
+            expect(queueFn).toHaveBeenCalledWith(null);
+        });
+
+        it('should call the queueFn with an error if processQueueElements is false', () => {
+            const type = 'track';
+            const rudderElement = new RudderElement();
+            const queueFn = jest.fn();
+
+            preProcessQueue.processQueueElements = false;
+            preProcessQueue.processQueueElement(type, rudderElement, queueFn);
+            expect(queueFn).toHaveBeenCalledWith(
+                new Error('The queue elements are not ready to be processed yet'),
+            );
+        });
+    });
+});

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -401,7 +401,7 @@ class Analytics {
           }
 
           // if not specified at event level, All: true is default
-          const clientSuppliedIntegrations = event[0].message.integrations || { All: true };
+          const clientSuppliedIntegrations = event[0].message.integrations;
 
           // get intersection between config plane native enabled destinations
           // (which were able to successfully load on the page) vs user supplied integrations

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -955,7 +955,8 @@ class Analytics {
       transformToServerNames(clonedRudderElement.message.integrations);
 
       // Holding the cloud mode events based on flag and integrations load check
-      if (!this.bufferDataPlaneEventsUntilReady || this.clientIntegrationObjects) {
+      const shouldNotBufferDataPlaneEvents = !this.bufferDataPlaneEventsUntilReady || this.clientIntegrationObjects;
+      if (shouldNotBufferDataPlaneEvents) {
         this.queueEventForDataPlane(type, clonedRudderElement);
       } else {
         this.preProcessQueue.enqueue(type, clonedRudderElement);

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1244,7 +1244,7 @@ class Analytics {
       this.loadIntegration = !!options.loadIntegration;
     }
 
-    if (options && options.bufferDataPlaneEventsUntilReady != undefined) {
+    if (options && typeof options.bufferDataPlaneEventsUntilReady === 'boolean') {
       this.bufferDataPlaneEventsUntilReady = options.bufferDataPlaneEventsUntilReady === true;
       if (this.bufferDataPlaneEventsUntilReady) {
         this.preProcessQueue.init(this.options, this.queueEventForDataPlane.bind(this));

--- a/src/utils/PreProcessQueue.js
+++ b/src/utils/PreProcessQueue.js
@@ -11,7 +11,6 @@ const queueOptions = {
   minRetryDelay: 1000,
   backoffFactor: 2,
   maxAttempts: Infinity,
-  maxItems: 100,
 };
 
 class PreProcessQueue {

--- a/src/utils/PreProcessQueue.js
+++ b/src/utils/PreProcessQueue.js
@@ -1,0 +1,65 @@
+/* eslint-disable consistent-return */
+
+import Queue from '@segment/localstorage-retry';
+
+const queueOptions = {
+  maxRetryDelay: 360000,
+  minRetryDelay: 1000,
+  backoffFactor: 2,
+  maxAttempts: Infinity,
+  maxItems: 100,
+};
+
+class PreProcessQueue {
+  constructor() {
+    this.data = undefined;
+    this.callback = undefined;
+  }
+
+  init(options, callback) {
+    if (options) {
+      // TODO: add checks for value - has to be +ve?
+      Object.assign(queueOptions, options);
+    }
+    if (callback) {
+      this.callback = callback;
+    }
+    this.payloadQueue = new Queue('rs_events', queueOptions, (item, done) => {
+      const { type, rudderElement } = item;
+      this.processQueueElement(type, rudderElement, (err, res) => {
+        if (err) {
+          return done(err);
+        }
+        done(null, res);
+      });
+    });
+    this.payloadQueue.start();
+  }
+
+  setCloudModeEventsIntegrationObjData(integrationsData) {
+    // An indicator to process elements in queue
+    this.data = integrationsData;
+  }
+
+  processQueueElement(type, rudderElement, queueFn) {
+    try {
+      if (this.data) {
+        // if not specified at event level, All: true is default
+        const clientSuppliedIntegrations = rudderElement.message.integrations || { All: true };
+        this.callback(type, rudderElement, clientSuppliedIntegrations);
+        queueFn(null);
+      } else {
+        queueFn(new Error("Events can't be process without integrationsData"));
+      }
+    } catch (error) {
+      queueFn(error);
+    }
+  }
+
+  enqueue(type, rudderElement) {
+    // add items to the queue
+    this.payloadQueue.addItem({ type, rudderElement });
+  }
+}
+
+export default PreProcessQueue;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -90,7 +90,7 @@ const FLUSH_INTERVAL_DEFAULT = 5000;
 
 const MAX_WAIT_FOR_INTEGRATION_LOAD = 10000;
 const INTEGRATION_LOAD_CHECK_INTERVAL = 1000;
-const MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS = 5000;
+const MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS = 10000;
 
 const POLYFILL_URL =
   "https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll";

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -90,6 +90,7 @@ const FLUSH_INTERVAL_DEFAULT = 5000;
 
 const MAX_WAIT_FOR_INTEGRATION_LOAD = 10000;
 const INTEGRATION_LOAD_CHECK_INTERVAL = 1000;
+const MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS = 5000;
 
 const POLYFILL_URL =
   "https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll";
@@ -135,6 +136,7 @@ export {
   SUPPORTED_CONSENT_MANAGERS,
   SYSTEM_KEYWORDS,
   UA_CH_LEVELS,
+  MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS,
 };
 
 /* module.exports = {


### PR DESCRIPTION
## PR Description

- this is a pr to delaying cloud mode events based on flag called bufferDataPlaneEventsUntilReady
- if that flag is enabled then we are buffering cloud mode events in local storage and waiting for device mode integrations to get loaded and post that processing events to cloud mode
- for buffering cloud mode events we are using Queue to store it in localStorage
- once device mode integrations are successfully loaded, we are processing buffered cloud mode events and sending it to server

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
