### PR TITLE
chore: use correct flag for skipping tags for npm versioned releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lerna:version": "lerna version --exact --conventional-commits --no-push -y",
     "lerna:publish": "lerna publish from-package --no-private -y --create-release github",
-    "bump-version:monorepo": "npm version prerelease --git-tag-version false",
+    "bump-version:monorepo": "npm version prerelease --no-git-tag-version",
     "setup": "npx lerna@6 bootstrap && lerna link",
     "setup:ci": "npx lerna@6 bootstrap --ci && lerna link",
     "clean": "lerna clean --yes && lerna run --concurrency 1 clean && git clean -xdf node_modules",


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Notion ticket

https://linear.app/rudderstack/issue/SDK-344/use-correct-flag-for-skipping-tags-during-releases

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
