### PR TITLE
fix: issues in rudder event structure

### DIFF
--- a/packages/analytics-js/__tests__/components/eventManager/RudderEventFactory.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/RudderEventFactory.test.ts
@@ -142,6 +142,7 @@ describe('RudderEventFactory', () => {
       messageId: 'test_uuid',
       integrations: { All: true },
       userId: 'user_id',
+      event: null,
     });
   });
 
@@ -238,6 +239,7 @@ describe('RudderEventFactory', () => {
       type: 'track',
       anonymousId: 'anon_id',
       channel: 'web',
+      event: null,
       context: {
         sessionStart: true,
         sessionId: 1234,
@@ -376,6 +378,8 @@ describe('RudderEventFactory', () => {
       messageId: 'test_uuid',
       integrations: { All: true },
       userId: 'new_user_id',
+      event: null,
+      properties: null,
     });
   });
 
@@ -443,6 +447,8 @@ describe('RudderEventFactory', () => {
       integrations: { All: true },
       previousId: 'user_id',
       userId: 'new_user_id',
+      properties: null,
+      event: null,
     });
   });
 
@@ -527,6 +533,8 @@ describe('RudderEventFactory', () => {
       groupId: 'overridden_group_id',
       integrations: { All: true },
       userId: 'user_id',
+      properties: null,
+      event: null,
     });
   });
 

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -364,6 +364,7 @@ describe('Event Manager - Utilities', () => {
         messageId: 'test_uuid',
         integrations: { All: true },
         userId: 'user_id',
+        event: null,
       });
 
       defaultPluginsManager.unregisterLocalPlugins();
@@ -1071,6 +1072,7 @@ describe('Event Manager - Utilities', () => {
             mobile: true,
           },
         },
+        properties: null,
         originalTimestamp: '2020-01-01T00:00:00.000Z',
         integrations: { All: true },
         messageId: 'test_uuid',

--- a/packages/analytics-js/src/components/eventManager/types.ts
+++ b/packages/analytics-js/src/components/eventManager/types.ts
@@ -65,7 +65,7 @@ export type RudderEvent = {
   originalTimestamp: string;
   integrations: IntegrationOpts;
   messageId: string;
-  event?: string; // track
+  event: Nullable<string>; // track
   previousId?: string; // alias
   userId?: Nullable<string>;
   sentAt?: string;

--- a/packages/analytics-js/src/components/eventManager/utilities.ts
+++ b/packages/analytics-js/src/components/eventManager/utilities.ts
@@ -228,6 +228,15 @@ const getEnrichedEvent = (
   }
 
   const processedEvent = mergeDeepRight(rudderEvent, commonEventData) as RudderEvent;
+  // Set the default values for the event properties
+  // matching with v1.1 payload
+  if (processedEvent.event === undefined) {
+    processedEvent.event = null;
+  }
+
+  if (processedEvent.properties === undefined) {
+    processedEvent.properties = null;
+  }
 
   processOptions(processedEvent, options);
   // TODO: We might not need this check altogether

--- a/packages/analytics-js/src/components/eventRepository/EventRepository.ts
+++ b/packages/analytics-js/src/components/eventRepository/EventRepository.ts
@@ -84,7 +84,9 @@ class EventRepository implements IEventRepository {
 
     // Invoke the callback if it exists
     try {
-      callback?.(event);
+      // Using the event sent to the data plane queue here
+      // to ensure the mutated (if any) event is sent to the callback
+      callback?.(dpQEvent);
     } catch (error) {
       this.onError(error, 'API Callback Invocation Failed');
     }


### PR DESCRIPTION
## PR Description

- Set default value `null` for `event` and `properties` fields.
- Used the mutated event from the data plane events queue for event callback invocation.

## Notion ticket

https://www.notion.so/rudderstacks/Fix-event-structure-JS-SDK-v3-6aeadd6ee4824420b0f2d1fdc15b45fe?pvs=4

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
