### PR TITLE
fix: forward only supported calls to the log provider

### DIFF
--- a/packages/analytics-js/src/services/Logger/Logger.ts
+++ b/packages/analytics-js/src/services/Logger/Logger.ts
@@ -54,7 +54,7 @@ class Logger implements ILogger {
     if (this.minLogLevel <= LOG_LEVEL_MAP[logMethod]) {
       this.logProvider[
         logMethod.toLowerCase() as Exclude<Lowercase<LogLevel>, Lowercase<LogLevel.None>>
-      ](...this.formatLogData(data));
+      ]?.(...this.formatLogData(data));
     }
   }
 


### PR DESCRIPTION
## PR Description

As `console.debug` is not supported in IE 10, I've added a check before calling the function.

## Notion ticket

https://linear.app/rudderstack/issue/SDK-374/fix-logger-to-forward-only-supported-calls-to-the-provider-js-sdk-v3

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
