### PR TITLE
ci(monorepo): fix github runners for deploy actions

### DIFF
--- a/.github/workflows/deploy-beta-v3.yml
+++ b/.github/workflows/deploy-beta-v3.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   deploy-tag:
     name: Deploy BETA/BugBash Feature v3
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/beta/') || startsWith(github.ref, 'refs/tags/bugbash')
 
     steps:

--- a/.github/workflows/deploy-dev-v3.yml
+++ b/.github/workflows/deploy-dev-v3.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   deploy-tag:
     name: Deploy to DEV v3
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/v3-hotfix/') || startsWith(github.ref, 'refs/heads/develop/') || github.event.pull_request.merged == true
 
     steps:

--- a/.github/workflows/deploy-npm-v3.yml
+++ b/.github/workflows/deploy-npm-v3.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   deploy-tag:
     name: Deploy to NPM v3
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main') || github.event.pull_request.merged == true
 
     steps:

--- a/.github/workflows/deploy-prod-v3.yml
+++ b/.github/workflows/deploy-prod-v3.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   deploy-tag:
     name: Deploy to PROD v3
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main') || github.event.pull_request.merged == true
 
     steps:

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   deploy-tag:
     name: Deploy Sanity Suite
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Configure AWS Credentials

--- a/.github/workflows/deploy-staging-v3.yml
+++ b/.github/workflows/deploy-staging-v3.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   deploy-tag:
     name: Deploy to STAGING v3
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/v3-hotfix-release') || startsWith(github.ref, 'refs/heads/v3-release') || startsWith(github.ref, 'refs/heads/v3-hotfix/')
 
     steps:

--- a/.github/workflows/publish-new-release-v3.yml
+++ b/.github/workflows/publish-new-release-v3.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   release:
     name: Publish new release v3
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: (startsWith(github.event.pull_request.head.ref, 'v3-release/') || startsWith(github.event.pull_request.head.ref, 'v3-hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
 
     steps:

--- a/.github/workflows/rollback-v3.yml
+++ b/.github/workflows/rollback-v3.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   deploy-tag:
     name: Rollback v3
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main')
 
     steps:

--- a/packages/analytics-js-service-worker/project.json
+++ b/packages/analytics-js-service-worker/project.json
@@ -88,9 +88,7 @@
         "baseBranch": "main",
         "preset": "conventional",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "releaseAs": "prerelease",
-        "preid": "beta"
+        "trackDeps": true
       }
     },
     "github": {


### PR DESCRIPTION
## PR Description

Use default github runners as our organisation self-hosted does not have aws cli.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
