### PR TITLE
fix: suppress notifying unwanted errors to Bugsnag

### DIFF
--- a/__tests__/utils/errorHandler.test.js
+++ b/__tests__/utils/errorHandler.test.js
@@ -1,37 +1,38 @@
-import { normaliseError } from '../../src/utils/errorHandler';
+import { normalizeError } from '../../src/utils/errorHandler';
 
 const staticMessage = '[handleError]::';
 const customMessage = '[Device-mode]:: [Destination: Sample]:: ';
+const sampleErrorMessage = 'Sample error message';
 
-describe("Test group for 'normaliseError' method", () => {
-  it('Should normaliseError for string input', () => {
-    const msg = 'Sample error message';
-    const errMessage = normaliseError(msg);
+describe("Test group for 'normalizeError' method", () => {
+  it('Should normalizeError for string input', () => {
+    const msg = sampleErrorMessage;
+    const errMessage = normalizeError(msg);
     expect(errMessage).toBe(`${staticMessage} "${msg}"`);
   });
-  it('Should normaliseError for Error object input', () => {
+  it('Should normalizeError for Error object input', () => {
     const newError = new Error('Test error');
-    const errMessage = normaliseError(newError);
+    const errMessage = normalizeError(newError);
     expect(errMessage).toBe(`${staticMessage} "Test error"`);
   });
-  it('Should normaliseError for array input', () => {
+  it('Should normalizeError for array input', () => {
     const arr = [1, 2, 3, 4];
-    const errMessage = normaliseError(arr);
+    const errMessage = normalizeError(arr);
     expect(errMessage).toBe(`${staticMessage} "${JSON.stringify(arr)}"`);
   });
-  it('Should normaliseError for customMessage input', () => {
-    const msg = 'Sample error message';
-    const errMessage = normaliseError(msg, customMessage);
+  it('Should normalizeError for customMessage input', () => {
+    const msg = sampleErrorMessage;
+    const errMessage = normalizeError(msg, customMessage);
     expect(errMessage).toBe(`${staticMessage}${customMessage} "${msg}"`);
   });
-  it('Should normaliseError for object with message property input', () => {
-    const msg = 'Sample error message';
-    const errMessage = normaliseError({ message: msg });
+  it('Should normalizeError for object with message property input', () => {
+    const msg = sampleErrorMessage;
+    const errMessage = normalizeError({ message: msg });
     expect(errMessage).toBe(`${staticMessage} "${msg}"`);
   });
-  it('Should normaliseError for object with no message property input', () => {
+  it('Should normalizeError for object with no message property input', () => {
     const obj = { random: 12345678 };
-    const errMessage = normaliseError(obj);
+    const errMessage = normalizeError(obj);
     expect(errMessage).toBe(`${staticMessage} "${JSON.stringify(obj)}"`);
   });
 });

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -10,12 +10,12 @@ function notifyError(error) {
   const errorReportingClient =
     window.rudderanalytics && window.rudderanalytics[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME];
 
-  if (errorReportingClient) {
+  if (errorReportingClient && error instanceof Error) {
     errorReportingClient.notify(error);
   }
 }
 
-function normaliseError(error, customMessage, analyticsInstance) {
+function normalizeError(error, customMessage, analyticsInstance) {
   let errorMessage;
   try {
     if (typeof error === 'string') {
@@ -66,7 +66,7 @@ function handleError(error, customMessage, analyticsInstance) {
   let errorMessage;
 
   try {
-    errorMessage = normaliseError(error, customMessage, analyticsInstance);
+    errorMessage = normalizeError(error, customMessage, analyticsInstance);
   } catch (err) {
     logger.error('[handleError] Exception:: ', err);
     logger.error('[handleError] Original error:: ', JSON.stringify(error));
@@ -78,9 +78,7 @@ function handleError(error, customMessage, analyticsInstance) {
   }
 
   logger.error(errorMessage);
-  let errorObj = error;
-  if (!(error instanceof Error)) errorObj = new Error(errorMessage);
-  notifyError(errorObj);
+  notifyError(error);
 }
 
-export { notifyError, handleError, normaliseError };
+export { notifyError, handleError, normalizeError };


### PR DESCRIPTION
## PR Description

Suppress global window errors that are not generated by the SDK

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
