### PR TITLE
chore: skip analytics v1.1 package during releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "lerna:version": "lerna version --exact --no-git-tag-version --conventional-commits --no-push -y",
+    "lerna:version": "lerna version --ignore \"rudder-sdk-js\" --exact --conventional-commits --no-push -y",
     "lerna:publish": "lerna publish from-package --no-private -y --create-release github",
     "bump-version:monorepo": "npm version prerelease --no-git-tag-version",
     "setup": "npx lerna@6 bootstrap && lerna link",


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Notion ticket

https://linear.app/rudderstack/issue/SDK-344/use-correct-flag-for-skipping-tags-during-releases

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
