### PR TITLE
fix(analytics-js): fix remote import error when imported with webpack

### DIFF
--- a/examples/nextjs/hooks/sample-app/src/app/useRudderAnalytics.ts
+++ b/examples/nextjs/hooks/sample-app/src/app/useRudderAnalytics.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { type RudderAnalytics } from '@rudderstack/analytics-js';
+import type { RudderAnalytics } from '@rudderstack/analytics-js';
 
 const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
   const [analytics, setAnalytics] = useState<RudderAnalytics>();
@@ -7,7 +7,7 @@ const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
   useEffect(() => {
     if (!analytics) {
       const initialize = async () => {
-        const { RudderAnalytics } = await import('@rudderstack/analytics-js/bundled');
+        const { RudderAnalytics } = await import('@rudderstack/analytics-js');
         const analyticsInstance = new RudderAnalytics();
 
         analyticsInstance.load('<writeKey>', '<dataplaneUrl>');

--- a/examples/nextjs/js/sample-app/src/app/page.js
+++ b/examples/nextjs/js/sample-app/src/app/page.js
@@ -10,7 +10,7 @@ export default function Home() {
     }
 
     const initialize = async () => {
-      const { RudderAnalytics } = await import('@rudderstack/analytics-js/bundled');
+      const { RudderAnalytics } = await import('@rudderstack/analytics-js');
       const analytics = new RudderAnalytics();
 
       analytics.load('<writeKey>', '<dataplaneUrl>');

--- a/examples/nextjs/page-router/sample-app/src/useRudderAnalytics.ts
+++ b/examples/nextjs/page-router/sample-app/src/useRudderAnalytics.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { type RudderAnalytics } from '@rudderstack/analytics-js';
+import type { RudderAnalytics } from '@rudderstack/analytics-js';
 
 const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
   const [analytics, setAnalytics] = useState<RudderAnalytics>();
@@ -7,7 +7,7 @@ const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
   useEffect(() => {
     if (!analytics) {
       const initialize = async () => {
-        const { RudderAnalytics } = await import('@rudderstack/analytics-js/bundled');
+        const { RudderAnalytics } = await import('@rudderstack/analytics-js');
         const analyticsInstance = new RudderAnalytics();
 
         analyticsInstance.load('<writeKey>', '<dataplaneUrl>');

--- a/examples/nextjs/ts/sample-app/src/app/page.tsx
+++ b/examples/nextjs/ts/sample-app/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useEffect } from 'react';
-import { type RudderAnalytics } from "@rudderstack/analytics-js";
+import type { RudderAnalytics } from "@rudderstack/analytics-js";
 
 export default function Home() {
   useEffect(() => {
@@ -10,7 +10,7 @@ export default function Home() {
       return;
     }
     const initialize = async () => {
-      const { RudderAnalytics } = await import('@rudderstack/analytics-js/bundled');
+      const { RudderAnalytics } = await import('@rudderstack/analytics-js');
       const analytics = new RudderAnalytics();
 
       analytics.load('<writeKey>', '<dataplaneUrl>');

--- a/packages/analytics-js-plugins/rollup.config.mjs
+++ b/packages/analytics-js-plugins/rollup.config.mjs
@@ -110,6 +110,7 @@ export function getDefaultConfig(distName) {
         name: modName,
         filename: remotePluginsExportsFilename,
         exposes: pluginsMap,
+        remoteType: 'promise',
       }),
       process.env.UGLIFY === 'true' &&
       terser({

--- a/packages/analytics-js/rollup.config.mjs
+++ b/packages/analytics-js/rollup.config.mjs
@@ -203,8 +203,10 @@ export function getDefaultConfig(distName) {
         remotes: {
           rudderAnalyticsRemotePlugins: {
             // use promise to set the path to allow override via loadOption value in case of proxy
+            // https://github.com/originjs/vite-plugin-federation#externaltype-urlpromise
             external: remotePluginsHostPromise,
-            externalType: 'promise'
+            externalType: 'promise',
+            format: 'esm'
           },
         }
       }),

--- a/packages/sanity-suite/rollup.config.mjs
+++ b/packages/sanity-suite/rollup.config.mjs
@@ -148,8 +148,8 @@ const getBuildConfig = featureName => ({
       FEATURE_DATA_RESIDENCY_WRITE_KEY: process.env.FEATURE_DATA_RESIDENCY_WRITE_KEY,
       DATA_PLANE_URL: process.env.DATAPLANE_URL,
       CONFIG_SERVER_HOST: process.env.CONFIG_SERVER_HOST,
-      APP_DEST_SDK_BASE_URL: getDestinationsURL(),
-      REMOTE_MODULES_BASE_PATH: process.env.REMOTE_MODULES_BASE_PATH,
+      APP_DEST_SDK_BASE_URL: getDestinationsURL() || '',
+      REMOTE_MODULES_BASE_PATH: process.env.REMOTE_MODULES_BASE_PATH || '',
       CDN_VERSION_PATH:
         `${process.env.STAGING ? 'staging/latest/' : ''}${process.env.CDN_VERSION_PATH || defaultVersion}/` || '',
       FEATURE: featureName,

--- a/packages/sanity-suite/src/index-npm.ts
+++ b/packages/sanity-suite/src/index-npm.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { RudderAnalytics, LoadOptions } from '@rudderstack/analytics-js/legacy';
+import { RudderAnalytics, type LoadOptions } from '@rudderstack/analytics-js/legacy';
 import { initSanitySuite } from './testBook';
 
 const getWriteKey = () => {
@@ -25,6 +25,7 @@ const getLoadOptions = (): Partial<LoadOptions> => {
         configUrl: 'CONFIG_SERVER_HOST',
         lockIntegrationsVersion: true,
         destSDKBaseURL: 'APP_DEST_SDK_BASE_URL',
+        pluginsSDKBaseURL: 'REMOTE_MODULES_BASE_PATH',
         consentManagement: {
           enabled: true,
           provider: 'oneTrust',
@@ -33,12 +34,14 @@ const getLoadOptions = (): Partial<LoadOptions> => {
           migrate: true,
         },
       };
+    // eslint-disable-next-line sonarjs/no-all-duplicated-branches
     case 'preloadBuffer':
       return {
         logLevel: 'DEBUG',
         configUrl: 'CONFIG_SERVER_HOST',
         lockIntegrationsVersion: true,
         destSDKBaseURL: 'APP_DEST_SDK_BASE_URL',
+        pluginsSDKBaseURL: 'REMOTE_MODULES_BASE_PATH',
         consentManagement: {
           enabled: true,
           provider: 'oneTrust',
@@ -54,6 +57,7 @@ const getLoadOptions = (): Partial<LoadOptions> => {
         configUrl: 'CONFIG_SERVER_HOST',
         lockIntegrationsVersion: true,
         destSDKBaseURL: 'APP_DEST_SDK_BASE_URL',
+        pluginsSDKBaseURL: 'REMOTE_MODULES_BASE_PATH',
         consentManagement: {
           enabled: true,
           provider: 'oneTrust',
@@ -69,6 +73,7 @@ const getLoadOptions = (): Partial<LoadOptions> => {
         configUrl: 'CONFIG_SERVER_HOST',
         lockIntegrationsVersion: true,
         destSDKBaseURL: 'APP_DEST_SDK_BASE_URL',
+        pluginsSDKBaseURL: 'REMOTE_MODULES_BASE_PATH',
         consentManagement: {
           enabled: true,
           provider: 'oneTrust',

--- a/patches/@originjs+vite-plugin-federation+1.3.2.patch
+++ b/patches/@originjs+vite-plugin-federation+1.3.2.patch
@@ -1,7 +1,16 @@
 diff --git a/node_modules/@originjs/vite-plugin-federation/dist/index.js b/node_modules/@originjs/vite-plugin-federation/dist/index.js
-index f0d9618..fd3e9d2 100644
+index f0d9618..bc12cba 100644
 --- a/node_modules/@originjs/vite-plugin-federation/dist/index.js
 +++ b/node_modules/@originjs/vite-plugin-federation/dist/index.js
+@@ -378,7 +378,7 @@ function prodRemotePlugin(options) {
+                             return new Promise((resolve, reject) => {
+                                 const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
+                                 getUrl().then(url => {
+-                                    import(/* @vite-ignore */ url).then(lib => {
++                                    import(/* webpackIgnore: true */ /* @vite-ignore */ url).then(lib => {
+                                         if (!remote.inited) {
+                                             const shareScope = wrapShareModule(remote.from)
+                                             lib.init(shareScope);
 @@ -873,12 +873,11 @@ function prodExposePlugin(options) {
      EXPOSES_MAP.set(item[0], exposeFilepath);
      EXPOSES_KEY_MAP.set(
@@ -50,10 +59,37 @@ index f0d9618..fd3e9d2 100644
                `./${slashPath}`
              );
            }
+@@ -1086,7 +1068,7 @@ const loadJS = async (url, fn) => {
+   document.getElementsByTagName('head')[0].appendChild(script);
+ }
+ function get(name, ${REMOTE_FROM_PARAMETER}){
+-  return import(/* @vite-ignore */ name).then(module => ()=> {
++  return import(/* webpackIgnore: true */ /* @vite-ignore */ name).then(module => ()=> {
+     if (${REMOTE_FROM_PARAMETER} === 'webpack') {
+       return Object.prototype.toString.call(module).indexOf('Module') > -1 && module.default ? module.default : module
+     }
+@@ -1120,7 +1102,7 @@ async function __federation_method_ensure(remoteId) {
+       return new Promise((resolve, reject) => {
+         const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
+         getUrl().then(url => {
+-          import(/* @vite-ignore */ url).then(lib => {
++          import(/* webpackIgnore: true */ /* @vite-ignore */ url).then(lib => {
+             if (!remote.inited) {
+               const shareScope = wrapShareScope(remote.from)
+               lib.init(shareScope);
 diff --git a/node_modules/@originjs/vite-plugin-federation/dist/index.mjs b/node_modules/@originjs/vite-plugin-federation/dist/index.mjs
-index b040304..c9df1b3 100644
+index b040304..132fa3b 100644
 --- a/node_modules/@originjs/vite-plugin-federation/dist/index.mjs
 +++ b/node_modules/@originjs/vite-plugin-federation/dist/index.mjs
+@@ -361,7 +361,7 @@ function prodRemotePlugin(options) {
+                             return new Promise((resolve, reject) => {
+                                 const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
+                                 getUrl().then(url => {
+-                                    import(/* @vite-ignore */ url).then(lib => {
++                                    import(/* webpackIgnore: true */ /* @vite-ignore */ url).then(lib => {
+                                         if (!remote.inited) {
+                                             const shareScope = wrapShareModule(remote.from)
+                                             lib.init(shareScope);
 @@ -856,12 +856,11 @@ function prodExposePlugin(options) {
      EXPOSES_MAP.set(item[0], exposeFilepath);
      EXPOSES_KEY_MAP.set(
@@ -102,3 +138,21 @@ index b040304..c9df1b3 100644
                `./${slashPath}`
              );
            }
+@@ -1069,7 +1051,7 @@ const loadJS = async (url, fn) => {
+   document.getElementsByTagName('head')[0].appendChild(script);
+ }
+ function get(name, ${REMOTE_FROM_PARAMETER}){
+-  return import(/* @vite-ignore */ name).then(module => ()=> {
++  return import(/* webpackIgnore: true */ /* @vite-ignore */ name).then(module => ()=> {
+     if (${REMOTE_FROM_PARAMETER} === 'webpack') {
+       return Object.prototype.toString.call(module).indexOf('Module') > -1 && module.default ? module.default : module
+     }
+@@ -1103,7 +1085,7 @@ async function __federation_method_ensure(remoteId) {
+       return new Promise((resolve, reject) => {
+         const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
+         getUrl().then(url => {
+-          import(/* @vite-ignore */ url).then(lib => {
++          import(/* webpackIgnore: true */ /* @vite-ignore */ url).then(lib => {
+             if (!remote.inited) {
+               const shareScope = wrapShareScope(remote.from)
+               lib.init(shareScope);


### PR DESCRIPTION
## PR Description

Allow the remote imports for federated modules to work when the SDK is used in an app that uses webpack as bundler

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-629/modern-bundling-does-not-work-with-webpack)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] IE11

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
