### PR TITLE
chore: changed sprig key name apiKey to environmentId

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Sprig/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Sprig/browser.test.js
@@ -17,8 +17,8 @@ beforeEach(() => {
   delete window.Sprig;
 });
 describe('Sprig init tests', () => {
-  test('Testing init call of Sprig with apiKey', () => {
-    const sprig = new Sprig({ apiKey: '12345' }, {}, destinationInfo);
+  test('Testing init call of Sprig with environmentId', () => {
+    const sprig = new Sprig({ environmentId: '12345' }, {}, destinationInfo);
     sprig.init();
     expect(typeof window.Sprig).toBe('function');
   });
@@ -27,7 +27,7 @@ describe('Sprig init tests', () => {
 describe('Sprig tests', () => {
   let sprig;
   beforeEach(() => {
-    sprig = new Sprig({ apiKey: '12345' }, {}, destinationInfo);
+    sprig = new Sprig({ environmentId: '12345' }, {}, destinationInfo);
     sprig.init();
   });
 

--- a/packages/analytics-js-integrations/src/integrations/Sprig/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Sprig/browser.js
@@ -12,7 +12,7 @@ class Sprig {
             logger.setLogLevel(analytics.logLevel);
         }
         this.analytics = analytics;
-        this.apiKey = config.apiKey;
+        this.environmentId = config.environmentId;
         this.name = NAME;
         ({
             shouldApplyDeviceModeTransformation: this.shouldApplyDeviceModeTransformation,
@@ -22,7 +22,7 @@ class Sprig {
     }
 
     loadScript() {
-        loadNativeSdk(this.apiKey);
+        loadNativeSdk(this.environmentId);
     }
 
     init() {

--- a/packages/analytics-js-integrations/src/integrations/Sprig/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/Sprig/nativeSdkLoader.js
@@ -1,6 +1,6 @@
 import { LOAD_ORIGIN } from '@rudderstack/analytics-js-common/v1.1/utils/constants';
 
-function loadNativeSdk(apiKey) {
+function loadNativeSdk(environmentId) {
     (function (l, e, a, p) {
         if (window.Sprig) return;
         window.Sprig = function () { S._queue.push(arguments) }
@@ -13,7 +13,7 @@ function loadNativeSdk(apiKey) {
         a.setAttribute('data-loader', LOAD_ORIGIN);
         p = l.getElementsByTagName('script')[0];
         p.parentNode.insertBefore(a, p);
-    })(document, 'https://cdn.sprig.com/shim.js', apiKey);
+    })(document, 'https://cdn.sprig.com/shim.js', environmentId);
 }
 
 export { loadNativeSdk };


### PR DESCRIPTION
## PR Description

- In the quest for greater clarity and adherence to Spring Cloud conventions, this PR addresses the naming conflict between apiKey used in device mode and apiKey utilized in the new Spring Cloud mode.
- Renamed apiKey used in device mode to environmentId for enhanced differentiation.
- Retained the name apiKey for usage in Spring Cloud mode, aligning with Spring documentation for consistency and clarity.
- name convention are more suitable as per sprig docs

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
