### PR TITLE
feat: enhancement: customerio option to send page name or not

### DIFF
--- a/src/integrations/CustomerIO/browser.js
+++ b/src/integrations/CustomerIO/browser.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names */
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable class-methods-use-this */
 import logger from '../../utils/logUtil';
 import { LOAD_ORIGIN } from '../../utils/ScriptLoader';
@@ -11,6 +13,7 @@ class CustomerIO {
     this.analytics = analytics;
     this.siteID = config.siteID;
     this.apiKey = config.apiKey;
+    this.sendPageNameInSDK = config.sendPageNameInSDK;
     this.name = NAME;
     this.areTransformationsConnected =
       destinationInfo && destinationInfo.areTransformationsConnected;
@@ -25,12 +28,16 @@ class CustomerIO {
       let a;
       let b;
       let c;
+      // eslint-disable-next-line prefer-const
       a = function (f) {
         return function () {
+          // eslint-disable-next-line prefer-rest-params
           window._cio.push([f].concat(Array.prototype.slice.call(arguments, 0)));
         };
       };
+      // eslint-disable-next-line prefer-const
       b = ['load', 'identify', 'sidentify', 'track', 'page'];
+      // eslint-disable-next-line no-plusplus
       for (c = 0; c < b.length; c++) {
         window._cio[b[c]] = a(b[c]);
       }
@@ -69,9 +76,12 @@ class CustomerIO {
 
   page(rudderElement) {
     logger.debug('in Customer IO page');
-
-    const name = rudderElement.message.name || rudderElement.message.properties.url;
-    window._cio.page(name, rudderElement.message.properties);
+    if (this.sendPageNameInSDK === false) {
+      window._cio.page(rudderElement.message.properties);
+    } else {
+      const name = rudderElement.message.name || rudderElement.message.properties.url;
+      window._cio.page(name, rudderElement.message.properties);
+    }
   }
 
   isLoaded() {


### PR DESCRIPTION
## PR Description

Providing an option for user from config dashbaord to send page name or not in page event.
If not send customerIo automatically captures the page url and map it to the page name.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
