### PR TITLE
fix(google_ads): removed un used and deprecated flag for google ads

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/GoogleAds/__fixtures__/data.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/GoogleAds/__fixtures__/data.js
@@ -39,7 +39,8 @@ const googleAdsConfigs = [
     disableAdPersonalization: false,
     eventFilteringOption: 'disable',
     sendPageView: true,
-    dynamicRemarketing: false,
+    trackConversions: true,
+    enableConversionEventsFiltering: false,
     eventMappingFromConfig: [
       { from: 'Sign Up', to: 'Signup' },
       { to: 'Lead', from: orderCompleted },
@@ -60,7 +61,8 @@ const googleAdsConfigs = [
     disableAdPersonalization: false,
     eventFilteringOption: 'disable',
     sendPageView: true,
-    dynamicRemarketing: true,
+    trackDynamicRemarketing: true,
+    enableDynamicRemarketingEventsFiltering: false,
     eventMappingFromConfig: [
       { from: 'Sign Up', to: 'Signup' },
       { to: 'Lead', from: orderCompleted },

--- a/packages/analytics-js-integrations/__tests__/integrations/GoogleAds/utils.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/GoogleAds/utils.test.js
@@ -12,32 +12,9 @@ import {
 } from './__fixtures__/data';
 
 describe('GoogleAds utilities shouldSendEvent function tests', () => {
-  // Old Config
-  test('dynamicRemarketing flag disabled', () => {
-    const eventToSend = shouldSendConversionEvent(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      false,
-    );
-    expect(eventToSend).toEqual(true);
-  });
-
-  test('dynamicRemarketing flag enabled', () => {
-    const eventToSend = shouldSendDynamicRemarketingEvent(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
-    );
-    expect(eventToSend).toEqual(true);
-  });
-
   // New Config
   test('event tracking is enabled and event filtering is disabled', () => {
-    const eventToSend = shouldSendConversionEvent(productAdded, true, false, mockEvents, undefined);
+    const eventToSend = shouldSendConversionEvent(productAdded, true, false, mockEvents);
     expect(eventToSend).toEqual(true);
   });
 
@@ -46,8 +23,7 @@ describe('GoogleAds utilities shouldSendEvent function tests', () => {
       'Product Viewed',
       false,
       false,
-      mockEvents,
-      undefined,
+      mockEvents
     );
     expect(eventToSend).toEqual(false);
   });
@@ -57,8 +33,7 @@ describe('GoogleAds utilities shouldSendEvent function tests', () => {
       'Product Added',
       true,
       true,
-      mockEvents,
-      undefined,
+      mockEvents
     );
     expect(eventToSend).toEqual(false);
   });
@@ -68,24 +43,7 @@ describe('GoogleAds utilities shouldSendEvent function tests', () => {
       orderCompleted,
       true,
       true,
-      mockEvents,
-      undefined,
-    );
-    expect(eventToSend).toEqual(true);
-  });
-
-  test('when both config (new + old) is present, new config should be given first priority', () => {
-    const eventToSend = shouldSendConversionEvent('Cart Checkout', true, true, mockEvents, false);
-    expect(eventToSend).toEqual(false);
-  });
-
-  test('when both config (new + old) is present, new config should be given first priority', () => {
-    const eventToSend = shouldSendDynamicRemarketingEvent(
-      orderCompleted,
-      true,
-      true,
-      mockEvents,
-      true,
+      mockEvents
     );
     expect(eventToSend).toEqual(true);
   });

--- a/packages/analytics-js-integrations/src/integrations/GoogleAds/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/GoogleAds/browser.js
@@ -22,7 +22,6 @@ class GoogleAds {
     }
     this.analytics = analytics;
     this.conversionId = config.conversionID;
-    this.pageLoadConversions = config.pageLoadConversions;
     this.clickEventConversions = config.clickEventConversions;
     this.defaultPageConversion = config.defaultPageConversion;
     this.sendPageView = config.sendPageView || true;
@@ -37,8 +36,6 @@ class GoogleAds {
     this.eventsToTrackDynamicRemarketing = config.eventsToTrackDynamicRemarketing || [];
     this.eventMappingFromConfig = config.eventMappingFromConfig;
     this.enableConversionLabel = config.enableConversionLabel || false;
-    // Depreciating: Added to make changes backward compatible
-    this.dynamicRemarketing = config.dynamicRemarketing;
     this.allowEnhancedConversions = config.allowEnhancedConversions || false;
     this.name = NAME;
     ({
@@ -101,8 +98,7 @@ class GoogleAds {
         event,
         this.trackConversions,
         this.enableConversionEventsFiltering,
-        this.eventsToTrackConversions,
-        this.dynamicRemarketing,
+        this.eventsToTrackConversions
       )
     ) {
       const { conversionLabel } = conversionData;
@@ -132,8 +128,7 @@ class GoogleAds {
         event,
         this.trackDynamicRemarketing,
         this.enableDynamicRemarketingEventsFiltering,
-        this.eventsToTrackDynamicRemarketing,
-        this.dynamicRemarketing,
+        this.eventsToTrackDynamicRemarketing
       )
     ) {
       // modify the event name to mapped event name from the config
@@ -179,8 +174,7 @@ class GoogleAds {
         name,
         this.trackConversions,
         this.enableConversionEventsFiltering,
-        this.eventsToTrackConversions,
-        this.dynamicRemarketing,
+        this.eventsToTrackConversions
       )
     ) {
       const { conversionLabel } = conversionData;
@@ -202,8 +196,7 @@ class GoogleAds {
         name,
         this.trackDynamicRemarketing,
         this.enableDynamicRemarketingEventsFiltering,
-        this.eventsToTrackDynamicRemarketing,
-        this.dynamicRemarketing,
+        this.eventsToTrackDynamicRemarketing
       )
     ) {
       const event = name;

--- a/packages/analytics-js-integrations/src/integrations/GoogleAds/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/GoogleAds/utils.js
@@ -46,8 +46,7 @@ function shouldSendConversionEvent(
   eventName,
   trackConversions,
   enableConversionEventsFiltering,
-  eventsToTrackConversions,
-  dynamicRemarketing,
+  eventsToTrackConversions
 ) {
   if (isDefinedAndNotNull(trackConversions)) {
     return shouldSendEvent(
@@ -57,7 +56,7 @@ function shouldSendConversionEvent(
       eventsToTrackConversions,
     );
   }
-  return !dynamicRemarketing;
+  return false;
 }
 
 /**
@@ -73,8 +72,7 @@ function shouldSendDynamicRemarketingEvent(
   eventName,
   trackDynamicRemarketing,
   enableDynamicRemarketingEventsFiltering,
-  eventsToTrackDynamicRemarketing,
-  dynamicRemarketing,
+  eventsToTrackDynamicRemarketing
 ) {
   if (isDefinedAndNotNull(trackDynamicRemarketing)) {
     return shouldSendEvent(
@@ -84,7 +82,7 @@ function shouldSendDynamicRemarketingEvent(
       eventsToTrackDynamicRemarketing,
     );
   }
-  return dynamicRemarketing;
+  return false;
 }
 
 /**


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
