### PR TITLE
ci(monorepo): use self hosted github runner

### DIFF
--- a/.github/workflows/build-and-quality-checks-v3.yml
+++ b/.github/workflows/build-and-quality-checks-v3.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build:
     name: Build & Code Quality Checks v3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-beta-v3.yml
+++ b/.github/workflows/deploy-beta-v3.yml
@@ -13,8 +13,9 @@ env:
 jobs:
   deploy-tag:
     name: Deploy BETA/BugBash Feature v3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: startsWith(github.ref, 'refs/heads/beta/') || startsWith(github.ref, 'refs/tags/bugbash')
+
     steps:
       - name: Extract feature name from branch
         id: extract_branch

--- a/.github/workflows/deploy-dev-v3.yml
+++ b/.github/workflows/deploy-dev-v3.yml
@@ -17,8 +17,9 @@ env:
 jobs:
   deploy-tag:
     name: Deploy to DEV v3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/v3-hotfix/') || startsWith(github.ref, 'refs/heads/develop/') || github.event.pull_request.merged == true
+
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-npm-v3.yml
+++ b/.github/workflows/deploy-npm-v3.yml
@@ -17,8 +17,9 @@ env:
 jobs:
   deploy-tag:
     name: Deploy to NPM v3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main') || github.event.pull_request.merged == true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-prod-v3.yml
+++ b/.github/workflows/deploy-prod-v3.yml
@@ -17,8 +17,9 @@ env:
 jobs:
   deploy-tag:
     name: Deploy to PROD v3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main') || github.event.pull_request.merged == true
+
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -21,7 +21,8 @@ env:
 jobs:
   deploy-tag:
     name: Deploy Sanity Suite
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-staging-v3.yml
+++ b/.github/workflows/deploy-staging-v3.yml
@@ -13,8 +13,9 @@ env:
 jobs:
   deploy-tag:
     name: Deploy to STAGING v3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/v3-hotfix-release') || startsWith(github.ref, 'refs/heads/v3-release') || startsWith(github.ref, 'refs/heads/v3-hotfix/')
+
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/publish-new-release-v3.yml
+++ b/.github/workflows/publish-new-release-v3.yml
@@ -13,8 +13,9 @@ env:
 jobs:
   release:
     name: Publish new release v3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: (startsWith(github.event.pull_request.head.ref, 'v3-release/') || startsWith(github.event.pull_request.head.ref, 'v3-hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
+
     steps:
       - name: Extract version from branch name (for release branches)
         id: extract-version

--- a/.github/workflows/rollback-v3.yml
+++ b/.github/workflows/rollback-v3.yml
@@ -13,8 +13,9 @@ env:
 jobs:
   deploy-tag:
     name: Rollback v3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main')
+
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: 'Unit Tests, Coverage & Sonar v3'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## PR Description

use self hosted github runners

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-678/use-hosted-github-runner-with-more-cores-to-speed-up-builds)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
