### PR TITLE
chore: migrate ga4 cookie_prefix for device mode users

### DIFF
--- a/src/integrations/GA4/browser.js
+++ b/src/integrations/GA4/browser.js
@@ -11,8 +11,9 @@ import {
   getDestinationEventProperties,
   getDestinationItemProperties,
 } from './utils';
-import { type, flattenJsonPayload } from '../../utils/utils';
 import { NAME } from './constants';
+import { Cookie } from '../../utils/storage/cookie';
+import { type, flattenJsonPayload } from '../../utils/utils';
 
 export default class GA4 {
   constructor(config, analytics, destinationInfo) {
@@ -23,6 +24,7 @@ export default class GA4 {
     this.clientId = '';
     this.sessionId = '';
     this.sessionNumber = '';
+    this.cookie = Cookie;
     this.analytics = analytics;
     this.measurementId = config.measurementId;
     this.capturePageView = config.capturePageView || 'rs';
@@ -53,10 +55,47 @@ export default class GA4 {
       gtagParameterObject.user_id = this.analytics.userId;
     }
 
-    gtagParameterObject.cookie_prefix = 'rs';
     if (this.isHybridModeEnabled && this.overrideClientAndSessionId) {
+      gtagParameterObject.cookie_prefix = 'rs';
       gtagParameterObject.client_id = this.analytics.anonymousId;
       gtagParameterObject.session_id = this.analytics.uSession.sessionInfo.id;
+    } else {
+      // Cookie migration logic
+      const clientCookie = this.cookie.get('rs_ga');
+      const defaultGA4Cookie = this.cookie.get('_ga');
+      const measurementIdArray = this.measurementId.split('-');
+      const sessionCookie = this.cookie.get(`rs_ga_${measurementIdArray[1]}`);
+
+      // Only override when both cookie with rs prefix is available and default cookie is not available
+      if (!defaultGA4Cookie && clientCookie && sessionCookie) {
+        const clientCookieArray = clientCookie.split('.');
+
+        let clientId;
+        if (clientCookieArray.length > 3) {
+          // client_id cookie : GA1.1.51545857.1686555747
+          clientId = `${clientCookieArray[2]}.${clientCookieArray[3]}`;
+        } else {
+          // client_id cookie : GA1.1.48512441-5e44-4860-9900-a8f6e6bc4041
+          const [, , rest] = clientCookieArray[2];
+          clientId = rest;
+        }
+
+        // session_id cookie : GS1.1.1686558743.1.1.1686558965.7.0.0
+        const sessionCookieArray = sessionCookie.split('.');
+        const sessionId = sessionCookieArray[2];
+
+        // Use existing client and session ids
+        if (clientId) {
+          gtagParameterObject.client_id = clientId;
+        }
+        if (sessionId) {
+          gtagParameterObject.session_id = sessionId;
+        }
+
+        // Remove rs prefixed cookies so that it won't used again
+        this.cookie.remove('rs_ga');
+        this.cookie.remove(`rs_ga_${measurementIdArray[1]}`);
+      }
     }
 
     gtagParameterObject.debug_mode = true;


### PR DESCRIPTION
## PR Description

- This pull request aims to migrate GA4 device mode users and remove the "rs" cookie_prefix. The cookie_prefix plays a crucial role in tracking and identifying user behavior within Google Analytics 4 (GA4). By migrating the cookie_prefix, we ensure that device mode users' tracking is aligned with the latest standards and best practices.

- The migration process involves checking the "rs_ga" cookie prior to loading the gtag library. If the "rs_ga" cookie is found, we extract the "client_id" and "session_id" values from it and set them as part of the gtag object. This enables seamless tracking and attribution of user data within the GA4 framework.

- Additionally, this pull request includes an override mechanism. We also check the presence of the "_ga" cookie. If the "_ga" cookie is present, we respect the default cookie and refrain from overriding any values. This ensures compatibility and consistency with existing "_ga" cookies, preserving any previous tracking data.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
