### PR TITLE
fix: transform to string any userId passed as number in identify calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-analytics",
-  "version": "2.33.1",
+  "version": "2.35.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-analytics",
-      "version": "2.33.1",
+      "version": "2.35.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/sanity-suite/__mocks__/identify8.json
+++ b/sanity-suite/__mocks__/identify8.json
@@ -1,0 +1,103 @@
+{
+  "message": {
+    "channel": "web",
+    "context": {
+      "app": {
+        "name": "RudderLabs JavaScript SDK",
+        "namespace": "com.rudderlabs.javascript",
+        "version": "2.22.2"
+      },
+      "traits": {
+        "name": "John Snow",
+        "title": "CEO",
+        "email": "name.surname@domain.com",
+        "alternativeEmail": "name.surname2@domain.com",
+        "company": "Company123",
+        "phone": "123-456-7890",
+        "rating": "Hot",
+        "dob": "1990-01-12T00:00:00.000Z",
+        "address": [
+          {
+            "city": "Austin",
+            "postalCode": 12345,
+            "country": "US",
+            "street": "Sample Address",
+            "state": "TX",
+            "label": "Home",
+            "defaultAddress": true
+          },
+          {
+            "city": "Houston",
+            "postalCode": 345678,
+            "country": "US",
+            "street": "Sample Address 2",
+            "state": "TX",
+            "label": "Office",
+            "defaultAddress": false
+          },
+          {
+            "city": "Dallas",
+            "postalCode": 987654,
+            "country": "US",
+            "street": "Sample Address 3",
+            "state": "TX",
+            "label": "Toms place",
+            "defaultAddress": false
+          }
+        ]
+      },
+      "library": {
+        "name": "RudderLabs JavaScript SDK",
+        "version": "2.22.2"
+      },
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+      "device": null,
+      "network": null,
+      "os": {
+        "name": "",
+        "version": ""
+      },
+      "locale": "en-US",
+      "screen": {
+        "density": 2,
+        "width": 1728,
+        "height": 1117,
+        "innerWidth": 1728,
+        "innerHeight": 969
+      },
+      "sessionId": 1673726912351,
+      "campaign": {},
+      "page": {
+        "path": "/index.html",
+        "referrer": "$direct",
+        "referring_domain": "",
+        "search": "",
+        "title": "RudderStack JS SDK Sanity Suite",
+        "url": "http://localhost:3001/index.html",
+        "tab_url": "http://localhost:3001/index.html",
+        "initial_referrer": "$direct",
+        "initial_referring_domain": ""
+      },
+      "consentManagement": {
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+      }
+    },
+    "type": "identify",
+    "messageId": "469fccf3-ba54-427d-9bf4-f01940382231",
+    "originalTimestamp": "2023-01-18T14:29:20.234Z",
+    "anonymousId": "7effd250-16c8-454c-957b-f0f2b357d356",
+    "userId": "1234567890",
+    "event": null,
+    "properties": null,
+    "integrations": {
+      "All": true,
+      "Google Analytics 4": {
+        "clientId": "284269621.1683957866",
+        "sessionId": 1683957866,
+        "sessionNumber": 1
+      }
+    },
+    "user_properties": null,
+    "sentAt": "2023-01-14T20:26:36.001Z"
+  }
+}

--- a/sanity-suite/package-lock.json
+++ b/sanity-suite/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "rudder-analytics-js-sdk-sanity-suite",
-  "version": "2.33.1",
+  "version": "2.35.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-analytics-js-sdk-sanity-suite",
-      "version": "2.33.1",
+      "version": "2.35.0",
       "license": "MIT",
       "dependencies": {
         "deep-equal": "2.2.1",
         "object-path": "0.11.8",
-        "rudder-sdk-js": "2.33.1"
+        "rudder-sdk-js": "2.35.0"
       },
       "devDependencies": {
         "@babel/core": "7.21.8",
@@ -4255,9 +4255,9 @@
       }
     },
     "node_modules/rudder-sdk-js": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.33.1.tgz",
-      "integrity": "sha512-4Pi1t4Gf3Yd/PcgVIj99bd9p6J0pa3O4VoJ4SneMMblSwCo4j4gvGva7GkfvAtSbi/V/RQ1J33OLDIHiNaS0FA=="
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.35.0.tgz",
+      "integrity": "sha512-6J//P1RSnPl0Xpr6gpBIs/BNq5YZG1VSayOSiCtZUdE1wqU/u119vYzoMiUtg1k35FmJXNzUcu9WGKsn9ukPcA=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -7655,9 +7655,9 @@
       }
     },
     "rudder-sdk-js": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.33.1.tgz",
-      "integrity": "sha512-4Pi1t4Gf3Yd/PcgVIj99bd9p6J0pa3O4VoJ4SneMMblSwCo4j4gvGva7GkfvAtSbi/V/RQ1J33OLDIHiNaS0FA=="
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.35.0.tgz",
+      "integrity": "sha512-6J//P1RSnPl0Xpr6gpBIs/BNq5YZG1VSayOSiCtZUdE1wqU/u119vYzoMiUtg1k35FmJXNzUcu9WGKsn9ukPcA=="
     },
     "run-parallel": {
       "version": "1.2.0",

--- a/sanity-suite/package.json
+++ b/sanity-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-analytics-js-sdk-sanity-suite",
-  "version": "2.33.1",
+  "version": "2.35.0",
   "description": "Sanity suite for testing JS SDK package",
   "main": "./dist/testBook.js",
   "scripts": {
@@ -27,7 +27,7 @@
   "dependencies": {
     "deep-equal": "2.2.1",
     "object-path": "0.11.8",
-    "rudder-sdk-js": "2.33.1"
+    "rudder-sdk-js": "2.35.0"
   },
   "devDependencies": {
     "@babel/core": "7.21.8",

--- a/sanity-suite/src/testBookSuites/identify.js
+++ b/sanity-suite/src/testBookSuites/identify.js
@@ -5,6 +5,7 @@ import identify4ExpectedData from '../../__mocks__/identify4.json';
 import identify5ExpectedData from '../../__mocks__/identify5.json';
 import identify6ExpectedData from '../../__mocks__/identify6.json';
 import identify7ExpectedData from '../../__mocks__/identify7.json';
+import identify8ExpectedData from '../../__mocks__/identify8.json';
 
 const identifyMethodSuite = {
   id: 'identifyMethod',
@@ -390,6 +391,63 @@ const identifyMethodSuite = {
       ],
       expectedResult: identify7ExpectedData,
       triggerHandler: ['reset', 'setAnonymousId', 'identify'],
+    },
+    {
+      id: 'identify8',
+      description: 'Identify with string userId and then with number userId',
+      inputData: [
+        [
+          '1234567890',
+          {
+            name: 'John Doe',
+            title: 'CEO',
+            email: 'name.surname@domain.com',
+            company: 'Company123',
+            phone: '123-456-7890',
+            rating: 'Hot',
+            dob: new Date(Date.UTC(1990, 0, 12)),
+            address: [
+              {
+                city: 'Austin',
+                postalCode: 12345,
+                country: 'US',
+                street: 'Sample Address',
+                state: 'TX',
+                label: 'Home',
+                defaultAddress: true,
+              },
+              {
+                city: 'Houston',
+                postalCode: 345678,
+                country: 'US',
+                street: 'Sample Address 2',
+                state: 'TX',
+                label: 'Office',
+                defaultAddress: false,
+              },
+              {
+                city: 'Dallas',
+                postalCode: 987654,
+                country: 'US',
+                street: 'Sample Address 3',
+                state: 'TX',
+                label: 'Toms place',
+                defaultAddress: false,
+              },
+            ],
+          },
+          null,
+        ],
+        [
+          1234567890,
+          {
+            name: 'John Snow',
+            alternativeEmail: 'name.surname2@domain.com',
+          },
+        ],
+      ],
+      expectedResult: identify8ExpectedData,
+      triggerHandler: ['identify', 'identify'],
     },
   ],
 };

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -715,10 +715,11 @@ class Analytics {
     if (typeof traits === 'function') (callback = traits), (options = null), (traits = null);
     if (typeof userId === 'object') (options = traits), (traits = userId), (userId = this.userId);
 
-    if (userId && this.userId && userId !== this.userId) {
+    const normalisedUserId = getStringId(userId);
+    if (normalisedUserId && this.userId && normalisedUserId !== this.userId) {
       this.reset();
     }
-    this.userId = getStringId(userId);
+    this.userId = normalisedUserId;
     this.storage.setUserId(this.userId);
 
     const clonedTraits = R.clone(traits);


### PR DESCRIPTION
## PR Description

normalise userId before comparing with existing (if any) in identify call

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Ensure-userId-in-identify-call-is-always-evaluated-as-string-when-used-e872975aa8204326a0f926f4bb9cb508?pvs=4)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
