### PR TITLE
feat(analytics-v1.1): add lock integrations version as query param in source config url

### DIFF
--- a/packages/analytics-v1.1/__tests__/utils/utils.test.js
+++ b/packages/analytics-v1.1/__tests__/utils/utils.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import * as utils from '../../src/utils/utils';
+import { fetchCookieConsentState, getConfigUrl } from '../../src/utils/utils';
 
 describe('Utilities for cookie consent management', () => {
   it('should return false when cookie consent is not enabled for OneTrust', () => {
@@ -8,7 +8,7 @@ describe('Utilities for cookie consent management', () => {
         enabled: false,
       },
     };
-    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    const actualState = fetchCookieConsentState(cookieConsentOptions);
     expect(actualState).toEqual(false);
   });
   it('should return false when cookie consent is not enabled for OneTrust', () => {
@@ -17,21 +17,21 @@ describe('Utilities for cookie consent management', () => {
         test: false,
       },
     };
-    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    const actualState = fetchCookieConsentState(cookieConsentOptions);
     expect(actualState).toEqual(false);
   });
   it('should return false when cookie consent load option is set as number', () => {
     const cookieConsentOptions = 1234567;
-    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    const actualState = fetchCookieConsentState(cookieConsentOptions);
     expect(actualState).toEqual(false);
   });
   it('should return false when cookie consent load option is set as string', () => {
     const cookieConsentOptions = 'test';
-    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    const actualState = fetchCookieConsentState(cookieConsentOptions);
     expect(actualState).toEqual(false);
   });
   it('should return false when cookie consent load option is empty object', () => {
-    const actualState = utils.fetchCookieConsentState({});
+    const actualState = fetchCookieConsentState({});
     expect(actualState).toEqual(false);
   });
   it('should return true when cookie consent is enabled for OneTrust', () => {
@@ -40,7 +40,30 @@ describe('Utilities for cookie consent management', () => {
         enabled: true,
       },
     };
-    const actualState = utils.fetchCookieConsentState(cookieConsentOptions);
+    const actualState = fetchCookieConsentState(cookieConsentOptions);
     expect(actualState).toEqual(true);
+  });
+});
+
+describe('getConfigUrl', () => {
+  const DEF_CONFIG_URL =
+    'https://api.rudderstack.com/sourceConfig/?p=__MODULE_TYPE__&v=__PACKAGE_VERSION__';
+  it('should return default config URL if no parameters are provided', () => {
+    const configUrl = getConfigUrl();
+    expect(configUrl).toEqual(DEF_CONFIG_URL);
+  });
+  it('should return config url with provided arguments as query parameters', () => {
+    const configUrl = getConfigUrl('test', 'test');
+    expect(configUrl).toEqual(`${DEF_CONFIG_URL}&writeKey=test&lockIntegrationsVersion=test`);
+  });
+
+  it('should return config url if only write key is provided', () => {
+    const configUrl = getConfigUrl('test');
+    expect(configUrl).toEqual(`${DEF_CONFIG_URL}&writeKey=test`);
+  });
+
+  it('should return config url if only lockIntegrationsVersion is provided', () => {
+    const configUrl = getConfigUrl(undefined, 'test');
+    expect(configUrl).toEqual(`${DEF_CONFIG_URL}&lockIntegrationsVersion=test`);
   });
 });

--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -1340,7 +1340,7 @@ class Analytics {
       return;
     }
 
-    let configUrl = getConfigUrl(writeKey);
+    let configUrl = getConfigUrl(writeKey, this.lockIntegrationsVersion);
     if (options && options.configUrl) {
       configUrl = getUserProvidedConfigUrl(options.configUrl, configUrl);
     }

--- a/packages/analytics-v1.1/src/utils/utils.js
+++ b/packages/analytics-v1.1/src/utils/utils.js
@@ -252,10 +252,23 @@ const isDefined = x => x !== undefined;
 const isNotNull = x => x !== null;
 const isDefinedAndNotNull = x => isDefined(x) && isNotNull(x);
 
-const getConfigUrl = writeKey =>
-  CONFIG_URL.concat(CONFIG_URL.includes('?') ? '&' : '?').concat(
-    writeKey ? `writeKey=${writeKey}` : '',
-  );
+const getConfigUrl = (writeKey, lockIntegrationsVersion) => {
+  let configUrl = CONFIG_URL;
+  const queryParamStrings = [];
+  if (writeKey) {
+    queryParamStrings.push(`writeKey=${writeKey}`);
+  }
+
+  if (lockIntegrationsVersion) {
+    queryParamStrings.push(`lockIntegrationsVersion=${lockIntegrationsVersion}`);
+  }
+
+  if (queryParamStrings.length > 0) {
+    configUrl = CONFIG_URL.concat(CONFIG_URL.includes('?') ? '&' : '?');
+    configUrl = configUrl.concat(queryParamStrings.join('&'));
+  }
+  return configUrl;
+};
 
 const getSDKUrlInfo = () => {
   const scripts = document.getElementsByTagName('script');

--- a/packages/sanity-suite/rollup.config.mjs
+++ b/packages/sanity-suite/rollup.config.mjs
@@ -24,7 +24,7 @@ const cdnVersionPath = process.env.CDN_VERSION_PATH ?? defaultVersion;
 const isStaging = process.env.STAGING === 'true';
 const isDMT = process.env.IS_DMT === 'true';
 const isDevEnvTestbook = process.env.IS_DEV_TESTBOOK === 'true';
-const distributionType = process.env.DISTRIBUTION_TYPE === 'npm' ? 'npm' : 'cdn';
+const distributionType = process.env.DISTRIBUTION_TYPE || 'cdn';
 const getDirectoryNames = async sourcePath =>
   (await readdir(sourcePath, { withFileTypes: true }))
     .filter(dirent => dirent.isDirectory())
@@ -34,7 +34,7 @@ const featuresList = await getDirectoryNames(`./public/${cdnVersionPath}`);
 console.log('featuresList', featuresList)
 
 const getDistPath = () => {
-  let distPath = distributionType? `/${distributionType}` : '/npm';
+  let distPath = distributionType ? `/${distributionType}` : '/npm';
   distPath += `/${cdnVersionPath}`;
 
   if (isStaging) {


### PR DESCRIPTION
## PR Description

Added the missing query parameter lock integrations version to the source config URL.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1058/add-integrationversionlock-in-sourceconfig-query-param-for-v11

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally and IE 11

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
