### PR TITLE
fix: xhr queue plugin retry mechanism

### DIFF
--- a/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
@@ -508,11 +508,18 @@ describe('Bugsnag utilities', () => {
         },
         ['key4', 'key6'], // excluded keys
       ],
+      [
+        {
+          someKey: BigInt(123),
+        },
+        undefined,
+        [],
+      ],
     ];
 
     it.each(tcData)('should convert signals to JSON %#', (input, expected, excludes) => {
       bugsnagConstants.APP_STATE_EXCLUDE_KEYS = excludes;
-      expect(getAppStateForMetadata(input)).toMatchObject(expected);
+      expect(getAppStateForMetadata(input)).toEqual(expected);
     });
   });
 });

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
@@ -313,6 +313,12 @@ describe('xhrQueue Plugin Utilities', () => {
 
       expect(deliveryUrl).toEqual('https://test.com/v1/track');
     });
+
+    it('should return delivery url if dataplane url contains additional path components', () => {
+      const deliveryUrl = getDeliveryUrl('https://test.com/some/path////', 'track');
+
+      expect(deliveryUrl).toEqual('https://test.com/some/path/v1/track');
+    });
   });
 
   describe('validatePayloadSize', () => {

--- a/packages/analytics-js-plugins/src/bugsnag/index.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-param-reassign */
 import {

--- a/packages/analytics-js-plugins/src/bugsnag/utils.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/utils.ts
@@ -1,5 +1,5 @@
 import { ApplicationState, BugsnagLib, IExternalSrcLoader, ILogger } from '../types/common';
-import { stringifyWithoutCircular } from '../utilities/common';
+import { isUndefined, stringifyWithoutCircular } from '../utilities/common';
 import {
   API_KEY,
   APP_STATE_EXCLUDE_KEYS,
@@ -182,8 +182,10 @@ const initBugsnagClient = (
   }
 };
 
-const getAppStateForMetadata = (state: ApplicationState): Record<string, any> =>
-  JSON.parse(stringifyWithoutCircular(state, false, APP_STATE_EXCLUDE_KEYS) as string);
+const getAppStateForMetadata = (state: ApplicationState): Record<string, any> | undefined => {
+  const stateStr = stringifyWithoutCircular(state, false, APP_STATE_EXCLUDE_KEYS);
+  return stateStr !== null ? JSON.parse(stateStr) : undefined;
+};
 
 export {
   isValidVersion,

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
@@ -56,7 +56,6 @@ const isDestinationSDKEvaluated = (
 };
 
 const wait = (time: number) =>
-  // eslint-disable-next-line compat/compat
   new Promise(resolve => {
     (globalThis as typeof window).setTimeout(resolve, time);
   });
@@ -124,7 +123,6 @@ const createDestinationInstance = (
 };
 
 const isDestinationReady = (dest: Destination, logger?: ILogger, time = 0) =>
-  // eslint-disable-next-line compat/compat
   new Promise((resolve, reject) => {
     const instance = dest.instance as DeviceModeDestination;
     if (instance.isLoaded() && (!instance.isReady || instance.isReady())) {

--- a/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
@@ -60,9 +60,10 @@ const validatePayloadSize = (event: RudderEvent, logger?: ILogger) => {
 const getNormalizedQueueOptions = (queueOpts: QueueOpts): QueueOpts =>
   mergeDeepRight(DEFAULT_RETRY_QUEUE_OPTIONS, queueOpts);
 
-const getDeliveryUrl = (dataplaneUrl: string, eventType: RudderEventType): string =>
-  // eslint-disable-next-line compat/compat
-  new URL(path.join(DATA_PLANE_API_VERSION, eventType), dataplaneUrl).toString();
+const getDeliveryUrl = (dataplaneUrl: string, eventType: RudderEventType): string => {
+  const dpUrl = new URL(dataplaneUrl);
+  return new URL(path.join(dpUrl.pathname, DATA_PLANE_API_VERSION, eventType), dpUrl).href;
+};
 
 /**
  * Mutates the event and return final event for delivery

--- a/packages/analytics-js/__tests__/components/utilities/json.test.ts
+++ b/packages/analytics-js/__tests__/components/utilities/json.test.ts
@@ -135,5 +135,20 @@ describe('Common Utils - JSON', () => {
       expect(json).not.toContain('size');
       expect(json).not.toContain('city');
     });
+
+    it('should return null for input containing BigInt values', () => {
+      const mockLogger = {
+        debug: jest.fn(),
+      };
+
+      const objWithBigInt = {
+        bigInt: BigInt(9007199254740991),
+      };
+      const json = stringifyWithoutCircular(objWithBigInt, false, [], mockLogger);
+      expect(json).toBe(null);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Error occurred while converting to string: TypeError: Do not know how to serialize a BigInt',
+      );
+    });
   });
 });

--- a/packages/analytics-js/__tests__/services/ExternalSrcLoader/ExternalSrcLoader.test.ts
+++ b/packages/analytics-js/__tests__/services/ExternalSrcLoader/ExternalSrcLoader.test.ts
@@ -79,7 +79,7 @@ describe('External Source Loader', () => {
       expect(defaultErrorHandler.onError).toHaveBeenCalledTimes(1);
       expect(defaultErrorHandler.onError).toHaveBeenCalledWith(
         new Error(
-          'Couldn\'t load the script: "https://dummy.dataplane.host.com/noConnectionSample" with id dummyScript.',
+          'Couldn\'t load the script "https://dummy.dataplane.host.com/noConnectionSample" with id dummyScript.',
         ),
         'ExternalSrcLoader',
       );

--- a/packages/analytics-js/__tests__/services/HttpClient/HttpClient.test.ts
+++ b/packages/analytics-js/__tests__/services/HttpClient/HttpClient.test.ts
@@ -13,6 +13,7 @@ jest.mock('../../../src/services/Logger', () => {
     ...originalModule,
     defaultLogger: {
       error: jest.fn((): void => {}),
+      debug: jest.fn((): void => {}),
     },
   };
 });
@@ -225,6 +226,28 @@ describe('HttpClient', () => {
     clientInstance.getAsyncData({
       callback,
       url: `${dummyDataplaneHost}/emptyJsonSample`,
+    });
+  });
+
+  it('should handle if input data contains non-stringifiable values', done => {
+    const callback = (response: any) => {
+      expect(response).toBeUndefined();
+      expect(defaultErrorHandler.onError).toHaveBeenCalledTimes(1);
+      expect(defaultErrorHandler.onError).toHaveBeenCalledWith(
+        new Error('Failed to prepare data for the request.'),
+        'HttpClient',
+      );
+      done();
+    };
+    clientInstance.getAsyncData({
+      callback,
+      url: `${dummyDataplaneHost}/nonStringifiableDataSample`,
+      options: {
+        data: {
+          a: 1,
+          b: BigInt(1),
+        },
+      },
     });
   });
 });

--- a/packages/analytics-js/src/components/utilities/json.ts
+++ b/packages/analytics-js/src/components/utilities/json.ts
@@ -54,7 +54,13 @@ const stringifyWithoutCircular = <T = Record<string, any> | any[] | number | str
   excludeNull?: boolean,
   excludeKeys?: string[],
   logger?: ILogger,
-): string | undefined =>
-  JSON.stringify(value, getCircularReplacer(excludeNull, excludeKeys, logger));
+): Nullable<string> => {
+  try {
+    return JSON.stringify(value, getCircularReplacer(excludeNull, excludeKeys, logger));
+  } catch (err) {
+    logger?.debug(`Error occurred while converting to string: ${err}`);
+    return null;
+  }
+};
 
 export { stringifyWithoutCircular };

--- a/packages/analytics-js/src/services/ExternalSrcLoader/jsFileLoader.ts
+++ b/packages/analytics-js/src/services/ExternalSrcLoader/jsFileLoader.ts
@@ -101,7 +101,7 @@ const jsFileLoader = (
 
       const onerror = () => {
         (globalThis as typeof window).clearTimeout(timeoutID);
-        reject(new Error(`Couldn't load the script: "${url}" with id ${id}.`));
+        reject(new Error(`Couldn't load the script "${url}" with id ${id}.`));
       };
 
       // Create the DOM element to load the script and add it to the DOM
@@ -111,14 +111,14 @@ const jsFileLoader = (
       timeoutID = (globalThis as typeof window).setTimeout(() => {
         reject(
           new Error(
-            `Timeout (${timeout} ms) occurred. Couldn't load the script: "${url}" with id ${id}.`,
+            `Timeout (${timeout} ms) occurred. Couldn't load the script "${url}" with id ${id}.`,
           ),
         );
       }, timeout);
     } catch (err) {
       reject(
         new Error(
-          `Exception occurred while loading the script "${url}" with id ${id}: "${stringifyWithoutCircular(
+          `Exception occurred while loading the script "${url}" with id ${id}. Original error: "${stringifyWithoutCircular(
             err as Record<string, any>,
           )}"`,
         ),

--- a/packages/analytics-js/src/services/HttpClient/xhr/xhrRequestHandler.ts
+++ b/packages/analytics-js/src/services/HttpClient/xhr/xhrRequestHandler.ts
@@ -1,10 +1,10 @@
-/* eslint-disable compat/compat */
 /* eslint-disable prefer-promise-reject-errors */
 import { mergeDeepRight } from '@rudderstack/analytics-js/components/utilities/object';
 import { DEFAULT_XHR_TIMEOUT } from '@rudderstack/analytics-js/constants/timeouts';
 import { stringifyWithoutCircular } from '@rudderstack/analytics-js/components/utilities/json';
 import { ILogger } from '@rudderstack/analytics-js/services/Logger/types';
 import { FAILED_REQUEST_ERR_MSG_PREFIX } from '@rudderstack/analytics-js/constants/errors';
+import { isNull } from '@rudderstack/analytics-js/components/utilities/checks';
 import { IXHRRequestOptions } from '../types';
 
 const DEFAULT_XHR_REQUEST_OPTIONS: Partial<IXHRRequestOptions> = {
@@ -50,6 +50,22 @@ const xhrRequest = (
   logger?: ILogger,
 ): Promise<string | undefined> =>
   new Promise((resolve, reject) => {
+    let payload;
+    if (options.sendRawData === true) {
+      payload = options.data;
+    } else {
+      payload = stringifyWithoutCircular(options.data, false, [], logger);
+      if (isNull(payload)) {
+        reject({
+          error: new Error(`Failed to prepare data for the request.`),
+          undefined,
+          options,
+        });
+        // return and don't process further
+        return;
+      }
+    }
+
     const xhr = new XMLHttpRequest();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const xhrReject = (e?: ProgressEvent) => {
@@ -94,23 +110,6 @@ const xhrRequest = (
         xhr.setRequestHeader(headerName, options.headers[headerName] as string);
       }
     });
-
-    let payload;
-    if (options.sendRawData === true) {
-      payload = options.data;
-    } else {
-      try {
-        payload = stringifyWithoutCircular(options.data, false, [], logger);
-      } catch (err) {
-        reject({
-          error: new Error(
-            `Request data parsing failed for URL: ${options.url}, ${(err as Error).message}`,
-          ),
-          xhr,
-          options,
-        });
-      }
-    }
 
     try {
       xhr.send(payload);


### PR DESCRIPTION
## PR Description
- implement the retry mechanism in the XHR plugin similar to v1.1
- fix paths bug in delivery URL preparation
- fix bug in XHR request module that validates payload

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
