### PR TITLE
fix: fix issue with error reporting global key in IE11 for npm package

### DIFF
--- a/__tests__/utils/errorHandler.test.js
+++ b/__tests__/utils/errorHandler.test.js
@@ -1,7 +1,7 @@
 import { handleError, normalizeError } from '../../src/utils/errorHandler';
 import { FAILED_REQUEST_ERR_MSG_PREFIX } from '../../src/utils/constants';
 
-window.rudderanalytics = {
+window.RudderStackGlobals = {
   errorReporting: {
     notify: jest.fn(),
   },
@@ -49,12 +49,12 @@ describe("Test group for 'handleError' method", () => {
     const errMessage = `sample error message`;
     const err = new Error(errMessage);
     handleError(err);
-    expect(window.rudderanalytics.errorReporting.notify).toHaveBeenCalledWith(err);
+    expect(window.RudderStackGlobals.errorReporting.notify).toHaveBeenCalledWith(err);
   });
   it('Should not notify for request failed errors', () => {
     const errMessage = `${FAILED_REQUEST_ERR_MSG_PREFIX} 504 for url: https://example.com`;
     const obj = new Error(errMessage);
     handleError(obj);
-    expect(window.rudderanalytics.errorReporting.notify).not.toHaveBeenCalled();
+    expect(window.RudderStackGlobals.errorReporting.notify).not.toHaveBeenCalled();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-analytics",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-analytics",
-      "version": "2.37.0",
+      "version": "2.38.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/sanity-suite/package-lock.json
+++ b/sanity-suite/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "rudder-analytics-js-sdk-sanity-suite",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-analytics-js-sdk-sanity-suite",
-      "version": "2.37.0",
+      "version": "2.38.0",
       "license": "MIT",
       "dependencies": {
         "deep-equal": "2.2.1",
         "get-value": "3.0.1",
         "object-path": "0.11.8",
-        "rudder-sdk-js": "2.37.0"
+        "rudder-sdk-js": "2.38.0"
       },
       "devDependencies": {
         "@babel/core": "7.21.8",
@@ -4275,9 +4275,9 @@
       }
     },
     "node_modules/rudder-sdk-js": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.37.0.tgz",
-      "integrity": "sha512-CyHoEJX9lHXZiQ1Mu5WqizkctFCpRagWio3mPhhqTDDMxDRdZow0p9UFXLOCCMpdkNmwcjakqk1nZWeeWwBqzQ=="
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.38.0.tgz",
+      "integrity": "sha512-474lo3uCMCOTT2dkIFDaZxhU5QiQblQwz8w4GC6DLTwdqQhh9jTcPjbxJVOhrWEvLqm/uR+ImJjLjR3vLV1g/A=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -7688,9 +7688,9 @@
       }
     },
     "rudder-sdk-js": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.37.0.tgz",
-      "integrity": "sha512-CyHoEJX9lHXZiQ1Mu5WqizkctFCpRagWio3mPhhqTDDMxDRdZow0p9UFXLOCCMpdkNmwcjakqk1nZWeeWwBqzQ=="
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.38.0.tgz",
+      "integrity": "sha512-474lo3uCMCOTT2dkIFDaZxhU5QiQblQwz8w4GC6DLTwdqQhh9jTcPjbxJVOhrWEvLqm/uR+ImJjLjR3vLV1g/A=="
     },
     "run-parallel": {
       "version": "1.2.0",

--- a/sanity-suite/package.json
+++ b/sanity-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-analytics-js-sdk-sanity-suite",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "Sanity suite for testing JS SDK package",
   "main": "./dist/testBook.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "deep-equal": "2.2.1",
     "get-value": "3.0.1",
     "object-path": "0.11.8",
-    "rudder-sdk-js": "2.37.0"
+    "rudder-sdk-js": "2.38.0"
   },
   "devDependencies": {
     "@babel/core": "7.21.8",

--- a/sanity-suite/src/testBookSuites/sourceConfig.js
+++ b/sanity-suite/src/testBookSuites/sourceConfig.js
@@ -1,5 +1,48 @@
 import sourceConfig1ExpectedData from '../../__mocks__/sourceConfig1.json';
-import { getConfigUrl, getJSONTrimmed, getUserProvidedConfigUrl } from '../../../src/utils/utils';
+
+const CONFIG_URL =
+  'https://api.rudderlabs.com/sourceConfig/?p=__MODULE_TYPE__&v=__PACKAGE_VERSION__';
+
+const getConfigUrl = (writeKey) => {
+  return CONFIG_URL.concat(CONFIG_URL.includes('?') ? '&' : '?').concat(
+    writeKey ? `writeKey=${writeKey}` : '',
+  );
+};
+
+const getJSONTrimmed = (context, url, writeKey, callback) => {
+  const cb_ = callback.bind(context);
+
+  const xhr = new XMLHttpRequest();
+
+  xhr.open('GET', url, true);
+  xhr.setRequestHeader('Authorization', `Basic ${btoa(`${writeKey}:`)}`);
+
+  xhr.onload = function () {
+    const { status } = xhr;
+    if (status == 200) {
+      cb_(200, xhr.responseText);
+    } else {
+      cb_(status);
+    }
+  };
+  xhr.send();
+};
+
+const getUserProvidedConfigUrl = (configUrl, defConfigUrl) => {
+  let url = configUrl;
+  if (url.indexOf('sourceConfig') === -1) {
+    url = `${url}/sourceConfig/`;
+  }
+  url = url.slice(-1) === '/' ? url : `${url}/`;
+  const defQueryParams = defConfigUrl.split('?')[1];
+  const urlSplitItems = url.split('?');
+  if (urlSplitItems.length > 1 && urlSplitItems[1] !== defQueryParams) {
+    url = `${urlSplitItems[0]}?${defQueryParams}`;
+  } else {
+    url = `${url}?${defQueryParams}`;
+  }
+  return url;
+};
 
 const sourceConfigAPISuite = {
   id: 'sourceConfig',

--- a/src/features/core/metrics/errorReporting/ErrorReportingService.js
+++ b/src/features/core/metrics/errorReporting/ErrorReportingService.js
@@ -85,7 +85,11 @@ class ErrorReportingService {
   // Expose the error reporting service as global variable after provider is ready,
   // so it can be used without injecting the service to consumer methods
   exposeToGlobal() {
-    window.rudderanalytics[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME] = this;
+    if (!window.RudderStackGlobals) {
+      window.RudderStackGlobals = {};
+    }
+
+    window.RudderStackGlobals[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME] = this;
   }
 
   leaveBreadcrumb(breadcrumb) {

--- a/src/features/core/metrics/errorReporting/providers/Bugsnag.js
+++ b/src/features/core/metrics/errorReporting/providers/Bugsnag.js
@@ -126,7 +126,10 @@ class BugsnagProvider {
    */
   init() {
     // Return if RS Bugsnag instance is already initialized
-    if (window.rudderanalytics && window.rudderanalytics[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME]) {
+    if (
+      window.RudderStackGlobals &&
+      window.RudderStackGlobals[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME]
+    ) {
       return;
     }
 

--- a/src/utils/notifyError.js
+++ b/src/utils/notifyError.js
@@ -7,7 +7,7 @@ import { ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME } from './constants';
  */
 const notifyError = (error) => {
   const errorReportingClient =
-    window.rudderanalytics && window.rudderanalytics[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME];
+    window.RudderStackGlobals && window.RudderStackGlobals[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME];
   if (errorReportingClient && error instanceof Error) {
     errorReportingClient.notify(error);
   }


### PR DESCRIPTION
## PR Description

Two issues with IE 11:
- sanity suite build was not transpiling imported code from out side sanity-suite folder
- the window.rudderanalytics.errorReporting was not allowed to be added in window.rudderanalytics object is not extensible anymore in npm builds. Using window.RudderStackGlobals that is used in v3 instead

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/IE11-issues-0a236aa3e6c74266bec4901d54d04e53?pvs=4)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
