### PR TITLE
fix: tiktok remove lowercasing for custom events

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/TikTokAds/tiktokads.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/TikTokAds/tiktokads.test.js
@@ -16,7 +16,7 @@ const basicConfig = {
     { to: 'Lead', from: 'orderCompleted' },
     { from: 'Page View', to: 'PageVisit' },
     { from: 'product_added', to: 'AddToCart' },
-  ]
+  ],
 };
 
 describe('tiktokads init tests', () => {
@@ -201,7 +201,7 @@ describe('TiktokAds Track event', () => {
         event: 'custom_event',
         properties: {
           customProp: 'testProp',
-          checkout_id: 'what is checkout id here??',
+          checkout_id: 'c_id',
           event_id: 'purchaseId',
           order_id: 'transactionId',
           value: 35.0,
@@ -230,7 +230,7 @@ describe('TiktokAds Track event', () => {
               category: 'Wholesaler',
               name: 'Drink',
               brand: '',
-              variant: 'Extra Cheese',
+              variant: 'Extra_Cheese',
               price: 50.0,
               quantity: 1,
               currency: 'GBP',
@@ -327,6 +327,63 @@ describe('TiktokAds Track event', () => {
       },
     });
     expect(window.ttq.track).not.toHaveBeenCalledWith();
+  });
+
+  test('Testing Track custom_event with no mapping and sendCustomEvents flag as true and event name is not in small-case', () => {
+    tiktokads = new TiktokAds({ ...basicConfig, sendCustomEvents: true }, { loglevel: 'DEBUG' });
+    tiktokads.init();
+    window.ttq.track = jest.fn();
+    tiktokads.track({
+      message: {
+        context: {},
+        event: 'CustomEvent',
+        properties: {
+          customProp: 'testProp',
+          checkout_id: 'what is checkout id here??',
+          event_id: 'purchaseId',
+          order_id: 'transactionId',
+          value: 35.0,
+          shipping: 4.0,
+          coupon: 'APPARELSALE',
+          currency: 'GBP',
+          products: [
+            {
+              product_id: 'PRODUCT_ID',
+              category: 'Wholesaler',
+              name: 'Drink',
+              brand: '',
+              variant: 'Extra Cheese',
+              price: 50.0,
+              quantity: 1,
+              currency: 'GBP',
+              position: 1,
+              value: 30.0,
+              typeOfProduct: 'Food',
+              content_type: 'CONTENT_TYPE',
+              url: 'https://www.example.com/product/bacon-jam2',
+              image_url: 'https://www.example.com/product/bacon-jam2.jpg',
+            },
+          ],
+        },
+      },
+    });
+    expect(window.ttq.track.mock.calls[0][0]).toEqual('CustomEvent');
+    expect(window.ttq.track.mock.calls[0][1]).toEqual({
+      value: 35.0,
+      currency: 'GBP',
+      event_id: 'purchaseId',
+      partner_name: 'RudderStack',
+      contents: [
+        {
+          content_category: 'Wholesaler',
+          content_id: 'PRODUCT_ID',
+          content_name: 'Drink',
+          content_type: 'CONTENT_TYPE',
+          price: 50.0,
+          quantity: 1,
+        },
+      ],
+    });
   });
 });
 

--- a/packages/analytics-js-integrations/src/integrations/TiktokAds/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/TiktokAds/browser.js
@@ -75,7 +75,7 @@ class TiktokAds {
       logger.error('Event name is required');
       return;
     }
-    event = event.toLowerCase().trim(); // Using optional chaining as we get sometime non-string event as well
+    event = event?.toLowerCase().trim(); // Using optional chaining as we get sometime non-string event as well
     const standardEventsMap = getHashFromArrayWithDuplicate(this.eventsToStandard);
     if (
       !this.sendCustomEvents &&

--- a/packages/analytics-js-integrations/src/integrations/TiktokAds/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/TiktokAds/browser.js
@@ -75,7 +75,7 @@ class TiktokAds {
       logger.error('Event name is required');
       return;
     }
-    event = event.toLowerCase().trim();
+    event = event?.toLowerCase().trim(); // Using optional chaining as we get sometime non-string event as well
     const standardEventsMap = getHashFromArrayWithDuplicate(this.eventsToStandard);
     if (
       !this.sendCustomEvents &&
@@ -96,7 +96,9 @@ class TiktokAds {
       });
       return;
     }
-    event = eventNameMapping[event] || event;
+    // Doc https://ads.tiktok.com/help/article/standard-events-parameters?lang=en
+    // For custom event we do not want to lower case the event or trim it we just want to send those as it is
+    event = eventNameMapping[event] || message.event;
     const updatedProperties = getTrackResponse(message);
     window.ttq.track(event, updatedProperties);
   }

--- a/packages/analytics-js-integrations/src/integrations/TiktokAds/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/TiktokAds/browser.js
@@ -75,7 +75,7 @@ class TiktokAds {
       logger.error('Event name is required');
       return;
     }
-    event = event?.toLowerCase().trim(); // Using optional chaining as we get sometime non-string event as well
+    event = event.toLowerCase().trim(); // Using optional chaining as we get sometime non-string event as well
     const standardEventsMap = getHashFromArrayWithDuplicate(this.eventsToStandard);
     if (
       !this.sendCustomEvents &&


### PR DESCRIPTION
## PR Description

Resolves INT-1197

For custom events we are lowering their event name but we should retain the message event case as these are case sensitive at tiktok side

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
