### PR TITLE
fix: error handler when destination ready check times out

### DIFF
--- a/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
@@ -158,7 +158,13 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
                   ];
                 })
                 .catch(err => {
-                  throw err;
+                  // The error message is already formatted in the isDestinationReady function
+                  logger?.error(err);
+
+                  state.nativeDestinations.failedDestinations.value = [
+                    ...state.nativeDestinations.failedDestinations.value,
+                    dest,
+                  ];
                 });
             } catch (err) {
               logger?.error(
@@ -175,7 +181,7 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
         }, INITIALIZED_CHECK_POLL_INTERVAL);
 
         timeoutId = (globalThis as typeof window).setTimeout(() => {
-          clearInterval(intervalId);
+          (globalThis as typeof window).clearInterval(intervalId);
 
           logger?.error(
             DESTINATION_SDK_EVALUATION_TIMEOUT_ERROR(


### PR DESCRIPTION
## PR Description

The error handler incorrectly rethrows the error when the destination ready check times out. Instead, the error is now logged and failed status updated to the state.

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Bug-Destination-ready-check-timeout-results-in-unhandled-error-in-async-context-JS-SDK-v3-dbe98f963a904e79a01a4e0cf7a8b620?pvs=4)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
