### PR TITLE
fix: trim called on undefined value

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/VWO/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/utils.js
@@ -21,7 +21,7 @@ const getDestinationOptions = integrationsOptions =>
  * @return {string} The sanitized event name.
  */
 const sanitizeName = eventName => {
-  return `rudder.${eventName.trim()}`;
+  return `rudder.${eventName?.trim() || "event"}`;
 };
 
 /**


### PR DESCRIPTION
## PR Description

Add optional chaining with default value  in sanitizeName function in vwo integrations.
Fixes INT-1171

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-1171/fix-trim-called-on-an-undefined-value

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
