### PR TITLE
fix: add eventName undefined or null validation for VWO destination

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/VWO/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/VWO/browser.test.js
@@ -56,6 +56,24 @@ describe('VWO Track Event', () => {
     });
   });
 
+  test('Testing Track Events without event', () => {
+    try {
+      mockVWO.track({
+        message: {
+          context: {},
+          properties: {
+            order_id: '140021222',
+            products: 'sports_shoes',
+            revenue: 77.95,
+            currency: 'USD',
+          },
+        },
+      });
+    } catch (error) {
+      expect(error).toEqual('Event name is required');
+    }
+  });
+
   test('Track call without parameters', async () => {
     mockVWO.init();
     mockVWO.track({

--- a/packages/analytics-js-integrations/src/integrations/VWO/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/browser.js
@@ -47,8 +47,8 @@ class VWO {
     window.VWO.event = window.VWO.event || function (...args) {
         window.VWO.push(['event', ...args]);
     };
- 
-    
+
+
     window.VWO.visitor = window.VWO.visitor || function (...args) {
         window.VWO.push(['visitor', ...args]);
     };
@@ -122,6 +122,10 @@ class VWO {
   track(rudderElement) {
     logger.debug('===In VWO track===');
     const eventName = rudderElement.message.event;
+    if (!eventName) {
+      logger.error('Event name is required');
+      return;
+    }
     const properties = (rudderElement.message && rudderElement.message.properties) || {};
     window.VWO = window.VWO || [];
     if (eventName === 'Order Completed') {


### PR DESCRIPTION
## PR Description

Added validation for eventName being null or undefined.
https://app.squadcast.com/incident/65542be4de34f1b4386d3a00

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
