### PR TITLE
fix: empty anonymous id after reset call

### DIFF
--- a/packages/analytics-js/__fixtures__/fixtures.ts
+++ b/packages/analytics-js/__fixtures__/fixtures.ts
@@ -394,7 +394,7 @@ const loadOptionWithInvalidEntry = {
   },
 };
 
-const anonymousIdWithNoStorageOption = {
+const anonymousIdWithNoStorageEntries = {
   userId: {
     type: 'cookieStorage',
     key: userSessionStorageKeys.userId,
@@ -445,5 +445,5 @@ export {
   entriesWithMixStorage,
   loadOptionWithEntry,
   loadOptionWithInvalidEntry,
-  anonymousIdWithNoStorageOption,
+  anonymousIdWithNoStorageEntries,
 };

--- a/packages/analytics-js/__fixtures__/fixtures.ts
+++ b/packages/analytics-js/__fixtures__/fixtures.ts
@@ -394,6 +394,41 @@ const loadOptionWithInvalidEntry = {
   },
 };
 
+const anonymousIdWithNoStorageOption = {
+  userId: {
+    type: 'cookieStorage',
+    key: userSessionStorageKeys.userId,
+  },
+  userTraits: {
+    type: 'cookieStorage',
+    key: userSessionStorageKeys.userTraits,
+  },
+  anonymousId: {
+    type: 'none',
+    key: userSessionStorageKeys.anonymousId,
+  },
+  groupId: {
+    type: 'cookieStorage',
+    key: userSessionStorageKeys.groupId,
+  },
+  groupTraits: {
+    type: 'cookieStorage',
+    key: userSessionStorageKeys.groupTraits,
+  },
+  initialReferrer: {
+    type: 'cookieStorage',
+    key: userSessionStorageKeys.initialReferrer,
+  },
+  initialReferringDomain: {
+    type: 'cookieStorage',
+    key: userSessionStorageKeys.initialReferringDomain,
+  },
+  sessionInfo: {
+    type: 'cookieStorage',
+    key: userSessionStorageKeys.sessionInfo,
+  },
+};
+
 export {
   identifyRequestPayload,
   trackRequestPayload,
@@ -410,4 +445,5 @@ export {
   entriesWithMixStorage,
   loadOptionWithEntry,
   loadOptionWithInvalidEntry,
+  anonymousIdWithNoStorageOption,
 };

--- a/packages/analytics-js/__tests__/components/userSessionManager/userSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/userSessionManager.test.ts
@@ -532,12 +532,14 @@ describe('User session manager', () => {
     expect(state.session.sessionInfo.value.sessionStart).toBe(undefined);
   });
   it('reset: should clear anonymousId with first parameter set to true', () => {
+    state.storage.entries.value = entriesWithOnlyCookieStorage;
     userSessionManager.init();
     userSessionManager.setAnonymousId(dummyAnonymousId);
     userSessionManager.reset(true);
-    expect(state.session.anonymousId.value).toEqual('');
+    expect(state.session.anonymousId.value).toEqual('test_uuid');
   });
   it('reset: should not start a new session with second parameter set to true', () => {
+    state.storage.entries.value = entriesWithOnlyCookieStorage;
     userSessionManager.init();
     const sessionInfoBeforeReset = JSON.parse(JSON.stringify(state.session.sessionInfo.value));
     userSessionManager.reset(true, true);

--- a/packages/analytics-js/__tests__/components/userSessionManager/userSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/userSessionManager.test.ts
@@ -12,6 +12,7 @@ import { defaultErrorHandler } from '../../../src/services/ErrorHandler';
 import { PluginsManager } from '../../../src/components/pluginsManager';
 import { defaultPluginEngine } from '../../../src/services/PluginEngine';
 import {
+  anonymousIdWithNoStorageOption,
   entriesWithMixStorage,
   entriesWithOnlyCookieStorage,
   entriesWithOnlyLocalStorage,
@@ -531,12 +532,19 @@ describe('User session manager', () => {
     expect(state.session.sessionInfo.value.id).not.toBe(sessionInfoBeforeReset.id);
     expect(state.session.sessionInfo.value.sessionStart).toBe(undefined);
   });
-  it('reset: should clear anonymousId with first parameter set to true', () => {
+  it('reset: should clear the existing anonymousId and set a new anonymousId with first parameter set to true', () => {
     state.storage.entries.value = entriesWithOnlyCookieStorage;
     userSessionManager.init();
     userSessionManager.setAnonymousId(dummyAnonymousId);
     userSessionManager.reset(true);
     expect(state.session.anonymousId.value).toEqual('test_uuid');
+  });
+  it('reset: should clear anonymousId and set default value in case of storage type is no_storage', () => {
+    state.storage.entries.value = anonymousIdWithNoStorageOption;
+    userSessionManager.init();
+    userSessionManager.setAnonymousId(dummyAnonymousId);
+    userSessionManager.reset(true);
+    expect(state.session.anonymousId.value).toEqual('');
   });
   it('reset: should not start a new session with second parameter set to true', () => {
     state.storage.entries.value = entriesWithOnlyCookieStorage;

--- a/packages/analytics-js/__tests__/components/userSessionManager/userSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/userSessionManager.test.ts
@@ -12,7 +12,7 @@ import { defaultErrorHandler } from '../../../src/services/ErrorHandler';
 import { PluginsManager } from '../../../src/components/pluginsManager';
 import { defaultPluginEngine } from '../../../src/services/PluginEngine';
 import {
-  anonymousIdWithNoStorageOption,
+  anonymousIdWithNoStorageEntries,
   entriesWithMixStorage,
   entriesWithOnlyCookieStorage,
   entriesWithOnlyLocalStorage,
@@ -540,7 +540,7 @@ describe('User session manager', () => {
     expect(state.session.anonymousId.value).toEqual('test_uuid');
   });
   it('reset: should clear anonymousId and set default value in case of storage type is no_storage', () => {
-    state.storage.entries.value = anonymousIdWithNoStorageOption;
+    state.storage.entries.value = anonymousIdWithNoStorageEntries;
     userSessionManager.init();
     userSessionManager.setAnonymousId(dummyAnonymousId);
     userSessionManager.reset(true);

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -333,8 +333,7 @@ class UserSessionManager implements IUserSessionManager {
    */
   setAnonymousId(anonymousId?: string, rudderAmpLinkerParam?: string) {
     let finalAnonymousId: string | undefined | null = anonymousId;
-    const storage: StorageType = state.storage.entries.value.anonymousId?.type as StorageType;
-    if (isStorageTypeValidForStoringData(storage)) {
+    if (this.isPersistenceEnabledForStorageEntry('anonymousId')) {
       if (!finalAnonymousId && rudderAmpLinkerParam) {
         const linkerPluginsResult = this.pluginsManager?.invokeMultiple<Nullable<string>>(
           'userSession.anonymousIdGoogleLinker',
@@ -510,7 +509,11 @@ class UserSessionManager implements IUserSessionManager {
       state.session.authToken.value = defaultUserSessionValues.authToken;
 
       if (resetAnonymousId) {
-        state.session.anonymousId.value = defaultUserSessionValues.anonymousId;
+        if (this.isPersistenceEnabledForStorageEntry('anonymousId')) {
+          this.setAnonymousId();
+        } else {
+          state.session.anonymousId.value = defaultUserSessionValues.anonymousId;
+        }
       }
 
       if (noNewSessionStart) {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -509,11 +509,8 @@ class UserSessionManager implements IUserSessionManager {
       state.session.authToken.value = defaultUserSessionValues.authToken;
 
       if (resetAnonymousId) {
-        if (this.isPersistenceEnabledForStorageEntry('anonymousId')) {
-          this.setAnonymousId();
-        } else {
-          state.session.anonymousId.value = defaultUserSessionValues.anonymousId;
-        }
+        // This will generate a new anonymous ID
+        this.setAnonymousId();
       }
 
       if (noNewSessionStart) {


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-738/fix-empty-anonymousid-after-reset-call

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
