### PR TITLE
fix(analytics-js): enforce default cloud mode events delivery plugin

### DIFF
--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -61,26 +61,26 @@ describe('Core - Analytics', () => {
 
       state.lifecycle.status.value = 'configured';
       expect(loadPluginsSpy).toHaveBeenCalledTimes(1);
-      expect(state.lifecycle.status.value).toBe('ready');
+      expect(state.lifecycle.status.value).toBe('pluginsLoading');
 
       state.lifecycle.status.value = 'pluginsLoading';
       expect(loadPluginsSpy).toHaveBeenCalledTimes(1);
       expect(state.lifecycle.status.value).toBe('pluginsLoading');
 
       state.lifecycle.status.value = 'pluginsReady';
-      expect(initSpy).toHaveBeenCalledTimes(2);
+      expect(initSpy).toHaveBeenCalledTimes(1);
       expect(state.lifecycle.status.value).toBe('ready');
 
       state.lifecycle.status.value = 'initialized';
-      expect(onInitializedSpy).toHaveBeenCalledTimes(3);
+      expect(onInitializedSpy).toHaveBeenCalledTimes(2);
       expect(state.lifecycle.status.value).toBe('ready');
 
       state.lifecycle.status.value = 'loaded';
-      expect(loadDestinationsSpy).toHaveBeenCalledTimes(4);
+      expect(loadDestinationsSpy).toHaveBeenCalledTimes(3);
       expect(state.lifecycle.status.value).toBe('ready');
 
       state.lifecycle.status.value = 'destinationsReady';
-      expect(onDestinationsReadySpy).toHaveBeenCalledTimes(5);
+      expect(onDestinationsReadySpy).toHaveBeenCalledTimes(4);
       expect(state.lifecycle.status.value).toBe('ready');
     });
   });

--- a/packages/analytics-js/src/components/pluginsManager/PluginsManager.ts
+++ b/packages/analytics-js/src/components/pluginsManager/PluginsManager.ts
@@ -112,7 +112,7 @@ class PluginsManager implements IPluginsManager {
       );
     }
 
-    // dataplane events delivery plugins
+    // Cloud mode (dataplane) events delivery plugins
     if (state.loadOptions.value.useBeacon === true && state.capabilities.isBeaconAvailable.value) {
       pluginsToLoadFromConfig = pluginsToLoadFromConfig.filter(
         pluginName => pluginName !== 'XhrQueue',
@@ -125,6 +125,14 @@ class PluginsManager implements IPluginsManager {
       pluginsToLoadFromConfig = pluginsToLoadFromConfig.filter(
         pluginName => pluginName !== 'BeaconQueue',
       );
+    }
+
+    // Enforce default cloud mode event delivery queue plugin is none exists
+    if (
+      !pluginsToLoadFromConfig.includes('XhrQueue') &&
+      !pluginsToLoadFromConfig.includes('BeaconQueue')
+    ) {
+      pluginsToLoadFromConfig.push('XhrQueue');
     }
 
     // Device mode destinations related plugins


### PR DESCRIPTION
## PR Description

Do not allow analytics to skip sending cloud mode events.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-619/make-either-of-xhr-or-beacon-plugins-mandatory)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
