### PR TITLE
fix(mixpanel): alias id ordering

### DIFF
--- a/src/integrations/Mixpanel/browser.js
+++ b/src/integrations/Mixpanel/browser.js
@@ -21,7 +21,6 @@
 /* eslint-disable vars-on-top */
 /* eslint-disable one-var */
 /* eslint-disable no-underscore-dangle */
-/* eslint-disable prettier/prettier */
 /* eslint-disable class-methods-use-this */
 import get from 'get-value';
 import logger from '../../utils/logUtil';
@@ -363,7 +362,7 @@ class Mixpanel {
      * groupIdentifierTraits: [ {trait: "<trait_value>"}, ... ]
      */
     const identifierTraitsList = parseConfigArray(this.groupKeySettings, 'groupKey');
-    if (traits && Object.keys(traits).length) {
+    if (traits && Object.keys(traits).length > 0) {
       identifierTraitsList.forEach((trait) => {
         window.mixpanel.get_group(trait, groupId).set_once(traits);
       });
@@ -390,7 +389,7 @@ class Mixpanel {
       logger.debug('===Mixpanel: userId is same as previousId. Skipping alias ===');
       return;
     }
-    window.mixpanel.alias(userId, previousId);
+    window.mixpanel.alias(previousId, userId);
   }
 }
 export default Mixpanel;


### PR DESCRIPTION
## PR Description

Fix the mixpanel alias call ID ordering

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
