### PR TITLE
feat(ga4): added identify call support for hybrid mode connection

### DIFF
--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -51,13 +51,12 @@ export default class GA4 {
       gtagParameterObject.user_id = this.analytics.userId;
     }
 
-    gtagParameterObject.cookie_prefix = 'rs';
     if (this.isHybridModeEnabled && this.overrideClientAndSessionId) {
+      gtagParameterObject.cookie_prefix = 'rs';
       gtagParameterObject.client_id = this.analytics.anonymousId;
-    }
-    if (this.isHybridModeEnabled && this.overrideClientAndSessionId) {
       gtagParameterObject.session_id = this.analytics.uSession.sessionInfo.id;
     }
+    
     gtagParameterObject.debug_mode = true;
 
     if (Object.keys(gtagParameterObject).length === 0) {

--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -222,12 +222,8 @@ export default class GA4 {
   }
 
   identify(rudderElement) {
-    // if Hybrid mode is enabled, don't send data to the device-mode
-    if (this.isHybridModeEnabled) {
-      return;
-    }
-
     logger.debug('In GoogleAnalyticsManager Identify');
+    
     window.gtag('set', 'user_properties', flattenJsonPayload(this.analytics.userTraits));
     // Setting the userId as a part of configuration
     if (sendUserIdToGA4(rudderElement.message.integrations) && rudderElement.message.userId) {


### PR DESCRIPTION
## PR Description

- This pull request introduces important updates to enhance our GA4 integration in hybrid mode. It enables support for the Identify call for hybrid mode, allowing us to update the userId and user_properties accurately. Additionally, we have made adjustments to the handling of cookie prefixes to ensure they are added only when necessary.

Key Changes:

1. Support for Identify call for hybrid mode: With this update, we can now utilize the Identify call to modify and synchronize the userId and user_properties between our system and GA4 in hybrid mode. This will provide more accurate and consistent tracking of user behavior and attributes.
2. Conditional addition of cookie prefix: We have introduced a new condition to add the cookie prefix selectively. The cookie prefix will only be applied when we are overriding the gtag client and session ID. This optimization reduces unnecessary cookie prefix usage, resulting in a more streamlined implementation.

- These updates have been thoroughly tested to ensure their effectiveness and reliability. They improve our GA4 integration, allowing for better user identification and seamless data tracking in hybrid mode

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
