### PR TITLE
feat(analytics-js): add additional consent management fields

### DIFF
--- a/packages/analytics-v1.1/__tests__/ketchConsent.test.js
+++ b/packages/analytics-v1.1/__tests__/ketchConsent.test.js
@@ -7,6 +7,9 @@ window.ketchConsent = {
 };
 
 const expectedDeniedPurposes = ['email_mktg', 'behavioral_advertising'];
+const expectedConsentedPurposes = ['analytics'];
+const provider = 'ketch';
+const resolutionStrategy = 'or';
 
 const ketch = new Ketch();
 
@@ -38,12 +41,13 @@ describe('Test suit for Ketch consent manager', () => {
     const allowEvent = ketch.isEnabled(destConfig);
     expect(allowEvent).toBe(true);
   });
-  it('Should return the category IDs that the user has not consented for', () => {
-    const actualDeniedPurposes = ketch.getDeniedList();
-    expect(actualDeniedPurposes).toEqual(expectedDeniedPurposes);
-  });
-  it('Should return the category IDs that the user has not consented for', () => {
-    const actualDeniedPurposes = ketch.getDeniedList();
-    expect(actualDeniedPurposes).toEqual(expectedDeniedPurposes);
+  it('Should return the entire consent information', () => {
+    const cmInfo = ketch.getConsentManagementInfo();
+    expect(cmInfo).toEqual({
+      allowedConsentIds: expectedConsentedPurposes,
+      deniedConsentIds: expectedDeniedPurposes,
+      provider,
+      resolutionStrategy,
+    });
   });
 });

--- a/packages/analytics-v1.1/__tests__/oneTrustCookieConsent.test.js
+++ b/packages/analytics-v1.1/__tests__/oneTrustCookieConsent.test.js
@@ -15,6 +15,9 @@ window.OneTrust = {
 window.OnetrustActiveGroups = ',C0001,C0003,';
 
 const expectedDeniedConsentIds = ['C0002', 'C0004', 'C0005', 'C0006'];
+const expectedConsentedConsentIds = ['C0001', 'C0003'];
+const provider = 'oneTrust';
+const resolutionStrategy = 'and';
 
 const oneTrust = new OneTrust();
 
@@ -82,8 +85,13 @@ describe('Test suit for OneTrust cookie consent manager', () => {
     const allowEvent = oneTrust.isEnabled(destConfig);
     expect(allowEvent).toBe(false);
   });
-  it('Should return the category IDs that the user has not consented for', () => {
-    const actualDeniedConsentIds = oneTrust.getDeniedList();
-    expect(actualDeniedConsentIds).toEqual(expectedDeniedConsentIds);
+  it('Should return the entire consent information', () => {
+    const cmInfo = oneTrust.getConsentManagementInfo();
+    expect(cmInfo).toEqual({
+      allowedConsentIds: expectedConsentedConsentIds,
+      deniedConsentIds: expectedDeniedConsentIds,
+      provider,
+      resolutionStrategy,
+    });
   });
 });

--- a/packages/analytics-v1.1/__tests__/oneTrustCookieConsent.test.js
+++ b/packages/analytics-v1.1/__tests__/oneTrustCookieConsent.test.js
@@ -15,7 +15,10 @@ window.OneTrust = {
 window.OnetrustActiveGroups = ',C0001,C0003,';
 
 const expectedDeniedConsentIds = ['C0002', 'C0004', 'C0005', 'C0006'];
-const expectedConsentedConsentIds = ['C0001', 'C0003'];
+const expectedConsentedConsentIds = {
+  C0001: 'Functional Cookies',
+  C0003: 'Analytical Cookies',
+};
 const provider = 'oneTrust';
 const resolutionStrategy = 'and';
 

--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -111,7 +111,7 @@ class Analytics {
     this.version = '__PACKAGE_VERSION__';
     this.lockIntegrationsVersion = false;
     this.errorReporting = new ErrorReportingService(logger);
-    this.deniedConsentIds = [];
+    this.consentManagementInfo = {};
     this.transformationHandler = DeviceModeTransformations;
   }
 
@@ -275,7 +275,7 @@ class Analytics {
         try {
           const cookieConsent = CookieConsentFactory.initialize(this.cookieConsentOptions);
           // Fetch denied consent group Ids and pass it to cloud mode
-          this.deniedConsentIds = cookieConsent && cookieConsent.getDeniedList();
+          this.consentManagementInfo = cookieConsent && cookieConsent.getConsentManagementInfo();
           // If cookie consent object is return we filter according to consents given by user
           // else we do not consider any filtering for cookie consent.
           this.clientIntegrations = this.clientIntegrations.filter(
@@ -949,7 +949,7 @@ class Analytics {
       // If cookie consent is enabled attach the denied consent group Ids to the context
       if (fetchCookieConsentState(this.cookieConsentOptions)) {
         rudderElement.message.context.consentManagement = {
-          deniedConsentIds: this.deniedConsentIds || [],
+          ...R.clone(this.consentManagementInfo),
         };
       }
 

--- a/packages/analytics-v1.1/src/features/core/cookieConsent/OneTrust/browser.js
+++ b/packages/analytics-v1.1/src/features/core/cookieConsent/OneTrust/browser.js
@@ -3,6 +3,8 @@ import { logger } from '@rudderstack/analytics-js-common/v1.1/utils/logUtil';
 /* eslint-disable class-methods-use-this */
 class OneTrust {
   isInitialized = false;
+  name = 'oneTrust';
+  resolutionStrategy = 'and';
 
   constructor() {
     // If user does not load onetrust sdk before loading rudderstack sdk
@@ -91,11 +93,17 @@ class OneTrust {
     }
   }
 
-  getDeniedList() {
+  getConsentManagementInfo() {
     if (!this.isInitialized) {
-      return [];
+      return {};
     }
-    return this.userDeniedConsentGroupIds;
+
+    return {
+      allowedConsentIds: this.userSetConsentGroupIds,
+      deniedConsentIds: this.userDeniedConsentGroupIds,
+      provider: this.name,
+      resolutionStrategy: this.resolutionStrategy,
+    };
   }
 }
 

--- a/packages/analytics-v1.1/src/features/core/cookieConsent/OneTrust/browser.js
+++ b/packages/analytics-v1.1/src/features/core/cookieConsent/OneTrust/browser.js
@@ -26,6 +26,7 @@ class OneTrust {
     const oneTrustAllGroupsInfo = window.OneTrust.GetDomainData().Groups;
     this.userSetConsentGroupNames = [];
     this.userDeniedConsentGroupIds = [];
+    this.userSetConsentGroups = {};
 
     // Get the names of the cookies consented by the user in the browser.
 
@@ -33,6 +34,7 @@ class OneTrust {
       const { CustomGroupId, GroupName } = group;
       if (this.userSetConsentGroupIds.includes(CustomGroupId)) {
         this.userSetConsentGroupNames.push(GroupName.toUpperCase().trim());
+        this.userSetConsentGroups[CustomGroupId] = GroupName;
       } else {
         this.userDeniedConsentGroupIds.push(CustomGroupId);
       }
@@ -99,7 +101,7 @@ class OneTrust {
     }
 
     return {
-      allowedConsentIds: this.userSetConsentGroupIds,
+      allowedConsentIds: this.userSetConsentGroups,
       deniedConsentIds: this.userDeniedConsentGroupIds,
       provider: this.name,
       resolutionStrategy: this.resolutionStrategy,

--- a/packages/analytics-v1.1/src/features/core/cookieConsent/ketch/browser.js
+++ b/packages/analytics-v1.1/src/features/core/cookieConsent/ketch/browser.js
@@ -3,6 +3,9 @@ import { Cookie } from '@rudderstack/analytics-js-common/v1.1/utils/storage/cook
 
 /* eslint-disable class-methods-use-this */
 class Ketch {
+  name = 'ketch';
+  resolutionStrategy = 'or';
+
   constructor() {
     this.userConsentedPurposes = [];
     this.userDeniedPurposes = [];
@@ -75,13 +78,18 @@ class Ketch {
       );
       return containsAnyOfConsent;
     } catch (e) {
-      logger.error(`Error occured checking ketch consent state ${e}`);
+      logger.error(`Error occurred checking ketch consent state ${e}`);
       return true;
     }
   }
 
-  getDeniedList() {
-    return this.userDeniedPurposes;
+  getConsentManagementInfo() {
+    return {
+      allowedConsentIds: this.userConsentedPurposes,
+      deniedConsentIds: this.userDeniedPurposes,
+      provider: this.name,
+      resolutionStrategy: this.resolutionStrategy,
+    };
   }
 
   getConsent() {

--- a/packages/sanity-suite/rollup.config.mjs
+++ b/packages/sanity-suite/rollup.config.mjs
@@ -24,7 +24,7 @@ const cdnVersionPath = process.env.CDN_VERSION_PATH ?? defaultVersion;
 const isStaging = process.env.STAGING === 'true';
 const isDMT = process.env.IS_DMT === 'true';
 const isDevEnvTestbook = process.env.IS_DEV_TESTBOOK === 'true';
-const distributionType = process.env.DISTRIBUTION_TYPE === 'npm' ? 'npm' : 'cdn';
+const distributionType = process.env.DISTRIBUTION_TYPE || 'cdn';
 const getDirectoryNames = async sourcePath =>
   (await readdir(sourcePath, { withFileTypes: true }))
     .filter(dirent => dirent.isDirectory())
@@ -34,7 +34,7 @@ const featuresList = await getDirectoryNames(`./public/${cdnVersionPath}`);
 console.log('featuresList', featuresList)
 
 const getDistPath = () => {
-  let distPath = distributionType? `/${distributionType}` : '/npm';
+  let distPath = distributionType ? `/${distributionType}` : '/npm';
   distPath += `/${cdnVersionPath}`;
 
   if (isStaging) {

--- a/packages/sanity-suite/src/ignoredProperties/ignoredProperties.js
+++ b/packages/sanity-suite/src/ignoredProperties/ignoredProperties.js
@@ -166,18 +166,6 @@ const ignoredProperties = [
     key: `message.context.timezone`,
     type: 'string',
   },
-  {
-    key: `message.context.consentManagement.allowedConsentIds`,
-    optional: true,
-  },
-  {
-    key: `message.context.consentManagement.provider`,
-    optional: true,
-  },
-  {
-    key: `message.context.consentManagement.resolutionStrategy`,
-    optional: true,
-  },
 ];
 
 export { ignoredProperties };


### PR DESCRIPTION
## PR Description

Added additional consent management fields into `context.consentManagement` in the event object.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-848/add-gcm-fields-in-events-context-for-v11-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
