### PR TITLE
feat: VWO integration update

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/VWO/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/utils.js
@@ -14,4 +14,29 @@ import {
 const getDestinationOptions = integrationsOptions =>
   integrationsOptions && (integrationsOptions[DISPLAY_NAME] || integrationsOptions[NAME]);
 
-export { getDestinationOptions };
+/**
+ * Sanitizes the given event name by trimming any leading or trailing whitespace and prefixing it with "rudder.".
+ *
+ * @param {string} eventName - The event name to be sanitized.
+ * @return {string} The sanitized event name.
+ */
+const sanitizeName = eventName => {
+  return `rudder.${eventName.trim()}`;
+};
+
+/**
+ * Sanitizes the properties object by formatting the keys and returning a new object with the formatted keys.
+ *
+ * @param {object} properties - The properties object to be sanitized.
+ * @return {object} - The sanitized properties object with formatted keys.
+ */
+const sanitizeAttributes = attributes => {
+  const formattedAttributes = {};
+  for (const key in attributes) {
+    const formattedKey = sanitizeName(key);
+    formattedAttributes[formattedKey] = attributes[key];
+  }
+  return formattedAttributes;
+};
+
+export { getDestinationOptions, sanitizeName, sanitizeAttributes };


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

Support added for streaming RudderStack events to VWO so that they can be used in VWO Campaigns.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

I am unsure about how to test an integration. Could not find the same in the Repo Docs. Any help here is appreciated.

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Security

- [X] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
