### PR TITLE
fix: storage migration to allow empty string values

### DIFF
--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1,10 +1,11 @@
+import type { IPluginsManager } from '@rudderstack/analytics-js-common/types/PluginsManager';
 import { UserSessionManager } from '../../../src/components/userSessionManager';
 import {
   defaultUserSessionValues,
   userSessionStorageKeys,
 } from '../../../src/components/userSessionManager/userSessionStorageKeys';
 import { StoreManager } from '../../../src/services/StoreManager';
-import { Store } from '../../../src/services/StoreManager/Store';
+import type { Store } from '../../../src/services/StoreManager/Store';
 import { state, resetState } from '../../../src/state';
 import { DEFAULT_SESSION_TIMEOUT_MS } from '../../../src/constants/timeouts';
 import { defaultLogger } from '../../../src/services/Logger';
@@ -27,6 +28,8 @@ jest.mock('@rudderstack/analytics-js-common/utilities/uuId', () => ({
 describe('User session manager', () => {
   const dummyAnonymousId = 'dummy-anonymousId-12345678';
   defaultLogger.warn = jest.fn();
+  defaultLogger.error = jest.fn();
+
   const defaultPluginsManager = new PluginsManager(
     defaultPluginEngine,
     defaultErrorHandler,
@@ -594,6 +597,8 @@ describe('User session manager', () => {
       // V3 encrypted
       rl_page_init_referrer:
         'RS_ENC_v3_Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMS9jZG4vbW9kZXJuL2lpZmUvaW5kZXguaHRtbCI%3D', // '"$direct"
+      // empty string
+      rl_group_id: 'RudderEncrypt%3AU2FsdGVkX19AHpnwm%2FJMyd%2Bu1Vq88KBjUYM0AsZnu8Q%3D', // '""'
     };
 
     setCustomValuesInStorageEngine(customData);
@@ -604,62 +609,83 @@ describe('User session manager', () => {
 
     defaultPluginsManager.init();
 
-    const invokeSpy = jest.spyOn(defaultPluginsManager, 'invokeSingle');
-    const extentionPoint = 'storage.migrate';
+    class MockPluginsManager implements IPluginsManager {
+      invokeSingle = jest.fn(() => ''); // always return empty string
+    }
+
+    const mockPluginsManager = new MockPluginsManager();
+
+    const storeManager = new StoreManager(
+      defaultPluginsManager,
+      defaultErrorHandler,
+      defaultLogger,
+    );
+
+    storeManager.init();
+
+    userSessionManager = new UserSessionManager(
+      defaultErrorHandler,
+      defaultLogger,
+      mockPluginsManager,
+      storeManager,
+    );
+
+    const invokeSpy = mockPluginsManager.invokeSingle;
+    const extensionPoint = 'storage.migrate';
 
     userSessionManager.init();
 
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_user_id',
       clientDataStoreCookie.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_trait',
       clientDataStoreCookie.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_anonymous_id',
       clientDataStoreCookie.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_group_id',
       clientDataStoreCookie.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_group_trait',
       clientDataStoreCookie.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_page_init_referrer',
       clientDataStoreCookie.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_page_init_referring_domain',
       clientDataStoreCookie.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_session',
       clientDataStoreCookie.engine,
       defaultErrorHandler,
@@ -667,56 +693,56 @@ describe('User session manager', () => {
     );
 
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_user_id',
       clientDataStoreLS.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_trait',
       clientDataStoreLS.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_anonymous_id',
       clientDataStoreLS.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_group_id',
       clientDataStoreLS.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_group_trait',
       clientDataStoreLS.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_page_init_referrer',
       clientDataStoreLS.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_page_init_referring_domain',
       clientDataStoreLS.engine,
       defaultErrorHandler,
       defaultLogger,
     );
     expect(invokeSpy).toHaveBeenCalledWith(
-      extentionPoint,
+      extensionPoint,
       'rl_session',
       clientDataStoreLS.engine,
       defaultErrorHandler,
@@ -733,5 +759,7 @@ describe('User session manager', () => {
     expect(state.session.initialReferrer.value).toBe('$direct');
     expect(state.session.initialReferringDomain.value).toBe('');
     expect(state.session.sessionInfo.value).not.toBeUndefined();
+
+    expect(defaultLogger.error).not.toHaveBeenCalled();
   });
 });

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -7,6 +7,7 @@ import {
 } from '@rudderstack/analytics-js-common/utilities/object';
 import {
   isDefinedNotNullAndNotEmptyString,
+  isNullOrUndefined,
   isString,
 } from '@rudderstack/analytics-js-common/utilities/checks';
 import type { IPluginsManager } from '@rudderstack/analytics-js-common/types/PluginsManager';
@@ -189,7 +190,11 @@ class UserSessionManager implements IUserSessionManager {
           this.errorHandler,
           this.logger,
         );
-        if (migratedVal) {
+
+        // Skip setting the value if it is null or undefined
+        // as those values indicate there is no need for migration or
+        // migration failed
+        if (!isNullOrUndefined(migratedVal)) {
           store.set(storageEntry, migratedVal);
         }
       });


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-822/storage-migration-skips-empty-entries-leading-to-unwanted-errors-on

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
