### PR TITLE
feat: add load option for alias with mixpanel distinctId

### DIFF
--- a/src/integrations/Mixpanel/util.js
+++ b/src/integrations/Mixpanel/util.js
@@ -162,6 +162,20 @@ const mapTraits = (arr) => {
   return ret;
 };
 
+/**
+ * Validates weather to send alias call with mixpanel distinct id or not
+ * @param {*} integrations
+ */
+function aliasWithMixpanelDistinctId(integrations) {
+  if (Object.prototype.hasOwnProperty.call(integrations, 'MP')) {
+    const { MP } = integrations;
+    if (Object.prototype.hasOwnProperty.call(MP, 'aliasWithMixpanelDistinctId')) {
+      return !!MP.aliasWithMixpanelDistinctId;
+    }
+  }
+  return false;
+}
+
 export {
   parseConfigArray,
   inverseObjectArrays,
@@ -170,4 +184,5 @@ export {
   extendTraits,
   mapTraits,
   formatTraits,
+  aliasWithMixpanelDistinctId,
 };


### PR DESCRIPTION
## PR Description

Added a new flag: `aliasWithMixpanelDistinctId` to the load options, 
which allows for the control of the following behaviors in Original ID Merge:

- Aliasing with Mixpanel's `distinctId`.
- User profile creation with RudderStack's `anonymousId`.

When aliasWithMixpanelDistinctId is set to true, RudderStack's anonymousId will be omitted from every call.
```
{
  integrations: {
    Mixpanel: {
      aliasWithMixpanelDistinctId: true;
    }
  }
}
```



## Notion ticket

[Ticket link](https://www.notion.so/rudderstacks/Mixpanel-Aliasing-with-mixpanel-distinctId-7a029279dfb34def8e8b8a66e7b1b797)

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
