### PR TITLE
fix: handle errors for cookies data URI encode and decode

### DIFF
--- a/packages/analytics-js/__tests__/services/StoreManager/component-cookie/index.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/component-cookie/index.test.ts
@@ -50,14 +50,6 @@ describe('cookie(name, null)', () => {
     expect(1).toEqual(Object.keys(obj).length);
     expect('0').toEqual(obj.name);
   });
-
-  it('should throw URIError for malformed cookie data', () => {
-    window.document.cookie = 'bad=%';
-    expect(() => {
-      cookie('bad');
-    }).toThrowError(new URIError('URI malformed'));
-    cookie('bad', null);
-  });
 });
 
 describe('cookie()', () => {

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -195,6 +195,8 @@ const INVALID_CONFIG_URL_WARNING = (context: string, configUrl: string): string 
 const POLYFILL_SCRIPT_LOAD_ERROR = (scriptId: string, url: string): string =>
   `Failed to load the polyfill script with ID "${scriptId}" from URL ${url}.`;
 
+const COOKIE_DATA_ENCODING_ERROR = `Failed to encode the cookie data.`;
+
 // DEBUG
 
 export {
@@ -245,4 +247,5 @@ export {
   API_CALLBACK_INVOKE_ERROR,
   INVALID_CONFIG_URL_WARNING,
   POLYFILL_SCRIPT_LOAD_ERROR,
+  COOKIE_DATA_ENCODING_ERROR,
 };

--- a/packages/analytics-js/src/services/StoreManager/component-cookie/index.ts
+++ b/packages/analytics-js/src/services/StoreManager/component-cookie/index.ts
@@ -1,21 +1,37 @@
 import { isNull } from '@rudderstack/analytics-js-common/utilities/checks';
 import { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 import { CookieOptions } from '@rudderstack/analytics-js-common/types/Store';
+import { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import { COOKIE_DATA_ENCODING_ERROR } from '@rudderstack/analytics-js/constants/logMessages';
 
 /**
  * Encode.
  */
-const encode = (value: any): string => encodeURIComponent(value);
+const encode = (value: any, logger?: ILogger): string | undefined => {
+  try {
+    return encodeURIComponent(value);
+  } catch (err) {
+    logger?.error(COOKIE_DATA_ENCODING_ERROR, err);
+    return undefined;
+  }
+};
 
 /**
  * Decode
  */
-const decode = (value: string): string => decodeURIComponent(value);
+const decode = (value: string): string | undefined => {
+  try {
+    return decodeURIComponent(value);
+  } catch (err) {
+    // Do nothing as non-RS SDK cookies may not be URI encoded
+    return undefined;
+  }
+};
 
 /**
  * Parse cookie `str`
  */
-const parse = (str: string): Record<string, string> => {
+const parse = (str: string): Record<string, string | undefined> => {
   const obj: Record<string, any> = {};
   const pairs = str.split(/\s*;\s*/);
   let pair;
@@ -26,7 +42,7 @@ const parse = (str: string): Record<string, string> => {
 
   pairs.forEach(pairItem => {
     pair = pairItem.split('=');
-    obj[decode(pair[0])] = decode(pair[1]);
+    obj[decode(pair[0]) as string] = decode(pair[1]);
   });
 
   return obj;
@@ -35,9 +51,14 @@ const parse = (str: string): Record<string, string> => {
 /**
  * Set cookie `name` to `value`
  */
-const set = (name?: string, value?: Nullable<string | number>, optionsConfig?: CookieOptions) => {
+const set = (
+  name?: string,
+  value?: Nullable<string | number>,
+  optionsConfig?: CookieOptions,
+  logger?: ILogger,
+) => {
   const options: CookieOptions = { ...optionsConfig } || {};
-  let cookieString = `${encode(name)}=${encode(value)}`;
+  let cookieString = `${encode(name, logger)}=${encode(value, logger)}`;
 
   if (isNull(value)) {
     options.maxage = -1;
@@ -73,7 +94,7 @@ const set = (name?: string, value?: Nullable<string | number>, optionsConfig?: C
 /**
  * Return all cookies
  */
-const all = (): Record<string, string> => {
+const all = (): Record<string, string | undefined> => {
   const cookieStringValue = globalThis.document.cookie;
   return parse(cookieStringValue);
 };
@@ -92,11 +113,13 @@ const cookie = function (
   name?: string,
   value?: Nullable<string | number>,
   options?: CookieOptions,
+  logger?: ILogger,
 ): void | any {
   switch (arguments.length) {
+    case 4:
     case 3:
     case 2:
-      return set(name, value, options);
+      return set(name, value, options, logger);
     case 1:
       if (name) {
         return get(name);

--- a/packages/analytics-js/src/services/StoreManager/component-cookie/index.ts
+++ b/packages/analytics-js/src/services/StoreManager/component-cookie/index.ts
@@ -40,9 +40,14 @@ const parse = (str: string): Record<string, string | undefined> => {
     return obj;
   }
 
+  // TODO: Decode only the cookies that are needed by the SDK
   pairs.forEach(pairItem => {
     pair = pairItem.split('=');
-    obj[decode(pair[0]) as string] = decode(pair[1]);
+    const keyName = decode(pair[0]);
+
+    if (keyName) {
+      obj[keyName] = decode(pair[1]);
+    }
   });
 
   return obj;

--- a/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
@@ -40,7 +40,7 @@ class CookieStorage implements IStorage {
   }
 
   setItem(key: string, value: Nullable<string>): boolean {
-    cookie(key, value, this.options);
+    cookie(key, value, this.options, this.logger);
     this.length = Object.keys(cookie()).length;
     return true;
   }


### PR DESCRIPTION
## PR Description

Added error handling around cookie data encoding.

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
