### PR TITLE
fix(analytics-js): post ready callback invocations

### DIFF
--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -218,7 +218,9 @@ describe('Core - Analytics', () => {
       const callback = jest.fn();
 
       state.lifecycle.loaded.value = true;
-      state.lifecycle.status.value = 'ready';
+      // Using the next lifecycle state ('readyExecuted') here as lifecycle is not started in this test
+      // In the real scenario, once the SDK is ready, the lifecycle state will be 'readyExecuted'
+      state.lifecycle.status.value = 'readyExecuted';
       analytics.ready(callback);
       expect(leaveBreadcrumbSpy).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledTimes(1);

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -464,7 +464,7 @@ class Analytics implements IAnalytics {
      * execute the callback immediately else push the callbacks to a queue that
      * will be executed after loading completes
      */
-    if (state.lifecycle.status.value === 'ready') {
+    if (state.lifecycle.status.value === 'readyExecuted') {
       try {
         callback();
       } catch (err) {


### PR DESCRIPTION
## PR Description

Ready callbacks registered post the SDK ready state are not fired. So, this issue has been fixed.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1020/fix-the-sdk-post-ready-callback-execution

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally (Chrome and IE 11)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
