### PR TITLE
fix(INT-523): replaced flag with dropdown for datacenter selection

### DIFF
--- a/src/integrations/CustomerIO/browser.js
+++ b/src/integrations/CustomerIO/browser.js
@@ -13,6 +13,7 @@ class CustomerIO {
     this.siteID = config.siteID;
     this.apiKey = config.apiKey;
     this.datacenterEU = config.datacenterEU;
+    this.datacenter = config.datacenter;
     this.sendPageNameInSDK = config.sendPageNameInSDK;
     this.name = NAME;
     ({
@@ -24,15 +25,15 @@ class CustomerIO {
 
   init() {
     logger.debug('===in init Customer IO init===');
-    const { siteID, datacenterEU } = this;
-    loadNativeSdk(siteID, datacenterEU);
+    const { siteID, datacenter, datacenterEU } = this;
+    loadNativeSdk(siteID, datacenter, datacenterEU);
   }
 
   identify(rudderElement) {
     logger.debug('in Customer IO identify');
     const { userId, context } = rudderElement.message;
     const { traits } = context || {};
-    if(!userId){
+    if (!userId) {
       logger.error('userId is required for Identify call.');
       return;
     }

--- a/src/integrations/CustomerIO/nativeSdkLoader.js
+++ b/src/integrations/CustomerIO/nativeSdkLoader.js
@@ -1,6 +1,6 @@
 import { LOAD_ORIGIN } from '../../utils/ScriptLoader';
 
-function loadNativeSdk(siteID, datacenterEU) {
+function loadNativeSdk(siteID, datacenter, datacenterEU) {
   window._cio = window._cio || [];
   (function () {
     let a;
@@ -22,7 +22,7 @@ function loadNativeSdk(siteID, datacenterEU) {
     t.id = 'cio-tracker';
     t.setAttribute('data-site-id', siteID);
     t.src = 'https://assets.customer.io/assets/track.js';
-    if (datacenterEU === true) {
+    if (datacenter === 'EU' || datacenterEU === true) {
       t.src = 'https://assets.customer.io/assets/track-eu.js';
     }
     s.parentNode.insertBefore(t, s);


### PR DESCRIPTION
## PR Description

Previously we were having a flag to check if datacenter is EU but now we are going with a drop down menu to select available datacenter from and falling back to previous flag in case new one is not available

## Notion ticket

Ticket link

## Screenshots

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Chrome
  >
- Firefox
  >
- Safari
  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
