### PR TITLE
fix: use utility to determine destination specific integration options

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/LaunchDarkly/utils.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/LaunchDarkly/utils.test.js
@@ -1,4 +1,4 @@
-import createUser from '../../../src/integrations/LaunchDarkly/utils';
+import { createUser } from '../../../src/integrations/LaunchDarkly/utils';
 import { mockAnonymousUsersSharedKey, mockTraits, mockUserId } from './__fixtures__/data';
 
 afterAll(() => {

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
@@ -3,9 +3,8 @@
 import { NAME } from '@rudderstack/analytics-js-common/constants/integrations/Amplitude/constants';
 import Logger from '../../utils/logger';
 import { type } from '../../utils/utils';
-
 import { loadNativeSdk } from './nativeSdkLoader';
-import { getTraitsToSetOnce, getTraitsToIncrement } from './utils';
+import { getTraitsToSetOnce, getTraitsToIncrement, getDestinationOptions } from './utils';
 
 const logger = new Logger(NAME);
 
@@ -219,7 +218,8 @@ class Amplitude {
     this.setDeviceId(rudderElement);
 
     const { properties, name, category, integrations } = rudderElement.message;
-    const useNewPageEventNameFormat = integrations?.AM?.useNewPageEventNameFormat || false;
+    const amplitudeIntgConfig = getDestinationOptions(integrations);
+    const useNewPageEventNameFormat = amplitudeIntgConfig?.useNewPageEventNameFormat || false;
     // all pages
     if (this.trackAllPages) {
       const event = 'Loaded a page';

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
@@ -1,3 +1,8 @@
+import {
+  NAME,
+  DISPLAY_NAME,
+} from '@rudderstack/analytics-js-common/constants/integrations/Amplitude/constants';
+
 const getTraitsToSetOnce = config => {
   const traitsToSetOnce = [];
   if (config.traitsToSetOnce && config.traitsToSetOnce.length > 0) {
@@ -22,4 +27,15 @@ const getTraitsToIncrement = config => {
   return traitsToIncrement;
 };
 
-export { getTraitsToSetOnce, getTraitsToIncrement };
+/**
+ * Get destination specific options from integrations options
+ * By default, it will return options for the destination using its display name
+ * If display name is not present, it will return options for the destination using its name
+ * The fallback is only for backward compatibility with SDK versions < v1.1
+ * @param {object} integrationsOptions Integrations options object
+ * @returns destination specific options
+ */
+const getDestinationOptions = integrationsOptions =>
+  integrationsOptions && (integrationsOptions[DISPLAY_NAME] || integrationsOptions[NAME]);
+
+export { getTraitsToSetOnce, getTraitsToIncrement, getDestinationOptions };

--- a/packages/analytics-js-integrations/src/integrations/Iterable/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/Iterable/utils.js
@@ -1,3 +1,7 @@
+import {
+  NAME,
+  DISPLAY_NAME,
+} from '@rudderstack/analytics-js-common/constants/integrations/Iterable/constants';
 import { getDataFromSource } from '../../utils/utils';
 import { isDefinedAndNotNull } from '../../utils/commonUtils';
 
@@ -10,6 +14,17 @@ const ITEMS_MAPPING = [
   { src: 'image_url', dest: 'imageUrl' },
   { src: 'url', dest: 'url' },
 ];
+
+/**
+ * Get destination specific options from integrations options
+ * By default, it will return options for the destination using its display name
+ * If display name is not present, it will return options for the destination using its name
+ * The fallback is only for backward compatibility with SDK versions < v1.1
+ * @param {object} integrationsOptions Integrations options object
+ * @returns destination specific options
+ */
+const getDestinationOptions = integrationsOptions =>
+  integrationsOptions && (integrationsOptions[DISPLAY_NAME] || integrationsOptions[NAME]);
 
 function getMappingObject(properties, mappings) {
   let itemsObject = {};
@@ -74,8 +89,9 @@ function existsInMapping(mappedEvents, event) {
  * @returns
  */
 const extractJWT = integrations => {
-  if (integrations?.ITERABLE) {
-    const { jwt_token: jwtToken } = integrations.ITERABLE;
+  const iterableIntgConfig = getDestinationOptions(integrations);
+  if (iterableIntgConfig) {
+    const { jwt_token: jwtToken } = iterableIntgConfig;
     return isDefinedAndNotNull(jwtToken) ? jwtToken : undefined;
   }
   return undefined;

--- a/packages/analytics-js-integrations/src/integrations/LaunchDarkly/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/LaunchDarkly/browser.js
@@ -1,9 +1,8 @@
 /* eslint-disable class-methods-use-this */
-import get from 'get-value';
 import logger from '@rudderstack/analytics-js-common/v1.1/utils/logUtil';
 import ScriptLoader from '@rudderstack/analytics-js-common/v1.1/utils/ScriptLoader';
 import { NAME } from '@rudderstack/analytics-js-common/constants/integrations/LaunchDarkly/constants';
-import createUser from './utils';
+import { createUser, getDestinationOptions } from './utils';
 
 class LaunchDarkly {
   constructor(config, analytics, destinationInfo) {
@@ -44,8 +43,8 @@ class LaunchDarkly {
 
   identify(rudderElement) {
     const { message } = rudderElement;
-    const anonymousUsersSharedKey =
-      get(message, `integrations.${NAME}.key`) || this.anonymousUsersSharedKey;
+    const launchDarklyIntgConfig = getDestinationOptions(message.integrations);
+    const anonymousUsersSharedKey = launchDarklyIntgConfig?.key || this.anonymousUsersSharedKey;
     this.launchDarklyUser = createUser(message, anonymousUsersSharedKey);
 
     if (window.ldclient) {

--- a/packages/analytics-js-integrations/src/integrations/LaunchDarkly/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/LaunchDarkly/utils.js
@@ -1,3 +1,19 @@
+import {
+  NAME,
+  DISPLAY_NAME,
+} from '@rudderstack/analytics-js-common/constants/integrations/LaunchDarkly/constants';
+
+/**
+ * Get destination specific options from integrations options
+ * By default, it will return options for the destination using its display name
+ * If display name is not present, it will return options for the destination using its name
+ * The fallback is only for backward compatibility with SDK versions < v1.1
+ * @param {object} integrationsOptions Integrations options object
+ * @returns destination specific options
+ */
+const getDestinationOptions = integrationsOptions =>
+  integrationsOptions && (integrationsOptions[DISPLAY_NAME] || integrationsOptions[NAME]);
+
 const createUser = (message, anonymousUsersSharedKey = undefined) => {
   const user = {
     key: message.userId || message.anonymousId,
@@ -21,4 +37,4 @@ const createUser = (message, anonymousUsersSharedKey = undefined) => {
   return user;
 };
 
-export default createUser;
+export { getDestinationOptions, createUser };

--- a/packages/analytics-js-integrations/src/integrations/Matomo/util.js
+++ b/packages/analytics-js-integrations/src/integrations/Matomo/util.js
@@ -1,9 +1,22 @@
 /* eslint-disable no-underscore-dangle */
 import each from '@ndhoule/each';
 import logger from '@rudderstack/analytics-js-common/v1.1/utils/logUtil';
-import { NAME } from '@rudderstack/analytics-js-common/constants/integrations/Matomo/constants';
+import {
+  NAME,
+  DISPLAY_NAME,
+} from '@rudderstack/analytics-js-common/constants/integrations/Matomo/constants';
 import { getHashFromArray } from '../../utils/commonUtils';
 
+/**
+ * Get destination specific options from integrations options
+ * By default, it will return options for the destination using its display name
+ * If display name is not present, it will return options for the destination using its name
+ * The fallback is only for backward compatibility with SDK versions < v1.1
+ * @param {object} integrationsOptions Integrations options object
+ * @returns destination specific options
+ */
+const getDestinationOptions = integrationsOptions =>
+  integrationsOptions && (integrationsOptions[DISPLAY_NAME] || integrationsOptions[NAME]);
 const userParameterRequiredErrorMessage = 'User parameter (sku or product_id) is required';
 
 /** If any event name matches with the goals list provided by the dashboard
@@ -399,8 +412,9 @@ const ecommerceEventsMapping = (event, message) => {
  */
 const checkCustomDimensions = message => {
   const { integrations } = message;
-  if (integrations) {
-    const customDimension = integrations[NAME]?.customDimension;
+  const matomoIntgConfig = getDestinationOptions(integrations);
+  if (matomoIntgConfig) {
+    const customDimension = matomoIntgConfig?.customDimension;
     if (customDimension) {
       const customDimensionsMap = getHashFromArray(
         customDimension,

--- a/packages/analytics-js-integrations/src/integrations/Mouseflow/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/Mouseflow/utils.js
@@ -1,6 +1,19 @@
 /* eslint-disable no-underscore-dangle */
-import get from 'get-value';
-import { NAME } from '@rudderstack/analytics-js-common/constants/integrations/Mouseflow/constants';
+import {
+  NAME,
+  DISPLAY_NAME,
+} from '@rudderstack/analytics-js-common/constants/integrations/Mouseflow/constants';
+
+/**
+ * Get destination specific options from integrations options
+ * By default, it will return options for the destination using its display name
+ * If display name is not present, it will return options for the destination using its name
+ * The fallback is only for backward compatibility with SDK versions < v1.1
+ * @param {object} integrationsOptions Integrations options object
+ * @returns destination specific options
+ */
+const getDestinationOptions = integrationsOptions =>
+  integrationsOptions && (integrationsOptions[DISPLAY_NAME] || integrationsOptions[NAME]);
 
 /*
  * Here, we are iterating each key-value pair of object 'Obj' and
@@ -20,7 +33,8 @@ const setCustomVariables = userProperties => {
  * Set custom Variables from integrations Object
  */
 const addCustomVariables = message => {
-  const customVariables = get(message, `integrations.${NAME}.customVariables`);
+  const mouseflowIntgConfig = getDestinationOptions(message.integrations);
+  const customVariables = mouseflowIntgConfig?.customVariables;
   setCustomVariables(customVariables);
 };
 


### PR DESCRIPTION
## PR Description

Created utility to read destination-specific options from integrations object.

## Notion ticket

https://linear.app/rudderstack/issue/SDK-355/use-utility-to-read-destination-specific-options-from-integrations

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
