### PR TITLE
fix: stop sending network breadcrumbs to bugsnag

### DIFF
--- a/packages/analytics-js-plugins/src/bugsnag/utils.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/utils.ts
@@ -124,6 +124,7 @@ const getNewClient = (state: ApplicationState, logger?: ILogger): BugsnagLib.Cli
       id: state.lifecycle.writeKey.value,
     },
     logger,
+    networkBreadcrumbsEnabled: false,
   };
 
   const client: BugsnagLib.Client = globalBugsnagLibInstance(clientConfig);

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
@@ -229,25 +229,25 @@ const initializeDestination = (
         ];
       })
       .catch(err => {
-        // The error message is already formatted in the isDestinationReady function
-        logger?.error(err);
-
         state.nativeDestinations.failedDestinations.value = [
           ...state.nativeDestinations.failedDestinations.value,
           dest,
         ];
+
+        // The error message is already formatted in the isDestinationReady function
+        logger?.error(err);
       });
   } catch (err) {
+    state.nativeDestinations.failedDestinations.value = [
+      ...state.nativeDestinations.failedDestinations.value,
+      dest,
+    ];
+
     errorHandler?.onError(
       err,
       DEVICE_MODE_DESTINATIONS_PLUGIN,
       DESTINATION_INIT_ERROR(dest.userFriendlyId),
     );
-
-    state.nativeDestinations.failedDestinations.value = [
-      ...state.nativeDestinations.failedDestinations.value,
-      dest,
-    ];
   }
 };
 


### PR DESCRIPTION
## PR Description
Add a configuration flag in Bugsnag client initialization to stop sending network breadcrumbs to Bugsnag.

## Notion ticket

https://linear.app/rudderstack/issue/SDK-375/stop-sending-network-breadcrumbs-to-bugsnag-js-sdk-v3

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
