### PR TITLE
feat: remove support for category names in onetrust plugin

### DIFF
--- a/packages/analytics-js-common/src/types/Consent.ts
+++ b/packages/analytics-js-common/src/types/Consent.ts
@@ -28,7 +28,7 @@ export type ConsentManagementProvider = 'oneTrust' | 'ketch' | 'custom';
 
 export type ConsentResolutionStrategy = 'and' | 'or';
 
-export type Consents = Record<string, string> | string[];
+export type Consents = string[];
 
 export type ConsentManagementOptions = {
   enabled: boolean;

--- a/packages/analytics-js-plugins/__tests__/oneTrustConsentManager/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/oneTrustConsentManager/index.test.ts
@@ -47,7 +47,7 @@ describe('Plugin - OneTrustConsentManager', () => {
 
     expect(state.consents.initialized.value).toBe(true);
     expect(state.consents.data.value).toStrictEqual({
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
       deniedConsentIds: ['C0002', 'C0004', 'C0005', 'C0006'],
     });
   });
@@ -68,7 +68,7 @@ describe('Plugin - OneTrustConsentManager', () => {
   it('should return true if destination specific category is consented', () => {
     state.consents.initialized.value = true;
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
 
     const destConfig = {
@@ -77,7 +77,7 @@ describe('Plugin - OneTrustConsentManager', () => {
       eventFilteringOption: 'disable',
       oneTrustCookieCategories: [
         {
-          oneTrustCookieCategory: 'Functional Cookies',
+          oneTrustCookieCategory: 'C0001',
         },
         {
           oneTrustCookieCategory: 'C0003',
@@ -107,7 +107,7 @@ describe('Plugin - OneTrustConsentManager', () => {
       eventFilteringOption: 'disable',
       oneTrustCookieCategories: [
         {
-          oneTrustCookieCategory: 'Functional Cookies',
+          oneTrustCookieCategory: 'C0001',
         },
         {
           oneTrustCookieCategory: '',
@@ -128,7 +128,7 @@ describe('Plugin - OneTrustConsentManager', () => {
   it('should return true if destination config does not have any mapping', () => {
     state.consents.initialized.value = true;
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
     const destConfig = {
       blacklistedEvents: [],
@@ -149,7 +149,7 @@ describe('Plugin - OneTrustConsentManager', () => {
   it('should return false if destination categories are not consented', () => {
     state.consents.initialized.value = true;
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
     const destConfig = {
       blacklistedEvents: [],
@@ -157,7 +157,7 @@ describe('Plugin - OneTrustConsentManager', () => {
       eventFilteringOption: 'disable',
       oneTrustCookieCategories: [
         {
-          oneTrustCookieCategory: 'Functional Cookies',
+          oneTrustCookieCategory: 'C0001',
         },
         {
           oneTrustCookieCategory: 'C0004',
@@ -177,7 +177,7 @@ describe('Plugin - OneTrustConsentManager', () => {
   it('should return true and log error if an exception occurs during destination consent status check', () => {
     state.consents.initialized.value = true;
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
     const destConfig = {
       blacklistedEvents: [],
@@ -206,7 +206,7 @@ describe('Plugin - OneTrustConsentManager', () => {
     state.consents.resolutionStrategy.value = 'and';
     state.consents.provider.value = 'oneTrust';
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
     const destConfig = {
       blacklistedEvents: [],
@@ -217,7 +217,7 @@ describe('Plugin - OneTrustConsentManager', () => {
           provider: 'oneTrust',
           consents: [
             {
-              consent: 'Functional Cookies',
+              consent: 'C0001',
             },
             {
               consent: 'C0004',
@@ -248,7 +248,7 @@ describe('Plugin - OneTrustConsentManager', () => {
     state.consents.resolutionStrategy.value = 'and';
     state.consents.provider.value = 'oneTrust';
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
     const destConfig = {
       blacklistedEvents: [],
@@ -279,7 +279,7 @@ describe('Plugin - OneTrustConsentManager', () => {
     state.consents.provider.value = 'oneTrust';
     state.consents.resolutionStrategy.value = 'and';
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
     const destConfig = {
       blacklistedEvents: [],
@@ -290,7 +290,7 @@ describe('Plugin - OneTrustConsentManager', () => {
           provider: 'oneTrust',
           consents: [
             {
-              consent: 'Functional Cookies',
+              consent: 'C0001',
             },
             {
               consent: 'C0003',
@@ -321,7 +321,7 @@ describe('Plugin - OneTrustConsentManager', () => {
     state.consents.provider.value = 'oneTrust';
     state.consents.resolutionStrategy.value = 'or';
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
     const destConfig = {
       blacklistedEvents: [],
@@ -332,7 +332,7 @@ describe('Plugin - OneTrustConsentManager', () => {
           provider: 'oneTrust',
           consents: [
             {
-              consent: 'Functional Cookies',
+              consent: 'C0001',
             },
             {
               consent: 'C0004',
@@ -363,7 +363,7 @@ describe('Plugin - OneTrustConsentManager', () => {
     state.consents.provider.value = 'oneTrust';
     state.consents.resolutionStrategy.value = 'or';
     state.consents.data.value = {
-      allowedConsentIds: { C0001: 'Functional Cookies', C0003: 'Analytical Cookies' },
+      allowedConsentIds: ['C0001', 'C0003'],
     };
     const destConfig = {
       blacklistedEvents: [],

--- a/packages/sanity-suite/__fixtures__/alias1.json
+++ b/packages/sanity-suite/__fixtures__/alias1.json
@@ -111,7 +111,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/alias2.json
+++ b/packages/sanity-suite/__fixtures__/alias2.json
@@ -73,7 +73,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/alias3.json
+++ b/packages/sanity-suite/__fixtures__/alias3.json
@@ -73,7 +73,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/alias4.json
+++ b/packages/sanity-suite/__fixtures__/alias4.json
@@ -73,7 +73,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/alias5.json
+++ b/packages/sanity-suite/__fixtures__/alias5.json
@@ -79,7 +79,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/alias6.json
+++ b/packages/sanity-suite/__fixtures__/alias6.json
@@ -111,7 +111,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/eventFiltering1.json
+++ b/packages/sanity-suite/__fixtures__/eventFiltering1.json
@@ -10,10 +10,7 @@
       "sessionStart": true,
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": {
-          "C0001": "Functional Cookies",
-          "C0003": "Analytical Cookies"
-        },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/eventFiltering2.json
+++ b/packages/sanity-suite/__fixtures__/eventFiltering2.json
@@ -10,10 +10,7 @@
       "sessionStart": true,
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": {
-          "C0001": "Functional Cookies",
-          "C0003": "Analytical Cookies"
-        },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/eventFiltering3.json
+++ b/packages/sanity-suite/__fixtures__/eventFiltering3.json
@@ -10,10 +10,7 @@
       "sessionStart": true,
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": {
-          "C0001": "Functional Cookies",
-          "C0003": "Analytical Cookies"
-        },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/group1.json
+++ b/packages/sanity-suite/__fixtures__/group1.json
@@ -74,7 +74,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/group2.json
+++ b/packages/sanity-suite/__fixtures__/group2.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/group3.json
+++ b/packages/sanity-suite/__fixtures__/group3.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/group4.json
+++ b/packages/sanity-suite/__fixtures__/group4.json
@@ -74,7 +74,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/group5.json
+++ b/packages/sanity-suite/__fixtures__/group5.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/group6.json
+++ b/packages/sanity-suite/__fixtures__/group6.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/identify1.json
+++ b/packages/sanity-suite/__fixtures__/identify1.json
@@ -111,7 +111,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/identify2.json
+++ b/packages/sanity-suite/__fixtures__/identify2.json
@@ -79,7 +79,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/identify3.json
+++ b/packages/sanity-suite/__fixtures__/identify3.json
@@ -74,7 +74,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/identify4.json
+++ b/packages/sanity-suite/__fixtures__/identify4.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/identify5.json
+++ b/packages/sanity-suite/__fixtures__/identify5.json
@@ -79,7 +79,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/identify6.json
+++ b/packages/sanity-suite/__fixtures__/identify6.json
@@ -80,7 +80,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/identify7.json
+++ b/packages/sanity-suite/__fixtures__/identify7.json
@@ -79,7 +79,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/identify8.json
+++ b/packages/sanity-suite/__fixtures__/identify8.json
@@ -80,7 +80,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/page1.json
+++ b/packages/sanity-suite/__fixtures__/page1.json
@@ -73,7 +73,7 @@
       "channel": "random",
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/page2.json
+++ b/packages/sanity-suite/__fixtures__/page2.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/page3.json
+++ b/packages/sanity-suite/__fixtures__/page3.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/page4.json
+++ b/packages/sanity-suite/__fixtures__/page4.json
@@ -73,7 +73,7 @@
       "channel": "random",
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/page5.json
+++ b/packages/sanity-suite/__fixtures__/page5.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/page6.json
+++ b/packages/sanity-suite/__fixtures__/page6.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/page7.json
+++ b/packages/sanity-suite/__fixtures__/page7.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/page8.json
+++ b/packages/sanity-suite/__fixtures__/page8.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/track1.json
+++ b/packages/sanity-suite/__fixtures__/track1.json
@@ -109,7 +109,7 @@
       "channel": "random",
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/track2.json
+++ b/packages/sanity-suite/__fixtures__/track2.json
@@ -79,7 +79,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/track3.json
+++ b/packages/sanity-suite/__fixtures__/track3.json
@@ -79,7 +79,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/track4.json
+++ b/packages/sanity-suite/__fixtures__/track4.json
@@ -109,7 +109,7 @@
       "channel": "random",
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/track5.json
+++ b/packages/sanity-suite/__fixtures__/track5.json
@@ -79,7 +79,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/track6.json
+++ b/packages/sanity-suite/__fixtures__/track6.json
@@ -42,7 +42,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },

--- a/packages/sanity-suite/__fixtures__/track7.json
+++ b/packages/sanity-suite/__fixtures__/track7.json
@@ -9,7 +9,7 @@
       },
       "consentManagement": {
         "deniedConsentIds": ["C0002", "C0004", "C0005", "C0006"],
-        "allowedConsentIds": { "C0001": "Functional Cookies", "C0003": "Analytical Cookies" },
+        "allowedConsentIds": ["C0001", "C0003"],
         "provider": "oneTrust",
         "resolutionStrategy": "and"
       },


### PR DESCRIPTION
## PR Description

I've removed the support for category names in the OneTrust consent management plugin.

This is a breaking change for the V3 SDK and will be documented.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1030/drop-support-for-category-names-for-onetrust-in-v3-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally (Chrome and IE 11)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
