### PR TITLE
fix: destination sdk load check

### DIFF
--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -186,20 +186,12 @@ class Analytics {
    * @returns boolean
    */
   integrationSDKLoaded(pluginName, modName) {
-    try {
-      return (
-        pluginName &&
-        modName &&
-        window[pluginName] &&
-        window.hasOwnProperty(pluginName) &&
-        window[pluginName][modName] &&
-        typeof window[pluginName][modName].prototype &&
-        typeof window[pluginName][modName].prototype.constructor !== 'undefined'
-      );
-    } catch (e) {
-      handleError(e, `While attempting to load ${pluginName} ${modName}`);
-      return false;
-    }
+    return (
+      window[pluginName] &&
+      window[pluginName][modName] &&
+      window[pluginName][modName].prototype &&
+      typeof window[pluginName][modName].prototype.constructor !== 'undefined'
+    );
   }
 
   /**


### PR DESCRIPTION
## PR Description

Fixed the bug that was incorrectly checking the `typeof` value of the prototype during destination SDK load check.

## Notion ticket

https://www.notion.so/rudderstacks/Bug-Destination-SDK-load-check-incorrectly-uses-typeof-in-the-conditional-statement-SDK-f43183362c9440ba9b8d1f67122affa3?pvs=4

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
