### PR TITLE
fix(analytics-js): exclude third party host scripts from content scripts

### DIFF
--- a/packages/analytics-js-plugins/rollup.config.mjs
+++ b/packages/analytics-js-plugins/rollup.config.mjs
@@ -53,6 +53,8 @@ const pluginsMap = {
   './XhrQueue': './src/xhrQueue/index.ts',
 };
 
+const bugsnagSDKUrl = 'https://d2wy8f7a9ursnm.cloudfront.net/v6/bugsnag.min.js';
+
 export function getDefaultConfig(distName) {
   const version = process.env.VERSION || 'dev-snapshot';
   const isLocalServerEnabled = isCDNPackageBuild && process.env.DEV_SERVER;
@@ -79,6 +81,7 @@ export function getDefaultConfig(distName) {
         __BUNDLE_ALL_PLUGINS__: isLegacyBuild,
         __RS_BUGSNAG_API_KEY__: process.env.BUGSNAG_API_KEY || '{{__RS_BUGSNAG_API_KEY__}}',
         __RS_BUGSNAG_RELEASE_STAGE__: process.env.BUGSNAG_RELEASE_STAGE || 'production',
+        __RS_BUGSNAG_SDK_URL__: bugsnagSDKUrl,
       }),
       resolve({
         jsnext: true,

--- a/packages/analytics-js-plugins/src/bugsnag/constants.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/constants.ts
@@ -4,7 +4,7 @@ const GLOBAL_LIBRARY_OBJECT_NAMES = [
   BUGSNAG_LIB_V7_INSTANCE_GLOBAL_KEY_NAME,
   BUGSNAG_LIB_INSTANCE_GLOBAL_KEY_NAME,
 ];
-const BUGSNAG_CDN_URL = 'https://d2wy8f7a9ursnm.cloudfront.net/v6/bugsnag.min.js';
+const BUGSNAG_CDN_URL = '__RS_BUGSNAG_SDK_URL__';
 const ERROR_REPORT_PROVIDER_NAME_BUGSNAG = 'rs-bugsnag';
 // This API key token is parsed in the CI pipeline
 const API_KEY = '__RS_BUGSNAG_API_KEY__';

--- a/packages/analytics-js-plugins/src/bugsnag/index.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/index.ts
@@ -6,7 +6,7 @@ import type { IExternalSrcLoader } from '@rudderstack/analytics-js-common/servic
 import type { ExtensionPlugin } from '@rudderstack/analytics-js-common/types/PluginEngine';
 import type { PluginName } from '@rudderstack/analytics-js-common/types/PluginsManager';
 import type { BugsnagLib } from '../types/plugins';
-import { BUGSNAG_API_KEY_VALIDATION_ERROR } from './logMessages';
+import { BUGSNAG_API_KEY_VALIDATION_ERROR, BUGSNAG_SDK_URL_ERROR } from './logMessages';
 import { API_KEY } from './constants';
 import { initBugsnagClient, loadBugsnagSDK, isApiKeyValid, getAppStateForMetadata } from './utils';
 
@@ -28,6 +28,13 @@ const Bugsnag = (): ExtensionPlugin => ({
         // If API key token is not parsed or invalid, don't proceed to initialize the client
         if (!isApiKeyValid(API_KEY)) {
           reject(new Error(BUGSNAG_API_KEY_VALIDATION_ERROR(API_KEY)));
+          return;
+        }
+
+        // If SDK URL is empty, don't proceed to initialize the client
+        // eslint-disable-next-line no-constant-condition
+        if (!'__RS_BUGSNAG_SDK_URL__') {
+          reject(new Error(BUGSNAG_SDK_URL_ERROR));
           return;
         }
 

--- a/packages/analytics-js-plugins/src/bugsnag/logMessages.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/logMessages.ts
@@ -9,4 +9,11 @@ const BUGSNAG_SDK_LOAD_TIMEOUT_ERROR = (timeout: number): string =>
 const BUGSNAG_SDK_LOAD_ERROR = (context: string): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}Failed to load the Bugsnag SDK.`;
 
-export { BUGSNAG_API_KEY_VALIDATION_ERROR, BUGSNAG_SDK_LOAD_TIMEOUT_ERROR, BUGSNAG_SDK_LOAD_ERROR };
+const BUGSNAG_SDK_URL_ERROR = 'The Bugsnag SDK URL is invalid. Failed to load the Bugsnag SDK.';
+
+export {
+  BUGSNAG_API_KEY_VALIDATION_ERROR,
+  BUGSNAG_SDK_LOAD_TIMEOUT_ERROR,
+  BUGSNAG_SDK_LOAD_ERROR,
+  BUGSNAG_SDK_URL_ERROR,
+};

--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -19,6 +19,11 @@
       "types": "./dist/npm/index.d.ts",
       "require": "./dist/npm/modern/bundled/cjs/index.js",
       "import": "./dist/npm/modern/bundled/esm/index.js"
+    },
+    "./content-script": {
+      "types": "./dist/npm/index.d.ts",
+      "require": "./dist/npm/modern/content-script/cjs/index.js",
+      "import": "./dist/npm/modern/content-script/esm/index.js"
     }
   },
   "types": "./dist/npm/index.d.ts",
@@ -55,8 +60,9 @@
     "build:browser": "rollup -c --environment VERSION:$npm_package_version,UGLIFY,PROD_DEBUG,ENV:prod",
     "build:npm": "rollup -c --environment VERSION:$npm_package_version,ENV:prod,MODULE_TYPE:npm",
     "build:npm:bundled": "BUNDLED_PLUGINS=all npm run build:npm:modern",
+    "build:npm:content-script": "BUNDLED_PLUGINS=all NO_EXTERNAL_HOST=true npm run build:npm:modern",
     "build:npm:modern": "BROWSERSLIST_ENV=modern npm run build:npm",
-    "build:package": "npm run build:npm:modern && npm run build:npm && npm run build:npm:bundled",
+    "build:package": "npm run build:npm:modern && npm run build:npm && npm run build:npm:bundled && npm run build:npm:content-script",
     "build:browser:test": "ONLY_IIFE=true npm run build:browser && sed 's/var rudderanalytics/rudderanalytics/g' dist/cdn/legacy/iife/rsa.min.js > __mocks__/cdnSDKv3.js",
     "test": "npm run build:browser:test && nx test --maxWorkers=50%",
     "test:ci": "npm run build:browser:test && nx test --parallel=false --configuration=ci --runInBand --maxWorkers=1 --forceExit",

--- a/packages/analytics-js/src/components/capabilitiesManager/polyfill/index.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/polyfill/index.ts
@@ -1,8 +1,11 @@
 import { legacyJSEngineRequiredPolyfills } from '../detection/dom';
 
-const POLYFILL_URL = `https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=${Object.keys(
-  legacyJSEngineRequiredPolyfills,
-).join('%2C')}`;
+// eslint-disable-next-line no-constant-condition
+const POLYFILL_URL = '__RS_POLYFILLIO_SDK_URL__'
+  ? `__RS_POLYFILLIO_SDK_URL__?version=3.111.0&features=${Object.keys(
+      legacyJSEngineRequiredPolyfills,
+    ).join('%2C')}`
+  : '';
 
 const POLYFILL_LOAD_TIMEOUT = 10 * 1000; // 10 seconds
 

--- a/packages/analytics-v1.1/package.json
+++ b/packages/analytics-v1.1/package.json
@@ -9,6 +9,11 @@
       "types": "./dist/npm/index.d.ts",
       "import": "./dist/npm/index.es.js",
       "require": "./dist/npm/index.js"
+    },
+    "./content-script": {
+      "types": "./dist/npm/index.d.ts",
+      "require": "./dist/npm/content-script/index.js",
+      "import": "./dist/npm/content-script/index.es.js"
     }
   },
   "typesVersions": {
@@ -34,7 +39,8 @@
     "build:browser:modern": "BROWSERSLIST_ENV=modern rollup --config rollup-configs/rollup.sdk.browser.mjs --environment VERSION:$npm_package_version,UGLIFY,PROD_DEBUG,ENV:prod",
     "build:browser": "rollup --config rollup-configs/rollup.sdk.browser.mjs --environment VERSION:$npm_package_version,UGLIFY,PROD_DEBUG,ENV:prod",
     "build:npm": "rollup --config rollup-configs/rollup.sdk.npm.mjs --environment VERSION:$npm_package_version,UGLIFY,ENV:prod,NPM",
-    "build:package": "npm run build:npm",
+    "build:npm:content-script": "NO_EXTERNAL_HOST=true npm run build:npm",
+    "build:package": "npm run build:npm && npm run build:npm:content-script",
     "build:browser:test": "npm run build:browser && sed 's/var rudderanalytics/rudderanalytics/g' dist/cdn/legacy/rudder-analytics.min.js > __mocks__/cdnSDK.js",
     "test": "npm run build:browser:test && nx test --maxWorkers=50%",
     "test:ci": "npm run build:browser:test && nx test --parallel=false --configuration=ci --runInBand --maxWorkers=1 --forceExit",

--- a/packages/analytics-v1.1/rollup-configs/rollup.sdk.npm.mjs
+++ b/packages/analytics-v1.1/rollup-configs/rollup.sdk.npm.mjs
@@ -3,9 +3,14 @@ import copy from 'rollup-plugin-copy';
 import { getDefaultConfig } from './rollup.utilities.mjs';
 
 const outDir = `dist`;
-const npmPackageOutDir = `${outDir}/npm`;
+let npmPackageOutDir = `${outDir}/npm`;
 const distName = 'rudder-analytics';
 const modName = 'rudderanalytics';
+const isContentScriptBuild = process.env.NO_EXTERNAL_HOST;
+
+if(isContentScriptBuild) {
+  npmPackageOutDir = `${npmPackageOutDir}/content-script`
+}
 
 const outputFiles = [
   {

--- a/packages/analytics-v1.1/rollup-configs/rollup.utilities.mjs
+++ b/packages/analytics-v1.1/rollup-configs/rollup.utilities.mjs
@@ -19,6 +19,19 @@ import { DEFAULT_EXTENSIONS } from '@babel/core';
 
 dotenv.config();
 
+const isContentScriptBuild = process.env.NO_EXTERNAL_HOST;
+let bugsnagSDKUrl = 'https://d2wy8f7a9ursnm.cloudfront.net/v6/bugsnag.min.js';
+let polyfillIoUrl = 'https://polyfill.io/v3/polyfill.min.js';
+let googleAdsSDKUrl = '//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';
+
+// For Chrome extension as content script any references in code to third party URLs
+// throw violations at approval phase even if relevant code is not used
+if(isContentScriptBuild) {
+  bugsnagSDKUrl = '';
+  polyfillIoUrl = '';
+  googleAdsSDKUrl = '';
+}
+
 export function getOutputFilePath(dirPath, distName) {
   const fileNamePrefix = `${distName}`;
   const fileNameSuffix = process.env.PROD_DEBUG === 'inline' ? '-map' : '';
@@ -60,6 +73,9 @@ export function getDefaultConfig(distName) {
         __MODULE_TYPE__: moduleType,
         __RS_BUGSNAG_API_KEY__: process.env.BUGSNAG_API_KEY || '{{__RS_BUGSNAG_API_KEY__}}',
         __RS_BUGSNAG_RELEASE_STAGE__: process.env.BUGSNAG_RELEASE_STAGE || 'production',
+        __RS_POLYFILLIO_SDK_URL__: polyfillIoUrl,
+        __RS_BUGSNAG_SDK_URL__: bugsnagSDKUrl,
+        __RS_GOOGLE_ADS_SDK_URL__: googleAdsSDKUrl
       }),
       alias({
         entries: [

--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -683,7 +683,7 @@ class Analytics {
       (options = properties), (properties = name), (name = null);
     if (typeof category === 'string' && typeof name !== 'string')
       (name = category), (category = null);
-    if (this.sendAdblockPage && category != 'RudderJS-Initiated') {
+    if (this.sendAdblockPage && category != 'RudderJS-Initiated' && '__RS_GOOGLE_ADS_SDK_URL__') {
       this.sendSampleRequest();
     }
     let clonedProperties = R.clone(properties);
@@ -1379,7 +1379,7 @@ class Analytics {
 
     // clone options
     const clonedOptions = R.clone(options);
-    if (this.arePolyfillsRequired(clonedOptions)) {
+    if (this.arePolyfillsRequired(clonedOptions) && POLYFILL_URL) {
       const id = 'polyfill';
       ScriptLoader(id, POLYFILL_URL, { skipDatasetAttributes: true });
       const self = this;
@@ -1472,7 +1472,7 @@ class Analytics {
   }
 
   sendSampleRequest() {
-    ScriptLoader('ad-block', '//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js', {
+    ScriptLoader('ad-block', '__RS_GOOGLE_ADS_SDK_URL__', {
       isNonNativeSDK: true,
     });
   }

--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -683,7 +683,7 @@ class Analytics {
       (options = properties), (properties = name), (name = null);
     if (typeof category === 'string' && typeof name !== 'string')
       (name = category), (category = null);
-    if (this.sendAdblockPage && category != 'RudderJS-Initiated' && '__RS_GOOGLE_ADS_SDK_URL__') {
+    if (this.sendAdblockPage && category !== 'RudderJS-Initiated') {
       this.sendSampleRequest();
     }
     let clonedProperties = R.clone(properties);
@@ -1472,6 +1472,11 @@ class Analytics {
   }
 
   sendSampleRequest() {
+    // eslint-disable-next-line no-constant-condition
+    if (!'__RS_GOOGLE_ADS_SDK_URL__') {
+      return;
+    }
+
     ScriptLoader('ad-block', '__RS_GOOGLE_ADS_SDK_URL__', {
       isNonNativeSDK: true,
     });

--- a/packages/analytics-v1.1/src/features/core/metrics/errorReporting/providers/Bugsnag.js
+++ b/packages/analytics-v1.1/src/features/core/metrics/errorReporting/providers/Bugsnag.js
@@ -8,7 +8,7 @@ import {
 import get from 'get-value';
 
 // Using the Bugsnag integration version to avoid version issues
-const BUGSNAG_CDN_URL = 'https://d2wy8f7a9ursnm.cloudfront.net/v6/bugsnag.min.js';
+const BUGSNAG_CDN_URL = '__RS_BUGSNAG_SDK_URL__';
 const BUGSNAG_VALID_MAJOR_VERSION = '6';
 const ERROR_REPORT_PROVIDER_NAME_BUGSNAG = 'rs-bugsnag';
 const BUGSNAG_LIB_INSTANCE_GLOBAL_KEY_NAME = 'bugsnag'; // For version 6 and bellow
@@ -121,10 +121,11 @@ class BugsnagProvider {
    * If already loaded initialize the SDK.
    */
   init() {
-    // Return if RS Bugsnag instance is already initialized
+    // Return if RS Bugsnag instance is already initialized or should not init
     if (
       window.RudderStackGlobals &&
-      window.RudderStackGlobals[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME]
+      window.RudderStackGlobals[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME] &&
+      BUGSNAG_CDN_URL
     ) {
       return;
     }

--- a/packages/analytics-v1.1/src/features/core/metrics/errorReporting/providers/Bugsnag.js
+++ b/packages/analytics-v1.1/src/features/core/metrics/errorReporting/providers/Bugsnag.js
@@ -124,9 +124,12 @@ class BugsnagProvider {
     // Return if RS Bugsnag instance is already initialized or should not init
     if (
       window.RudderStackGlobals &&
-      window.RudderStackGlobals[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME] &&
-      BUGSNAG_CDN_URL
+      window.RudderStackGlobals[ERROR_REPORTING_SERVICE_GLOBAL_KEY_NAME]
     ) {
+      return;
+    }
+
+    if (!BUGSNAG_CDN_URL) {
       return;
     }
 

--- a/packages/analytics-v1.1/src/utils/constants.js
+++ b/packages/analytics-v1.1/src/utils/constants.js
@@ -19,6 +19,7 @@ const DEST_SDK_BASE_URL = `${SDK_CDN_BASE_URL}/${CDN_ARCH_VERSION_DIR}/${CDN_INT
 
 const DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT_MS = 10000;
 const INTG_SUFFIX = '_RS';
+// eslint-disable-next-line no-constant-condition
 const POLYFILL_URL = '__RS_POLYFILLIO_SDK_URL__'
   ? '__RS_POLYFILLIO_SDK_URL__?version=3.111.0&features=Number.isNaN%2CURL%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll%2CTextEncoder%2Cnavigator.sendBeacon'
   : '';

--- a/packages/analytics-v1.1/src/utils/constants.js
+++ b/packages/analytics-v1.1/src/utils/constants.js
@@ -19,8 +19,9 @@ const DEST_SDK_BASE_URL = `${SDK_CDN_BASE_URL}/${CDN_ARCH_VERSION_DIR}/${CDN_INT
 
 const DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT_MS = 10000;
 const INTG_SUFFIX = '_RS';
-const POLYFILL_URL =
-  'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Number.isNaN%2CURL%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll%2CTextEncoder%2Cnavigator.sendBeacon';
+const POLYFILL_URL = '__RS_POLYFILLIO_SDK_URL__'
+  ? '__RS_POLYFILLIO_SDK_URL__?version=3.111.0&features=Number.isNaN%2CURL%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll%2CTextEncoder%2Cnavigator.sendBeacon'
+  : '';
 
 const SAMESITE_COOKIE_OPTS = ['Lax', 'None', 'Strict'];
 


### PR DESCRIPTION
## PR Description

Provide new export alias for Chrome Extension content script usage in order to avoid any violations regarding third party script import during chome extension store approval.

## Linear task (optional)

Resolves [SDK-1002](https://linear.app/rudderstack/issue/SDK-1002/chrome-extension-store-approval-fails-with-violations-for-third-party)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
