### PR TITLE
feat: auto capture timezone as a part of context

### DIFF
--- a/packages/analytics-js-common/__tests__/utilities/timezone.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/timezone.test.ts
@@ -1,0 +1,9 @@
+import { getTimezone } from '../../src/utilities/timezone';
+
+describe('Common Utils - Timezone', () => {
+  it('should return timezone of the user', () => {
+    const timezone = getTimezone();
+    expect(typeof timezone).toBe('string');
+    expect(timezone.startsWith('GMT')).toBe(true);
+  });
+});

--- a/packages/analytics-js-common/src/types/ApplicationState.ts
+++ b/packages/analytics-js-common/src/types/ApplicationState.ts
@@ -49,6 +49,7 @@ export type ContextState = {
   locale: Signal<Nullable<string>>;
   screen: Signal<ScreenInfo>;
   'ua-ch': Signal<UADataValues | undefined>;
+  timezone: Signal<string | undefined>;
 };
 
 export type EventBufferState = {

--- a/packages/analytics-js-common/src/types/Event.ts
+++ b/packages/analytics-js-common/src/types/Event.ts
@@ -31,6 +31,7 @@ export type RudderContext = {
   screen: ScreenInfo;
   campaign?: UTMParameters;
   trulyAnonymousTracking?: boolean;
+  timezone: string;
 };
 
 export type RudderEvent = {

--- a/packages/analytics-js-common/src/utilities/index.ts
+++ b/packages/analytics-js-common/src/utilities/index.ts
@@ -10,3 +10,4 @@ export * as string from './string';
 export * as timestamp from './timestamp';
 export * as url from './url';
 export * as uuId from './uuId';
+export * as timezone from './timezone';

--- a/packages/analytics-js-common/src/utilities/timezone.ts
+++ b/packages/analytics-js-common/src/utilities/timezone.ts
@@ -1,0 +1,10 @@
+/**
+ * To get the timezone of the user
+ * @returns string
+ */
+const getTimezone = (): string => {
+  const timezone = new Date().toString().match(/([A-Z]+[+-]\d+)/);
+  return timezone && timezone.length > 0 ? timezone[1] : 'NA';
+};
+
+export { getTimezone };

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -252,6 +252,7 @@ describe('Event Manager - Utilities', () => {
         state.context.userAgent.value = 'test';
         state.context.screen.value = { width: 100, height: 100 } as ScreenInfo;
         state.context.os.value = { name: 'test', version: '1.0' } as OSInfo;
+        state.context.timezone.value = 'GMT+0530';
       });
 
       // @ts-ignore
@@ -315,6 +316,7 @@ describe('Event Manager - Utilities', () => {
             mobile: true,
           },
           userAgent: 'test',
+          timezone: 'GMT+0530',
           consentManagement: {
             deniedConsentIds: ['id1', 'id2'],
           },
@@ -975,6 +977,7 @@ describe('Event Manager - Utilities', () => {
         state.context.userAgent.value = 'test';
         state.context.screen.value = { width: 100, height: 100 } as ScreenInfo;
         state.context.os.value = { name: 'test', version: '1.0' } as OSInfo;
+        state.context.timezone.value = 'GMT+0530';
       });
 
       const rudderEvent = {
@@ -1033,6 +1036,7 @@ describe('Event Manager - Utilities', () => {
           'ua-ch': {
             mobile: true,
           },
+          timezone: 'GMT+0530',
         },
         properties: null,
         originalTimestamp: '2020-01-01T00:00:00.000Z',

--- a/packages/analytics-js/src/components/capabilitiesManager/CapabilitiesManager.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/CapabilitiesManager.ts
@@ -9,6 +9,7 @@ import {
   SESSION_STORAGE,
 } from '@rudderstack/analytics-js-common/constants/storages';
 import { CAPABILITIES_MANAGER } from '@rudderstack/analytics-js-common/constants/loggerContexts';
+import { getTimezone } from '@rudderstack/analytics-js-common/utilities/timezone';
 import { POLYFILL_SCRIPT_LOAD_ERROR } from '../../constants/logMessages';
 import { getLanguage, getUserAgent } from '../utilities/page';
 import { getStorageEngine } from '../../services/StoreManager/storages';
@@ -85,6 +86,7 @@ class CapabilitiesManager implements ICapabilitiesManager {
       state.context.userAgent.value = getUserAgent();
       state.context.locale.value = getLanguage();
       state.context.screen.value = getScreenDetails();
+      state.context.timezone.value = getTimezone();
 
       if (hasUAClientHints()) {
         getUserAgentClientHint((uach?: UADataValues) => {

--- a/packages/analytics-js/src/components/eventManager/utilities.ts
+++ b/packages/analytics-js/src/components/eventManager/utilities.ts
@@ -254,6 +254,7 @@ const getEnrichedEvent = (
       screen: state.context.screen.value,
       campaign: extractUTMParameters(globalThis.location.href),
       page: getContextPageProperties(pageProps),
+      timezone: state.context.timezone.value,
     },
     originalTimestamp: getCurrentTimeFormatted(),
     integrations: DEFAULT_INTEGRATIONS_CONFIG,

--- a/packages/analytics-js/src/state/slices/context.ts
+++ b/packages/analytics-js/src/state/slices/context.ts
@@ -29,6 +29,7 @@ const contextState: ContextState = {
     innerHeight: 0,
   }),
   'ua-ch': signal(undefined),
+  timezone: signal(undefined),
 };
 
 export { contextState };

--- a/packages/analytics-v1.1/src/utils/RudderContext.js
+++ b/packages/analytics-v1.1/src/utils/RudderContext.js
@@ -1,4 +1,5 @@
 // Context class
+import { getTimezone } from '@rudderstack/analytics-js-common/utilities/timezone';
 import RudderApp from './RudderApp';
 import { RudderLibraryInfo, RudderOSInfo } from './RudderInfo';
 import { getUserAgent, getLanguage } from './navigator';
@@ -15,6 +16,7 @@ class RudderContext {
     this.os = new RudderOSInfo();
     this.locale = getLanguage();
     this.screen = getScreenDetails();
+    this.timezone = getTimezone();
   }
 }
 


### PR DESCRIPTION
## PR Description

- Auto capture timezone and attach it to event context for v1.1 and v3.
- Following the same format as mobile. Example: "GMT+0530"

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
