### PR TITLE
feat: mixpanel simplified ID merge

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -13,7 +13,7 @@ module.exports = [
     name: 'All Integrations - CDN',
     path: 'dist/legacy/js-integrations/*.min.js',
     gzip: true,
-    limit: '435.1 kB',
+    limit: '435.2 kB',
   },
   {
     name: 'Core - NPM',

--- a/src/integrations/Mixpanel/browser.js
+++ b/src/integrations/Mixpanel/browser.js
@@ -381,7 +381,7 @@ class Mixpanel {
   alias(rudderElement) {
     logger.debug('in Mixpanel alias');
     if (this.identityMergeApi === 'simplified') {
-      logger.error(
+      logger.debug(
         "===Mixpanel: Event type 'alias' is not supported when 'Simplified ID merge' api is selected in webapp===",
       );
       return;

--- a/src/integrations/Mixpanel/browser.js
+++ b/src/integrations/Mixpanel/browser.js
@@ -79,6 +79,7 @@ class Mixpanel {
     this.areTransformationsConnected =
       destinationInfo && destinationInfo.areTransformationsConnected;
     this.destinationId = destinationInfo && destinationInfo.destinationId;
+    this.identityMergeApi = config.identityMergeApi || 'original';
   }
 
   init() {
@@ -186,12 +187,15 @@ class Mixpanel {
     peopleProperties = extendTraits(peopleProperties);
     const superProperties = parseConfigArray(this.superProperties, 'property');
 
-    // eslint-disable-next-line camelcase
-    const user_id = rudderElement.message.userId || rudderElement.message.anonymousId;
+    let userId = rudderElement.message.userId || rudderElement.message.anonymousId;
+    if (this.identityMergeApi === 'simplified') {
+      // calling mixpanel .identify() only for known users
+      userId = rudderElement.message.userId;
+    }
     let traits = formatTraits(rudderElement.message);
     const { email, username } = traits;
     // id
-    if (user_id) window.mixpanel.identify(user_id);
+    if (userId) window.mixpanel.identify(userId);
 
     // name tag
     const nametag = email || username;
@@ -376,6 +380,13 @@ class Mixpanel {
    */
   alias(rudderElement) {
     logger.debug('in Mixpanel alias');
+    if (this.identityMergeApi === 'simplified') {
+      logger.error(
+        "===Mixpanel: Event type 'alias' is not supported when 'Simplified ID merge' api is selected in webapp===",
+      );
+      return;
+    }
+
     const { previousId, userId } = rudderElement.message;
     const newId = userId;
     if (!previousId) {

--- a/src/integrations/Mixpanel/browser.js
+++ b/src/integrations/Mixpanel/browser.js
@@ -76,9 +76,6 @@ class Mixpanel {
       username: '$username',
       phone: '$phone',
     };
-    this.areTransformationsConnected =
-      destinationInfo && destinationInfo.areTransformationsConnected;
-    this.destinationId = destinationInfo && destinationInfo.destinationId;
     this.identityMergeApi = config.identityMergeApi || 'original';
     ({
       shouldApplyDeviceModeTransformation: this.shouldApplyDeviceModeTransformation,

--- a/src/integrations/Mixpanel/browser.js
+++ b/src/integrations/Mixpanel/browser.js
@@ -386,9 +386,7 @@ class Mixpanel {
   alias(rudderElement) {
     logger.debug('in Mixpanel alias');
     if (this.identityMergeApi === 'simplified') {
-      logger.debug(
-        "===Mixpanel: Event type 'alias' is not supported when 'Simplified ID merge' api is selected in webapp===",
-      );
+      logger.debug("===Mixpanel: Alias call is deprecated in 'Simplified ID Merge'===");
       return;
     }
 


### PR DESCRIPTION
## PR Description
For feature INT-163
- Removed the support of alias call when Simplified ID merge is selected.
- Removed the fallback value of anonymousId for `identify` calls since `alias` call is now removed. Mixpanel will take care of merging known users (userId) with anonymous users (deviceId) created by mixpanel sdk.

## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Mixpanel-Simplified-ID-Merge-Device-Mode-dda27518bdfa4d08a1496b9c4466df11)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
