### PR TITLE
feat: buffer consent method invocations

### DIFF
--- a/packages/analytics-js/.size-limit.js
+++ b/packages/analytics-js/.size-limit.js
@@ -13,24 +13,24 @@ module.exports = [
     name: 'Core CJS - NPM',
     path: 'dist/npm/modern/cjs/index.js',
     gzip: true,
-    limit: '25 KiB',
+    limit: '25.5 KiB',
   },
   {
     name: 'Core - NPM',
     path: 'dist/npm/modern/umd/index.js',
     gzip: true,
-    limit: '25 KiB',
+    limit: '25.5 KiB',
   },
   {
     name: 'Core Legacy - CDN',
     path: 'dist/cdn/legacy/iife/rsa.min.js',
     gzip: true,
-    limit: '50 KiB',
+    limit: '51 KiB',
   },
   {
     name: 'Core - CDN',
     path: 'dist/cdn/modern/iife/rsa.min.js',
     gzip: true,
-    limit: '25 KiB',
+    limit: '25.5 KiB',
   },
 ];

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -232,7 +232,6 @@ describe('Core - Rudder Analytics Facade', () => {
   it('should retrieve all preloaded events and set to global', () => {
     expect((window as any).RudderStackGlobals.app.preloadedEventsBuffer).toEqual([
       ['track'],
-      ['load', { option1: true }],
       ['track'],
     ]);
   });

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -16,7 +16,13 @@ describe('Core - Rudder Analytics Facade', () => {
   beforeEach(() => {
     Analytics.mockClear();
     analyticsInstanceMock = new Analytics() as jest.Mocked<Analytics>;
-    (window as any).rudderanalytics = [['track'], ['load', { option1: true }], ['track']];
+    (window as any).rudderanalytics = [
+      ['track'],
+      ['consent', { sendPageEvent: true }],
+      ['load', { option1: true }],
+      ['consent', { sendPageEvent: false }],
+      ['track'],
+    ];
     rudderAnalytics = new RudderAnalytics();
     (rudderAnalytics as any).analyticsInstances = { writeKey: analyticsInstanceMock };
     (rudderAnalytics as any).defaultAnalyticsKey = 'writeKey';
@@ -231,6 +237,8 @@ describe('Core - Rudder Analytics Facade', () => {
 
   it('should retrieve all preloaded events and set to global', () => {
     expect((window as any).RudderStackGlobals.app.preloadedEventsBuffer).toEqual([
+      ['consent', { sendPageEvent: true }],
+      ['consent', { sendPageEvent: false }],
       ['track'],
       ['track'],
     ]);

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -538,26 +538,6 @@ describe('Core - Analytics', () => {
             },
           },
         },
-        storage: {
-          type: 'cookieStorage',
-          entries: {
-            userId: {
-              type: 'sessionStorage',
-            },
-            userTraits: {
-              type: 'localStorage',
-            },
-            groupId: {
-              type: 'memoryStorage',
-            },
-            groupTraits: {
-              type: 'memoryStorage',
-            },
-            authToken: {
-              type: 'none',
-            },
-          },
-        },
       });
 
       expect(state.consents.initialized.value).toBe(false);

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -596,5 +596,29 @@ describe('Core - Analytics', () => {
       expect(trackSpy).toHaveBeenCalled();
       expect(pageSpy).toHaveBeenCalled();
     });
+
+    it('should add consent auto tracking events to the end of the buffered events', () => {
+      analytics.prepareInternalServices();
+
+      state.eventBuffer.toBeProcessedArray.value = [['identify', { userId: 'test_user_id' }]];
+
+      state.consents.enabled.value = true;
+      state.lifecycle.loaded.value = true;
+      state.consents.initialized.value = false;
+
+      analytics.consent(
+        {
+          sendPageEvent: true,
+          trackConsent: true,
+        },
+        true,
+      ); // Send true to mimic buffered invocation
+
+      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
+        ['identify', { userId: 'test_user_id' }],
+        ['track', { name: 'Consent Management Interaction', properties: {} }],
+        ['page', { properties: { category: null, name: null } }],
+      ]);
+    });
   });
 });

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -441,10 +441,18 @@ describe('Core - Analytics', () => {
   });
 
   describe('consent', () => {
+    it('should buffer methods until loaded', () => {
+      analytics.consent({ sendPageEvent: true });
+      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
+        ['consent', { sendPageEvent: true }],
+      ]);
+    });
+
     it('should resume SDK processing on consent', () => {
       analytics.prepareInternalServices();
 
       state.consents.enabled.value = true;
+      state.lifecycle.loaded.value = true;
       state.consents.initialized.value = false;
       state.storage.type.value = 'localStorage';
       state.storage.entries.value = entriesWithMixStorage;
@@ -472,26 +480,6 @@ describe('Core - Analytics', () => {
         consentManagement: {
           provider: 'custom',
           enabled: true,
-        },
-        storage: {
-          type: 'cookieStorage',
-          entries: {
-            userId: {
-              type: 'sessionStorage',
-            },
-            userTraits: {
-              type: 'localStorage',
-            },
-            groupId: {
-              type: 'memoryStorage',
-            },
-            groupTraits: {
-              type: 'memoryStorage',
-            },
-            authToken: {
-              type: 'none',
-            },
-          },
         },
         storage: {
           type: 'cookieStorage',
@@ -579,7 +567,7 @@ describe('Core - Analytics', () => {
       });
 
       expect(leaveBreadcrumbSpy).toHaveBeenCalledWith('New consent invocation');
-      expect(invokeSingleSpy).toHaveBeenCalledTimes(2); // 1 for consents data fetch and other for setting active destinations
+      expect(invokeSingleSpy).toHaveBeenCalledTimes(6); // 1 for consents data fetch and other for setting active destinations, 2 x 2 for queueing consent track and page events to event queue plugins
       expect(initializeStorageStateSpy).toHaveBeenCalledTimes(1);
       expect(syncStorageDataToStateSpy).toHaveBeenCalledTimes(1);
       expect(resumeSpy).toHaveBeenCalledTimes(1);

--- a/packages/analytics-js/__tests__/components/preloadBuffer/index.test.ts
+++ b/packages/analytics-js/__tests__/components/preloadBuffer/index.test.ts
@@ -78,7 +78,7 @@ describe('Preload Buffer', () => {
     window.location.href = testUrlParams;
     (window as any).RudderStackGlobals = {
       app: {
-        preloadedEventsBuffer: [['track'], ['load', { option1: true }], ['track']],
+        preloadedEventsBuffer: [['track'], ['track']],
       },
     };
 

--- a/packages/analytics-js/__tests__/components/preloadBuffer/index.test.ts
+++ b/packages/analytics-js/__tests__/components/preloadBuffer/index.test.ts
@@ -1,6 +1,7 @@
 import {
   getEventDataFromQueryString,
   getPreloadedLoadEvent,
+  promotePreloadedConsentEventsToTop,
   retrieveEventsFromQueryString,
   retrievePreloadBufferEvents,
 } from '../../../src/components/preloadBuffer';
@@ -78,7 +79,7 @@ describe('Preload Buffer', () => {
     window.location.href = testUrlParams;
     (window as any).RudderStackGlobals = {
       app: {
-        preloadedEventsBuffer: [['track'], ['track']],
+        preloadedEventsBuffer: [['consent'], ['track'], ['track']],
       },
     };
 
@@ -89,6 +90,7 @@ describe('Preload Buffer', () => {
       ['setAnonymousId', 'asdfghjkl'],
       ['identify', 'qzxcvbnm', { dummy1: 'true' }],
       ['track', 'dummyName', { dummy: 'true' }],
+      ['consent'],
       ['track'],
       ['track'],
     ]);
@@ -106,5 +108,23 @@ describe('Preload Buffer', () => {
 
     expect(analytics.enqueuePreloadBufferEvents).toHaveBeenCalledTimes(0);
     expect(analytics.load).toHaveBeenCalledTimes(0);
+  });
+
+  it('should promote consent events to top if they exist in the preloaded events array', () => {
+    const argumentsArray: PreloadedEventCall[] = [
+      ['track'],
+      ['consent', { option1: true }],
+      ['track'],
+      ['consent', { option1: false }],
+    ];
+
+    promotePreloadedConsentEventsToTop(argumentsArray);
+
+    expect(argumentsArray).toStrictEqual([
+      ['consent', { option1: true }],
+      ['consent', { option1: false }],
+      ['track'],
+      ['track'],
+    ]);
   });
 });

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -690,6 +690,13 @@ class Analytics implements IAnalytics {
   }
 
   consent(options?: ConsentOptions) {
+    const type = 'consent';
+
+    if (!state.lifecycle.loaded.value) {
+      state.eventBuffer.toBeProcessedArray.value.push([type, options]);
+      return;
+    }
+
     this.errorHandler.leaveBreadcrumb(`New consent invocation`);
 
     batch(() => {

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -124,32 +124,32 @@ export interface IAnalytics {
   /**
    * To register a callback for SDK ready state
    */
-  ready(callback: ApiCallback): void;
+  ready(callback: ApiCallback, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a page view event
    */
-  page(pageOptions: PageCallOptions): void;
+  page(pageOptions: PageCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user track event
    */
-  track(trackCallOptions: TrackCallOptions): void;
+  track(trackCallOptions: TrackCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user identification event
    */
-  identify(identifyCallOptions: IdentifyCallOptions): void;
+  identify(identifyCallOptions: IdentifyCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user alias event
    */
-  alias(aliasCallOptions: AliasCallOptions): void;
+  alias(aliasCallOptions: AliasCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user group event
    */
-  group(groupCallOptions: GroupCallOptions): void;
+  group(groupCallOptions: GroupCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To get anonymousId set in the SDK
@@ -159,12 +159,16 @@ export interface IAnalytics {
   /**
    * To set anonymousId
    */
-  setAnonymousId(anonymousId?: string, rudderAmpLinkerParam?: string): void;
+  setAnonymousId(
+    anonymousId?: string,
+    rudderAmpLinkerParam?: string,
+    isBufferedInvocation?: boolean,
+  ): void;
 
   /**
    * Clear user information, optionally anonymousId as well
    */
-  reset(resetAnonymousId?: boolean): void;
+  reset(resetAnonymousId?: boolean, isBufferedInvocation?: boolean): void;
 
   /**
    * To get userId set in the SDK
@@ -189,12 +193,12 @@ export interface IAnalytics {
   /**
    * To manually start user session in the SDK
    */
-  startSession(sessionId?: number): void;
+  startSession(sessionId?: number, isBufferedInvocation?: boolean): void;
 
   /**
    * To manually end user session in the SDK
    */
-  endSession(): void;
+  endSession(isBufferedInvocation?: boolean): void;
 
   /**
    * To fetch the current sessionId
@@ -205,7 +209,7 @@ export interface IAnalytics {
    * To record consent
    * @param options Consent API options
    */
-  consent(options?: ConsentOptions): void;
+  consent(options?: ConsentOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To set auth token

--- a/packages/sanity-suite/__fixtures__/alias1.json
+++ b/packages/sanity-suite/__fixtures__/alias1.json
@@ -110,7 +110,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/alias2.json
+++ b/packages/sanity-suite/__fixtures__/alias2.json
@@ -72,7 +72,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/alias5.json
+++ b/packages/sanity-suite/__fixtures__/alias5.json
@@ -78,7 +78,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/alias6.json
+++ b/packages/sanity-suite/__fixtures__/alias6.json
@@ -110,7 +110,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/eventFiltering1.json
+++ b/packages/sanity-suite/__fixtures__/eventFiltering1.json
@@ -72,7 +72,10 @@
       },
       "channel": "random",
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/eventFiltering2.json
+++ b/packages/sanity-suite/__fixtures__/eventFiltering2.json
@@ -72,7 +72,10 @@
       },
       "channel": "random",
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/group1.json
+++ b/packages/sanity-suite/__fixtures__/group1.json
@@ -73,7 +73,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/group2.json
+++ b/packages/sanity-suite/__fixtures__/group2.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/group4.json
+++ b/packages/sanity-suite/__fixtures__/group4.json
@@ -73,7 +73,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/group5.json
+++ b/packages/sanity-suite/__fixtures__/group5.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/group6.json
+++ b/packages/sanity-suite/__fixtures__/group6.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/identify1.json
+++ b/packages/sanity-suite/__fixtures__/identify1.json
@@ -110,7 +110,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/identify2.json
+++ b/packages/sanity-suite/__fixtures__/identify2.json
@@ -78,7 +78,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/identify3.json
+++ b/packages/sanity-suite/__fixtures__/identify3.json
@@ -73,7 +73,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/identify4.json
+++ b/packages/sanity-suite/__fixtures__/identify4.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/identify5.json
+++ b/packages/sanity-suite/__fixtures__/identify5.json
@@ -78,7 +78,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/identify6.json
+++ b/packages/sanity-suite/__fixtures__/identify6.json
@@ -79,7 +79,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/identify7.json
+++ b/packages/sanity-suite/__fixtures__/identify7.json
@@ -78,7 +78,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/identify8.json
+++ b/packages/sanity-suite/__fixtures__/identify8.json
@@ -79,7 +79,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/page1.json
+++ b/packages/sanity-suite/__fixtures__/page1.json
@@ -72,7 +72,10 @@
       },
       "channel": "random",
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/page2.json
+++ b/packages/sanity-suite/__fixtures__/page2.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/page4.json
+++ b/packages/sanity-suite/__fixtures__/page4.json
@@ -72,7 +72,10 @@
       },
       "channel": "random",
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/page5.json
+++ b/packages/sanity-suite/__fixtures__/page5.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/page6.json
+++ b/packages/sanity-suite/__fixtures__/page6.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/page7.json
+++ b/packages/sanity-suite/__fixtures__/page7.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/page8.json
+++ b/packages/sanity-suite/__fixtures__/page8.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/page9.json
+++ b/packages/sanity-suite/__fixtures__/page9.json
@@ -108,7 +108,10 @@
       },
       "channel": "random",
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/track1.json
+++ b/packages/sanity-suite/__fixtures__/track1.json
@@ -108,7 +108,10 @@
       },
       "channel": "random",
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/track2.json
+++ b/packages/sanity-suite/__fixtures__/track2.json
@@ -78,7 +78,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/track4.json
+++ b/packages/sanity-suite/__fixtures__/track4.json
@@ -108,7 +108,10 @@
       },
       "channel": "random",
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/track5.json
+++ b/packages/sanity-suite/__fixtures__/track5.json
@@ -78,7 +78,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/track6.json
+++ b/packages/sanity-suite/__fixtures__/track6.json
@@ -41,7 +41,10 @@
         "initial_referring_domain": ""
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530"
     },

--- a/packages/sanity-suite/__fixtures__/track7.json
+++ b/packages/sanity-suite/__fixtures__/track7.json
@@ -8,7 +8,10 @@
         "version": "2.22.2"
       },
       "consentManagement": {
-        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"]
+        "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
+        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "provider": "oneTrust",
+        "resolutionStrategy": "and"
       },
       "timezone": "GMT+0530",
       "traits": {},

--- a/packages/sanity-suite/src/ignoredProperties/ignoredProperties.js
+++ b/packages/sanity-suite/src/ignoredProperties/ignoredProperties.js
@@ -161,6 +161,18 @@ const ignoredProperties = [
     key: `message.context.timezone`,
     type: 'string',
   },
+  {
+    key: `message.context.consentManagement.allowedConsentIds`,
+    optional: true,
+  },
+  {
+    key: `message.context.consentManagement.provider`,
+    optional: true,
+  },
+  {
+    key: `message.context.consentManagement.resolutionStrategy`,
+    optional: true,
+  },
 ];
 
 export { ignoredProperties };


### PR DESCRIPTION
## PR Description

Consent API invocations are now buffered.
- `consent` method invocations are promoted to the beginning of the buffered queue.
- Buffer events processing logic is altered a bit to accommodate the special needs of the consent API.
  - We want the `consent` preloaded events to be executed first, but the automatic track and page events it triggered should be executed immediately.
  - Because some pre-loaded events from the query string API could need to be executed first.
- Fixed the incorrect buffering API methods invocations.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-815/manual-testing-and-test-book-for-gcm-phase-i

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
