### PR TITLE
fix: patch localstorage retry package

### DIFF
--- a/patches/@segment+localstorage-retry+1.3.0.patch
+++ b/patches/@segment+localstorage-retry+1.3.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@segment/localstorage-retry/lib/engine.js b/node_modules/@segment/localstorage-retry/lib/engine.js
+index 5e3fffe..656a774 100644
+--- a/node_modules/@segment/localstorage-retry/lib/engine.js
++++ b/node_modules/@segment/localstorage-retry/lib/engine.js
+@@ -1,7 +1,7 @@
+ 'use strict';
+ 
+ var keys = require('@ndhoule/keys');
+-var uuid = require('uuid').v4;
++var uuid = require('@lukeed/uuid').v4;
+ 
+ var inMemoryStore = {
+   _data: {},


### PR DESCRIPTION
## PR Description

Patch the @segment/localstorage-retry package to remove reference to the `uuid` package.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
