### PR TITLE
fix: add trim & lowercase for klaviyo track event

### DIFF
--- a/src/integrations/Klaviyo/browser.js
+++ b/src/integrations/Klaviyo/browser.js
@@ -141,9 +141,10 @@ class Klaviyo {
 
   track(rudderElement) {
     const { message } = rudderElement;
-    const { event } = message;
+    let { event } = message;
     const properties = message?.properties || {};
 
+    event = event ? event.trim().toLowerCase() : event;
     if (this.ecomEvents.includes(event)) {
       let payload = ecommEventPayload(this.eventNameMapping[event], message);
       const eventName = this.eventNameMapping[event];

--- a/src/integrations/Klaviyo/browser.js
+++ b/src/integrations/Klaviyo/browser.js
@@ -141,10 +141,9 @@ class Klaviyo {
 
   track(rudderElement) {
     const { message } = rudderElement;
-    let { event } = message;
     const properties = message?.properties || {};
 
-    event = event ? event.trim().toLowerCase() : event;
+    const event = message.event ? message.event.trim().toLowerCase() : message.event;
     if (this.ecomEvents.includes(event)) {
       let payload = ecommEventPayload(this.eventNameMapping[event], message);
       const eventName = this.eventNameMapping[event];


### PR DESCRIPTION
## PR Description

- Add trim and lowercase of event name before mapping

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
