### PR TITLE
ci: enable bugbash tag deployment via github action

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,4 +1,4 @@
-name: Deploy BETA Feature
+name: Deploy BETA/BugBash Feature
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   deploy-tag:
-    name: Deploy BETA Feature
+    name: Deploy BETA/BugBash Feature
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/beta/') || startsWith(github.ref, 'refs/tags/bugbash')
     steps:

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -11,11 +11,21 @@ jobs:
   deploy-tag:
     name: Deploy BETA Feature
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/heads/beta/')
+    if: startsWith(github.ref, 'refs/heads/beta/') || startsWith(github.ref, 'refs/tags/bugbash')
     steps:
       - name: Extract feature name from branch
         shell: bash
-        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/beta/})" >>$GITHUB_OUTPUT
+        run: |
+          source_branch_name=${GITHUB_REF##*/}
+          RELEASE_TYPE=beta
+          grep -q "bugbash/" <<< "${GITHUB_REF}" && RELEASE_TYPE=bugbash
+          FEATURE_NAME=${source_branch_name#bugbash/}
+          FEATURE_NAME=${FEATURE_NAME#beta/}
+          FEATURE_NAME=${FEATURE_NAME#refs/heads/}
+          FEATURE_NAME=${FEATURE_NAME#refs/tags/}
+
+          echo "branch_name=$FEATURE_NAME" >> $GITHUB_OUTPUT
+          echo "branch_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: Configure AWS Credentials
@@ -36,18 +46,16 @@ jobs:
       - name: Build and sync files to S3
         env:
           HUSKY: 0
+          BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
+          BUGSNAG_RELEASE_STAGE: 'beta'
         run: |
           npm ci
           npm run build:browser
           npm run build:integration:all
-      - name: Fix Bugsnag API key
-        env:
-          BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
-        run: |
-          sed -i -e 's|{{RS_BUGSNAG_API_KEY}}|'$BUGSNAG_API_KEY'|' dist/legacy/rudder-analytics.min.js
+
       - name: Sync files to S3 beta folder
         run: |
-          aws s3 cp dist/legacy/rudder-analytics.min.js s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/beta/${{ steps.extract_branch.outputs.branch }}/rudder-analytics.min.js --cache-control max-age=3600
-          aws s3 cp dist/legacy/rudder-analytics.min.js.map s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/beta/${{ steps.extract_branch.outputs.branch }}/rudder-analytics.min.js.map --cache-control max-age=3600
-          aws s3 cp dist/legacy/js-integrations/ s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/beta/${{ steps.extract_branch.outputs.branch }}/js-integrations/ --recursive --cache-control max-age=3600
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/beta/*"
+          aws s3 cp dist/legacy/rudder-analytics.min.js s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/rudder-analytics.min.js --cache-control max-age=3600
+          aws s3 cp dist/legacy/rudder-analytics.min.js.map s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/rudder-analytics.min.js.map --cache-control max-age=3600
+          aws s3 cp dist/legacy/js-integrations/ s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/js-integrations/ --recursive --cache-control max-age=3600
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/*"


### PR DESCRIPTION
## PR Description

Allow deplyment of bugbash tags also as beta to their own cdn folders to enable multible bugbash on the same time.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
