### PR TITLE
feat(ga4): support of user_properties as a part of init call

### DIFF
--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -67,6 +67,11 @@ export default class GA4 {
       window.gtag('config', measurementId, gtagParameterObject);
     }
 
+    // If userTraits available, setting it as a part of global gtag object
+    if (this.analytics.userTraits) {
+      window.gtag('set', 'user_properties', flattenJsonPayload(this.analytics.userTraits));
+    }
+
     /**
      * Setting the parameter sessionId, clientId and session_number using gtag api
      * Ref: https://developers.google.com/tag-platform/gtagjs/reference


### PR DESCRIPTION
## PR Description

- In this PR, we have introduced a new feature to support user_properties as a part of the init call. Previously, user_properties were being set as a part of the gtag object. However, we encountered a limitation where the gtag object would get wiped clean on every page load, meaning that user_traits were not stored in gtag cookies or storage. Consequently, users were required to manually call an identify function on every page load.

- To address this issue, we have implemented a solution that includes setting user_properties as a part of the init call. This enhancement allows us to automatically set the existing user_properties as a part of the gtag object on each page load without the need for an explicit identify call.

- By incorporating user_properties in the init call, we improve the user experience by reducing the manual effort required and ensuring that important user_traits persist across page loads.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
