### PR TITLE
fix: persisted data decryption for v3

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -13,7 +13,7 @@ module.exports = [
     name: 'All Integrations - CDN',
     path: 'dist/legacy/js-integrations/*.min.js',
     gzip: true,
-    limit: '435.5 kB',
+    limit: '436 kB',
   },
   {
     name: 'Core - NPM',

--- a/jest/jest.polyfills.js
+++ b/jest/jest.polyfills.js
@@ -4,3 +4,7 @@ require('isomorphic-fetch');
 
 // Mocking Math random
 global.Math.random = () => 0.5;
+
+import { TextDecoder } from 'util';
+
+Object.assign(global, { TextDecoder });

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1357,8 +1357,8 @@ class Analytics {
           !Object.values ||
           !String.prototype.replaceAll ||
           !this.isDatasetAvailable() ||
-      typeof TextDecoder !== 'function' ||
-      typeof Uint8Array !== 'function'))
+          typeof TextDecoder !== 'function' ||
+          typeof Uint8Array !== 'function'))
     );
   }
 

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1356,9 +1356,9 @@ class Analytics {
           !Object.entries ||
           !Object.values ||
           !String.prototype.replaceAll ||
-          !this.isDatasetAvailable())) ||
+          !this.isDatasetAvailable() ||
       typeof TextDecoder !== 'function' ||
-      typeof Uint8Array !== 'function'
+      typeof Uint8Array !== 'function'))
     );
   }
 

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1345,18 +1345,20 @@ class Analytics {
         ? options.polyfillIfRequired
         : true;
     return (
-      polyfillIfRequired &&
-      (!String.prototype.endsWith ||
-        !String.prototype.startsWith ||
-        !String.prototype.includes ||
-        !Array.prototype.find ||
-        !Array.prototype.includes ||
-        typeof window.URL !== 'function' ||
-        typeof Promise === 'undefined' ||
-        !Object.entries ||
-        !Object.values ||
-        !String.prototype.replaceAll ||
-        !this.isDatasetAvailable())
+      (polyfillIfRequired &&
+        (!String.prototype.endsWith ||
+          !String.prototype.startsWith ||
+          !String.prototype.includes ||
+          !Array.prototype.find ||
+          !Array.prototype.includes ||
+          typeof window.URL !== 'function' ||
+          typeof Promise === 'undefined' ||
+          !Object.entries ||
+          !Object.values ||
+          !String.prototype.replaceAll ||
+          !this.isDatasetAvailable())) ||
+      typeof TextDecoder !== 'function' ||
+      typeof Uint8Array !== 'function'
     );
   }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -22,7 +22,7 @@ const INTEGRATION_LOAD_CHECK_INTERVAL = 1000;
 const DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT_MS = 10000;
 const INTG_SUFFIX = '_RS';
 const POLYFILL_URL =
-  'https://polyfill.io/v3/polyfill.min.js?features=Number.isNaN%2CURL%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll';
+  'https://polyfill.io/v3/polyfill.min.js?features=Number.isNaN%2CURL%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll%2CTextDecoder%2Uint8Array';
 
 const GENERIC_TRUE_VALUES = ['true', 'True', 'TRUE', 't', 'T', '1'];
 const GENERIC_FALSE_VALUES = ['false', 'False', 'FALSE', 'f', 'F', '0'];

--- a/src/utils/storage/storage.js
+++ b/src/utils/storage/storage.js
@@ -5,6 +5,7 @@ import get from 'get-value';
 import logger from '../logUtil';
 import { Cookie } from './cookie';
 import { Store } from './store';
+import { fromBase64 } from './v3DecryptionUtils';
 
 const defaults = {
   user_storage_key: 'rl_user_id',
@@ -17,6 +18,7 @@ const defaults = {
   session_info: 'rl_session',
   auth_token: 'rl_auth_token',
   prefix: 'RudderEncrypt:',
+  prefixV3: 'RS_ENC_v3_', // prefix for v3 encryption
   key: 'Rudder',
 };
 
@@ -64,6 +66,11 @@ function decryptValue(value) {
   }
   if (value.substring(0, defaults.prefix.length) === defaults.prefix) {
     return AES.decrypt(value.substring(defaults.prefix.length), defaults.key).toString(Utf8);
+  }
+
+  // Try if it is v3 encrypted value
+  if (value.substring(0, defaults.prefixV3.length) === defaults.prefixV3) {
+    return fromBase64(value.substring(defaults.prefixV3.length));
   }
   return value;
 }

--- a/src/utils/storage/v3DecryptionUtils.js
+++ b/src/utils/storage/v3DecryptionUtils.js
@@ -1,0 +1,19 @@
+/**
+ * Converts a base64 encoded string to bytes array
+ * @param base64Str base64 encoded string
+ * @returns bytes array
+ */
+const base64ToBytes = (base64Str) => {
+  const binString = globalThis.atob(base64Str);
+  const bytes = binString.split('').map((char) => char.charCodeAt(0));
+  return new Uint8Array(bytes);
+};
+
+/**
+ * Decodes a base64 encoded string
+ * @param value base64 encoded string
+ * @returns decoded string
+ */
+const fromBase64 = (value) => new TextDecoder().decode(base64ToBytes(value));
+
+export { fromBase64 };


### PR DESCRIPTION
## PR Description

Allowed decryption of v3 SDK encrypted cookies.

## Notion ticket

https://linear.app/rudderstack/issue/SDK-209/allow-v11-to-decrypt-stored-data-from-v3-encryption

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
