### PR TITLE
feat: introduce flexible configuration for maximum buffering time of data plane events

### DIFF
--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -43,7 +43,7 @@ import {
   SAMESITE_COOKIE_OPTS,
   SYSTEM_KEYWORDS,
   UA_CH_LEVELS,
-  MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS,
+  DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT_MS,
 } from "../utils/constants";
 import { integrations } from "../integrations";
 import RudderElementBuilder from "../utils/RudderElementBuilder";
@@ -107,6 +107,7 @@ class Analytics {
     this.loaded = false;
     this.loadIntegration = true;
     this.bufferDataPlaneEventsUntilReady = false;
+    this.dataPlaneEventsBufferTimeout = DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT_MS;
     this.integrationsData = {};
     this.cookieConsentOptions = {};
     // flag to indicate client integrations` ready status
@@ -259,7 +260,7 @@ class Analytics {
         // Fallback logic to process buffered cloud mode events if integrations are failed to load in given interval
         setTimeout(() => {
           this.processBufferedCloudModeEvents();
-        }, MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS);
+        }, this.dataPlaneEventsBufferTimeout);
       }
 
       // If cookie consent object is return we filter according to consents given by user
@@ -1243,6 +1244,10 @@ class Analytics {
 
     if (options && options.loadIntegration != undefined) {
       this.loadIntegration = !!options.loadIntegration;
+    }
+
+    if (options && typeof options.dataPlaneEventsBufferTimeout === 'number') {
+      this.dataPlaneEventsBufferTimeout = options.dataPlaneEventsBufferTimeout;
     }
 
     if (options && typeof options.bufferDataPlaneEventsUntilReady === 'boolean') {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -90,7 +90,7 @@ const FLUSH_INTERVAL_DEFAULT = 5000;
 
 const MAX_WAIT_FOR_INTEGRATION_LOAD = 10000;
 const INTEGRATION_LOAD_CHECK_INTERVAL = 1000;
-const MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS = 10000;
+const DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT_MS = 10000;
 
 const POLYFILL_URL =
   "https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll";
@@ -136,7 +136,7 @@ export {
   SUPPORTED_CONSENT_MANAGERS,
   SYSTEM_KEYWORDS,
   UA_CH_LEVELS,
-  MAX_TIME_TO_BUFFER_CLOUD_MODE_EVENTS,
+  DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT_MS,
 };
 
 /* module.exports = {


### PR DESCRIPTION
## PR Description
- This pull request introduces a new flag, dataPlaneEventsBufferTimeout, which allows users to specify the maximum buffering time for data plane events. If no value is provided and bufferDataPlaneEventsUntilReady is set to true, the default timeout value of 10 seconds will be used.
- The dataPlaneEventsBufferTimeout flag accepts a numerical value representing the timeout duration in milliseconds. This enhancement provides customers with greater control over timeout values, allowing them to customize it according to their specific needs.
- By introducing this flexibility, users can effectively manage the buffering duration for data plane events and optimize their system's performance.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
