### PR TITLE
fix: stop sending network breadcrumbs to bugsnag

### DIFF
--- a/src/features/core/metrics/errorReporting/providers/Bugsnag.js
+++ b/src/features/core/metrics/errorReporting/providers/Bugsnag.js
@@ -200,6 +200,7 @@ class BugsnagProvider {
       enabledBreadcrumbTypes: ['error', 'log', 'user'],
       maxEvents: 100,
       releaseStage: getReleaseStage(),
+      networkBreadcrumbsEnabled: false,
     });
 
     this.onClientReady();


### PR DESCRIPTION
## PR Description

Add a configuration flag in Bugsnag client initialization to stop sending network breadcrumbs to Bugsnag.

## Notion ticket

https://linear.app/rudderstack/issue/SDK-375/stop-sending-network-breadcrumbs-to-bugsnag

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
