### PR TITLE
feat: add validations for load options

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "format": "prettier --write .",
     "lint:fix": "eslint . --fix",
     "prepare": "husky install",
-    "pre-commit": "npm run test -- --concurrency 1 --scope \"@rudderstack/analytics-js\" --scope \"@rudderstack/analytics-js-plugins\" && npm run check:size:build && npx lint-staged",
+    "pre-commit": "npm run test && npm run check:size:build && npx lint-staged",
     "commit-msg": "commitlint --edit",
     "commit": "git-cz",
     "release": "npx standard-version",

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
@@ -31,6 +31,9 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
         state.loadOptions.value.integrations,
       );
 
+      state.nativeDestinations.loadIntegration.value = state.loadOptions.value
+        .loadIntegration as boolean;
+
       // Filter destination that doesn't have mapping config-->Integration names
       const configSupportedDestinations =
         state.nativeDestinations.configuredDestinations.value.filter(configDest => {

--- a/packages/analytics-js/src/components/configManager/ConfigManager.ts
+++ b/packages/analytics-js/src/components/configManager/ConfigManager.ts
@@ -235,19 +235,18 @@ class ConfigManager implements IConfigManager {
       } else {
         this.processConfig(res as SourceConfigResponse);
       }
-      return;
-    }
-
-    // fetch source config from config url API
-    this.httpClient.getAsyncData({
-      url: state.lifecycle.sourceConfigUrl.value as string,
-      options: {
-        headers: {
-          'Content-Type': undefined,
+    } else {
+      // fetch source config from config url API
+      this.httpClient.getAsyncData({
+        url: state.lifecycle.sourceConfigUrl.value as string,
+        options: {
+          headers: {
+            'Content-Type': undefined,
+          },
         },
-      },
-      callback: this.processConfig,
-    });
+        callback: this.processConfig,
+      });
+    }
   }
 }
 

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -185,6 +185,9 @@ const WRITE_KEY_NOT_A_STRING_ERROR = (context: string, writeKey: string | undefi
 const EMPTY_GROUP_CALL_ERROR = (context: string): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The group() method must be called with at least one argument.`;
 
+const READY_CALLBACK_INVOKE_ERROR = (context: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}Failed to invoke the ready callback.`;
+
 // DEBUG
 
 export {
@@ -231,4 +234,5 @@ export {
   STORAGE_TYPE_VALIDATION_WARNING,
   WRITE_KEY_NOT_A_STRING_ERROR,
   EMPTY_GROUP_CALL_ERROR,
+  READY_CALLBACK_INVOKE_ERROR,
 };

--- a/packages/analytics-js/src/state/slices/loadOptions.ts
+++ b/packages/analytics-js/src/state/slices/loadOptions.ts
@@ -26,6 +26,9 @@ const defaultLoadOptions: LoadOptions = {
   polyfillIfRequired: true,
   integrations: { All: true },
   useBeacon: false,
+  beaconQueueOptions: {},
+  destinationsQueueOptions: {},
+  queueOptions: {},
   lockIntegrationsVersion: false,
   uaChTrackLevel: UaChTrackLevel.None,
   plugins: [],
@@ -38,6 +41,7 @@ const defaultLoadOptions: LoadOptions = {
     },
     migrate: false,
   },
+  sendAdblockPageOptions: {},
 };
 
 const loadOptionsState: LoadOptionsState = signal(clone(defaultLoadOptions));


### PR DESCRIPTION
## PR Description
- Added missing validations for load options
- Fixed a bug where the load option `loadIntegrations` was not getting forwarded to the integrations.
- Added error handling for ready callbacks invocation.

## Notion ticket

https://linear.app/rudderstack/issue/SDK-150/dev-testing-for-v3-after-refactoring

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
