### PR TITLE
fix: add check to disallow track events without event name

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/VWO/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/browser.js
@@ -44,14 +44,17 @@ class VWO {
     }
 
     window.VWO = window.VWO || [];
-    window.VWO.event = window.VWO.event || function (...args) {
+    window.VWO.event =
+      window.VWO.event ||
+      function (...args) {
         window.VWO.push(['event', ...args]);
-    };
- 
-    
-    window.VWO.visitor = window.VWO.visitor || function (...args) {
+      };
+
+    window.VWO.visitor =
+      window.VWO.visitor ||
+      function (...args) {
         window.VWO.push(['visitor', ...args]);
-    };
+      };
 
     // Send track or iddentify when
     if (this.sendExperimentTrack || this.experimentViewedIdentify) {
@@ -122,6 +125,11 @@ class VWO {
   track(rudderElement) {
     logger.debug('===In VWO track===');
     const eventName = rudderElement.message.event;
+    // throw error if event name is not present
+    if (!eventName) {
+      logger.error('[VWO] track:: event name is required');
+      return;
+    }
     const properties = (rudderElement.message && rudderElement.message.properties) || {};
     window.VWO = window.VWO || [];
     if (eventName === 'Order Completed') {


### PR DESCRIPTION
## PR Description

Minor fix to add check for missing event name for track events in VWO.

## Linear task (optional)

Resolves INT-1126

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
