### PR TITLE
chore: revert sanity suite changes

### DIFF
--- a/packages/sanity-suite/src/testBook/ResultAssertions.js
+++ b/packages/sanity-suite/src/testBook/ResultAssertions.js
@@ -13,9 +13,8 @@ class ResultsAssertions {
       if (resultData.message) {
         ignoredProperties.forEach(property => {
           if (
-            typeof objectPath.get(expectedResultData, property.key) !== 'undefined' &&
-            (typeof objectPath.get(resultData, property.key) === property.type ||
-              property.optional === true)
+            typeof objectPath.get(resultData, property.key) === property.type ||
+            property.optional === true
           ) {
             objectPath.set(
               resultData,


### PR DESCRIPTION
## PR Description

Reverted the checking of non-existent parameters in the expected result as there could be scenarios where the outcome has new or extra properties that we want to sanitize and ignore.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
