### PR TITLE
Add explicit export for bundled package

### DIFF
--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js",
-  "version": "3.0.0-beta.12",
+  "version": "3.0.0-beta.13",
   "description": "RudderStack Javascript SDK",
   "main": "dist/npm/modern/cjs/index.js",
   "module": "dist/npm/modern/esm/index.js",
@@ -16,6 +16,11 @@
       "import": "./dist/npm/legacy/esm/index.js"
     },
     "./bundled": {
+      "types": "./dist/npm/index.d.ts",
+      "require": "./dist/npm/modern/bundled/cjs/index.js",
+      "import": "./dist/npm/modern/bundled/esm/index.js"
+    },
+    "./dist/npm/modern/bundled/esm": {
       "types": "./dist/npm/index.d.ts",
       "require": "./dist/npm/modern/bundled/cjs/index.js",
       "import": "./dist/npm/modern/bundled/esm/index.js"


### PR DESCRIPTION
## PR Description

Adds an explicit export to `analytics-js/package.json` that works properly with NX monorepos (due to them not appearing to properly handle aliased exports). This is entirely additive and should not affect existing versions when using `@rudderstack/analytics-js/bundled` but provides a workaround for people using Next.js with NX.

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] IE11 (on a Mac, don't have an easy way to test IE11. And come on, IE11? Really? ;) )

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
