### PR TITLE
fix: `decryptValue()` return early if value is not string

### DIFF
--- a/src/utils/storage/storage.js
+++ b/src/utils/storage/storage.js
@@ -59,7 +59,7 @@ function trim(value) {
  * @param {*} value
  */
 function decryptValue(value) {
-  if (!value || (typeof value === 'string' && trim(value) === '')) {
+  if (!value || typeof value !== 'string' || trim(value) === '') {
     return value;
   }
   if (value.substring(0, defaults.prefix.length) === defaults.prefix) {


### PR DESCRIPTION
## PR Description

When we deploy `rudder-sdk-js` we been getting a lot of crash report around 

https://github.com/rudderlabs/rudder-sdk-js/blob/66c998ba2785cd33445119f9468d0d3488b34f38/src/utils/storage/storage.js#L65

Basically, the error is:

`e.substring is not a function`

https://github.com/rudderlabs/rudder-sdk-js/blob/66c998ba2785cd33445119f9468d0d3488b34f38/src/utils/storage/storage.js#L62

It look to me that the follow check is not defensive enough. If `value` is not string but truthful. e.g. an empty `{}`, the code will fallthrough and try to access `{}.substring`, which will crash.

My solution is to switch the string check to ignore all non string `value`, while still skipping empty string. the fallen through code will ensure value is string in this case.

It might still fail `parse()` but at least its trap in try catch and default to null.

This is causing failure to load rudder analytics.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
