### PR TITLE
feat: amplitude add support for unset

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Amplitude/amplitude.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Amplitude/amplitude.test.js
@@ -247,11 +247,69 @@ describe('Amplitude identify tests', () => {
 
     // Add assertions here
   });
+  it('should identify user with only traits', () => {
+    const config = {
+      apiKey: 'YOUR_AMPLITUDE_API_KEY',
+      trackAllPages: true,
+      trackNamedPages: true,
+      trackCategorizedPages: true,
+      attribution: true,
+      flushQueueSize: 30,
+      flushIntervalMillis: 1000,
+      trackNewCampaigns: true,
+      trackRevenuePerProduct: false,
+      preferAnonymousIdForDeviceId: false,
+      traitsToSetOnce: ['email', 'name'],
+      traitsToIncrement: ['age'],
+      appendFieldsToEventProps: false,
+      unsetParamsReferrerOnNewSession: false,
+      trackProductsOnce: false,
+      versionName: '1.0.0',
+      groupTypeTrait: 'groupType',
+      groupValueTrait: 'groupValue',
+    };
+
+    const analytics = {
+      logLevel: 'debug',
+      getAnonymousId: () => 'ANONYMOUS_ID',
+    };
+
+    const destinationInfo = {
+      shouldApplyDeviceModeTransformation: true,
+      propagateEventsUntransformedOnError: false,
+      destinationId: 'DESTINATION_ID',
+    };
+
+    const rudderElement = {
+      message: {
+        context: {},
+        integrations: {
+          Amplitude: {
+            fieldsToUnset: ['unsetField', 'objUn.innerObj.ina'],
+          },
+        },
+      },
+    };
+    window.amplitude.identify = jest.fn();
+    const amplitude = new Amplitude(config, analytics, destinationInfo);
+    amplitude.init();
+    amplitude.identify(rudderElement);
+    expect(window.amplitude.identify.mock.calls[0][0]._q).toEqual([
+      {
+        args: ['unsetField'],
+        name: 'unset',
+      },
+      {
+        args: ['objUn.innerObj.ina'],
+        name: 'unset',
+      },
+    ]);
+  });
 });
 
 describe('Amplitude track tests', () => {
-  // Track event with properties and no products array
-  it('should track event with properties and no products array', () => {
+  // Track event with properties and no products
+  it('should track event with properties and no products ', () => {
     const config = {
       apiKey: 'YOUR_AMPLITUDE_API_KEY',
       trackAllPages: true,
@@ -302,8 +360,8 @@ describe('Amplitude track tests', () => {
       key2: 'value2',
     });
   });
-  // Track event with properties and empty products array
-  it('should track event with properties and empty products array', () => {
+  // Track event with properties and empty products
+  it('should track event with properties and empty products ', () => {
     const config = {
       apiKey: 'YOUR_AMPLITUDE_API_KEY',
       trackAllPages: true,

--- a/packages/analytics-js-integrations/__tests__/integrations/Amplitude/amplitude.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Amplitude/amplitude.test.js
@@ -247,7 +247,7 @@ describe('Amplitude identify tests', () => {
 
     // Add assertions here
   });
-  it('should identify user with only traits', () => {
+  it('should identify user with no traits and unset field only', () => {
     const config = {
       apiKey: 'YOUR_AMPLITUDE_API_KEY',
       trackAllPages: true,
@@ -304,6 +304,55 @@ describe('Amplitude identify tests', () => {
         name: 'unset',
       },
     ]);
+  });
+  it('should identify user with no traits and empty unset field', () => {
+    const config = {
+      apiKey: 'YOUR_AMPLITUDE_API_KEY',
+      trackAllPages: true,
+      trackNamedPages: true,
+      trackCategorizedPages: true,
+      attribution: true,
+      flushQueueSize: 30,
+      flushIntervalMillis: 1000,
+      trackNewCampaigns: true,
+      trackRevenuePerProduct: false,
+      preferAnonymousIdForDeviceId: false,
+      traitsToSetOnce: ['email', 'name'],
+      traitsToIncrement: ['age'],
+      appendFieldsToEventProps: false,
+      unsetParamsReferrerOnNewSession: false,
+      trackProductsOnce: false,
+      versionName: '1.0.0',
+      groupTypeTrait: 'groupType',
+      groupValueTrait: 'groupValue',
+    };
+
+    const analytics = {
+      logLevel: 'debug',
+      getAnonymousId: () => 'ANONYMOUS_ID',
+    };
+
+    const destinationInfo = {
+      shouldApplyDeviceModeTransformation: true,
+      propagateEventsUntransformedOnError: false,
+      destinationId: 'DESTINATION_ID',
+    };
+
+    const rudderElement = {
+      message: {
+        context: {},
+        integrations: {
+          Amplitude: {
+            fieldsToUnset: [],
+          },
+        },
+      },
+    };
+    window.amplitude.identify = jest.fn();
+    const amplitude = new Amplitude(config, analytics, destinationInfo);
+    amplitude.init();
+    amplitude.identify(rudderElement);
+    expect(window.amplitude.identify).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
@@ -6,7 +6,12 @@ import {
 } from '@rudderstack/analytics-js-common/constants/integrations/Amplitude/constants';
 import Logger from '../../utils/logger';
 import { loadNativeSdk } from './nativeSdkLoader';
-import { getTraitsToSetOnce, getTraitsToIncrement, getDestinationOptions } from './utils';
+import {
+  getTraitsToSetOnce,
+  getTraitsToIncrement,
+  getDestinationOptions,
+  getFieldsToUnset,
+} from './utils';
 
 const logger = new Logger(DISPLAY_NAME);
 
@@ -86,12 +91,12 @@ class Amplitude {
     // rudderElement.message.context will always be present as part of identify event payload.
     const { traits } = rudderElement.message.context;
     const { userId, integrations } = rudderElement.message;
-    const amplitudeIntgConfig = getDestinationOptions(integrations);
-    const fieldsToUnset = amplitudeIntgConfig?.fieldsToUnset || undefined;
+    const fieldsToUnset = getFieldsToUnset(integrations);
     const amplitudeIdentify = new window.amplitude.Identify();
     let sendIdentifyCall = false;
-    if (fieldsToUnset && Array.isArray(fieldsToUnset) && fieldsToUnset.length > 0) {
+    if (fieldsToUnset) {
       sendIdentifyCall = true;
+      // AM Docs: https://amplitude.github.io/Amplitude-JavaScript/Identify/#identifyunset
       fieldsToUnset.forEach(fieldToUnset => {
         amplitudeIdentify.unset(fieldToUnset);
       });

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
@@ -90,7 +90,7 @@ class Amplitude {
     const fieldsToUnset = amplitudeIntgConfig?.fieldsToUnset || undefined;
     const amplitudeIdentify = new window.amplitude.Identify();
     let sendIdentifyCall = false;
-    if (fieldsToUnset) {
+    if (fieldsToUnset && Array.isArray(fieldsToUnset) && fieldsToUnset.length > 0) {
       sendIdentifyCall = true;
       fieldsToUnset.forEach(fieldToUnset => {
         amplitudeIdentify.unset(fieldToUnset);

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
@@ -38,4 +38,16 @@ const getTraitsToIncrement = config => {
 const getDestinationOptions = integrationsOptions =>
   integrationsOptions && (integrationsOptions[DISPLAY_NAME] || integrationsOptions[NAME]);
 
-export { getTraitsToSetOnce, getTraitsToIncrement, getDestinationOptions };
+/**
+ * Checks if there is any fieldsTounset provided and returns that list
+ * @param {*} integrations integrations object
+ */
+const getFieldsToUnset = integrations => {
+  const amplitudeIntgConfig = getDestinationOptions(integrations);
+  const fieldsToUnset = amplitudeIntgConfig?.fieldsToUnset || undefined;
+  if (fieldsToUnset && Array.isArray(fieldsToUnset) && fieldsToUnset.length > 0) {
+    return fieldsToUnset;
+  }
+  return undefined;
+};
+export { getTraitsToSetOnce, getTraitsToIncrement, getDestinationOptions, getFieldsToUnset };


### PR DESCRIPTION
## PR Description

Adding support for [Amplitude unset field ](https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/#keys-for-the-event-argument:~:text=exceed%2040%20layers.-,user_properties,-Optional.%20Object.%20A)through Rudderstack Integration Object

## Linear task (optional)
Resolves INT-950

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
