### PR TITLE
fix: add eventName undefined or null validation for VWO destination

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/VWO/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/VWO/browser.test.js
@@ -56,6 +56,24 @@ describe('VWO Track Event', () => {
     });
   });
 
+  test('Testing Track Events without event', () => {
+    try {
+      mockVWO.track({
+        message: {
+          context: {},
+          properties: {
+            order_id: '140021222',
+            products: 'sports_shoes',
+            revenue: 77.95,
+            currency: 'USD',
+          },
+        },
+      });
+    } catch (error) {
+      expect(error).toEqual('Event name is required');
+    }
+  });
+
   test('Track call without parameters', async () => {
     mockVWO.init();
     mockVWO.track({

--- a/packages/analytics-js-integrations/src/integrations/VWO/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/browser.js
@@ -47,8 +47,7 @@ class VWO {
     window.VWO.event = window.VWO.event || function (...args) {
         window.VWO.push(['event', ...args]);
     };
- 
-    
+
     window.VWO.visitor = window.VWO.visitor || function (...args) {
         window.VWO.push(['visitor', ...args]);
     };
@@ -122,6 +121,10 @@ class VWO {
   track(rudderElement) {
     logger.debug('===In VWO track===');
     const eventName = rudderElement.message.event;
+    if (!eventName) {
+      logger.error('Event name is required');
+      return;
+    }
     const properties = (rudderElement.message && rudderElement.message.properties) || {};
     window.VWO = window.VWO || [];
     if (eventName === 'Order Completed') {

--- a/packages/analytics-js-integrations/src/integrations/VWO/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/utils.js
@@ -20,9 +20,7 @@ const getDestinationOptions = integrationsOptions =>
  * @param {string} eventName - The event name to be sanitized.
  * @return {string} The sanitized event name.
  */
-const sanitizeName = eventName => {
-  return `rudder.${eventName.trim()}`;
-};
+const sanitizeName = eventName => `rudder.${eventName?.trim()}`;
 
 /**
  * Sanitizes the properties object by formatting the keys and returning a new object with the formatted keys.

--- a/packages/analytics-js-integrations/src/integrations/VWO/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/utils.js
@@ -25,15 +25,15 @@ const sanitizeName = eventName => `rudder.${eventName?.trim()}`;
 /**
  * Sanitizes the properties object by formatting the keys and returning a new object with the formatted keys.
  *
- * @param {object} properties - The properties object to be sanitized.
+ * @param {object} attributes - The properties object to be sanitized.
  * @return {object} - The sanitized properties object with formatted keys.
  */
 const sanitizeAttributes = attributes => {
   const formattedAttributes = {};
-  for (const key in attributes) {
+  Object.keys(attributes).forEach(key => {
     const formattedKey = sanitizeName(key);
     formattedAttributes[formattedKey] = attributes[key];
-  }
+  });
   return formattedAttributes;
 };
 


### PR DESCRIPTION
## PR Description

Add eventName undefined or null validation for VWO destination

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
