### PR TITLE
feat: update tests and send delivery_category as part of contents for Purchase event

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/utils.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/utils.test.js
@@ -1,4 +1,4 @@
-import { buildPayLoad, getHashedStatus } from '../../../src/integrations/FacebookPixel/utils';
+import { buildPayLoad, getHashedStatus, getProductsContentsAndContentIds } from '../../../src/integrations/FacebookPixel/utils';
 
 const blacklistPiiPropertiesMock = [
   {
@@ -735,6 +735,41 @@ describe('buildPayLoad_function', () => {
     );
     expect(payload).toEqual({
       email: 'acb@gmail.com',
+    });
+  });
+
+  it('test getProductsContentsAndContentIds', () => {
+    const products = [
+      {
+        product_id: "prodid1",
+        quantity: 5,
+        price: 55,
+        delivery_category: "in_store",
+      },
+      {
+        product_id: "prodid2",
+        quantity: 7,
+        price: 77,
+        delivery_category: "home_delivery",
+      }
+    ];
+    const payload = getProductsContentsAndContentIds(products, 10, 100);
+    expect(payload).toEqual({
+      contents: [
+        {
+          id: "prodid1",
+          quantity: 5,
+          item_price: 55,
+          delivery_category: "in_store",
+        },
+        {
+          id: "prodid2",
+          quantity: 7,
+          item_price: 77,
+          delivery_category: "home_delivery",
+        }
+      ],
+      contentIds: ["prodid1", "prodid2"],
     });
   });
 });

--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
@@ -120,7 +120,6 @@ class FacebookPixel {
   }
 
   track(rudderElement) {
-    const self = this;
     const { event } = rudderElement.message;
     const properties = eventHelpers.getProperties(rudderElement.message);
     const {
@@ -135,6 +134,7 @@ class FacebookPixel {
       contentName,
       product_id: productId,
       product_name: productName,
+      delivery_category: deliveryCategory
     } = properties;
     let { value, category, currency } = properties;
 
@@ -176,12 +176,12 @@ class FacebookPixel {
       };
 
       this.makeTrackSignalCall(
-        self.pixelId,
+        this.pixelId,
         'ViewContent',
         merge(productInfo, payload),
         derivedEventID,
       );
-      this.makeTrackSignalCalls(self.pixelId, event, legacyTo, derivedEventID, {
+      this.makeTrackSignalCalls(this.pixelId, event, legacyTo, derivedEventID, {
         currency,
         value: revValue,
       });
@@ -199,18 +199,18 @@ class FacebookPixel {
       };
 
       this.makeTrackSignalCall(
-        self.pixelId,
+        this.pixelId,
         eventHelpers.getEventName(event),
         merge(productInfo, payload),
         derivedEventID,
       );
-      this.makeTrackSignalCalls(self.pixelId, event, legacyTo, derivedEventID, {
+      this.makeTrackSignalCalls(this.pixelId, event, legacyTo, derivedEventID, {
         currency,
         value: productInfo.value,
       });
     } else if (event === 'Order Completed') {
       const contentType = getContentType(rudderElement, 'product', this.categoryToContent);
-      const { contents, contentIds } = getProductsContentsAndContentIds(products, quantity, price);
+      const { contents, contentIds } = getProductsContentsAndContentIds(products, quantity, price, deliveryCategory);
 
       // ref: https://developers.facebook.com/docs/meta-pixel/implementation/marketing-api#purchase
       // "trackSingle" feature is :
@@ -227,12 +227,12 @@ class FacebookPixel {
       };
 
       this.makeTrackSignalCall(
-        self.pixelId,
+        this.pixelId,
         'Purchase',
         merge(productInfo, payload),
         derivedEventID,
       );
-      this.makeTrackSignalCalls(self.pixelId, event, legacyTo, derivedEventID, {
+      this.makeTrackSignalCalls(this.pixelId, event, legacyTo, derivedEventID, {
         currency,
         value: revValue,
       });
@@ -248,8 +248,8 @@ class FacebookPixel {
         search_string: query,
       };
 
-      this.makeTrackSignalCall(self.pixelId, 'Search', merge(productInfo, payload), derivedEventID);
-      this.makeTrackSignalCalls(self.pixelId, event, legacyTo, derivedEventID, { currency, value });
+      this.makeTrackSignalCall(this.pixelId, 'Search', merge(productInfo, payload), derivedEventID);
+      this.makeTrackSignalCalls(this.pixelId, event, legacyTo, derivedEventID, { currency, value });
     } else if (event === 'Checkout Started') {
       let contentCategory = category;
       const { contents, contentIds } = getProductsContentsAndContentIds(products, quantity, price);
@@ -268,12 +268,12 @@ class FacebookPixel {
       };
 
       this.makeTrackSignalCall(
-        self.pixelId,
+        this.pixelId,
         'InitiateCheckout',
         merge(productInfo, payload),
         derivedEventID,
       );
-      this.makeTrackSignalCalls(self.pixelId, event, legacyTo, derivedEventID, {
+      this.makeTrackSignalCalls(this.pixelId, event, legacyTo, derivedEventID, {
         currency,
         value: revValue,
       });
@@ -282,14 +282,14 @@ class FacebookPixel {
       if (eventHelpers.isCustomEventNotMapped(standardTo, legacyTo, event)) {
         logger.debug('inside custom not mapped');
         payload.value = revValue;
-        window.fbq('trackSingleCustom', self.pixelId, event, payload, {
+        window.fbq('trackSingleCustom', this.pixelId, event, payload, {
           eventID: derivedEventID,
         });
       } else {
         payload.value = revValue;
         payload.currency = currency;
-        this.makeTrackSignalCalls(self.pixelId, event, standardTo, derivedEventID, payload);
-        this.makeTrackSignalCalls(self.pixelId, event, legacyTo, derivedEventID, {
+        this.makeTrackSignalCalls(this.pixelId, event, standardTo, derivedEventID, payload);
+        this.makeTrackSignalCalls(this.pixelId, event, legacyTo, derivedEventID, {
           currency,
           value: revValue,
         });

--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/utils.js
@@ -219,19 +219,21 @@ const getContentType = (rudderElement, defaultValue, categoryToContent) => {
  * @param {*} products
  * @param {*} quantity
  * @param {*} price
+ * @param {*} [deliveryCategory]
  * @returns
  */
-const getProductsContentsAndContentIds = (products, quantity, price) => {
+const getProductsContentsAndContentIds = (products, quantity, price, deliveryCategory) => {
   const contents = products
     ? products
         .filter(product => product)
-        .map(({ product_id: prodId, sku, id, quantity: productQuantity, price: productPrice }) => {
+        .map(({ product_id: prodId, sku, id, quantity: productQuantity, price: productPrice, delivery_category: prodDeliveryCategory }) => {
           const productId = prodId || sku || id;
           return isDefined(productId)
             ? {
-                id: productId,
-                quantity: productQuantity || quantity || 1,
-                item_price: productPrice || price,
+              id: productId,
+              quantity: productQuantity || quantity || 1,
+              item_price: productPrice || price,
+              delivery_category: prodDeliveryCategory || deliveryCategory,
               }
             : null;
         })


### PR DESCRIPTION
## PR Description

Send delivery_category as part of contents for Purchase(Order completed) event

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
