### PR TITLE
chore: upgrade rollup-plugin-serve to fix serve issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,7 @@
         "rollup-plugin-generate-html-template": "1.7.0",
         "rollup-plugin-livereload": "2.0.5",
         "rollup-plugin-polyfill-node": "0.13.0",
-        "rollup-plugin-serve": "2.0.2",
+        "rollup-plugin-serve": "2.0.3",
         "rollup-plugin-typescript2": "0.36.0",
         "rollup-plugin-visualizer": "5.12.0",
         "serve": "14.2.1",
@@ -22751,28 +22751,25 @@
       }
     },
     "node_modules/rollup-plugin-serve": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-serve/-/rollup-plugin-serve-2.0.2.tgz",
-      "integrity": "sha512-ALqyTbPhlf7FZ5RzlbDvMYvbKuCHWginJkTo6dMsbgji/a78IbsXox+pC83HENdkTRz8OXrTj+aShp3+3ratpg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-serve/-/rollup-plugin-serve-2.0.3.tgz",
+      "integrity": "sha512-gQKmfQng17+jOsX5tmDanvJkm0f9XLqWVvXsD7NGd1SlneT+U1j/HjslDUXQz6cqwLnVDRc6xF2lj6rre+eeeQ==",
       "dev": true,
       "dependencies": {
-        "mime": ">=2.4.6",
+        "mime": "^3",
         "opener": "1"
       }
     },
     "node_modules/rollup-plugin-serve/node_modules/mime": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.1.tgz",
-      "integrity": "sha512-5lZ5tyrIfliMXzFtkYyekWbtRXObT9OWa8IwQ5uxTBDHucNNwniRqo0yInflj+iYi5CBa6qxadGzGarDfuEOxA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa"
-      ],
       "bin": {
-        "mime": "bin/cli.js"
+        "mime": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/rollup-plugin-typescript2": {

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "rollup-plugin-generate-html-template": "1.7.0",
     "rollup-plugin-livereload": "2.0.5",
     "rollup-plugin-polyfill-node": "0.13.0",
-    "rollup-plugin-serve": "2.0.2",
+    "rollup-plugin-serve": "2.0.3",
     "rollup-plugin-typescript2": "0.36.0",
     "rollup-plugin-visualizer": "5.12.0",
     "serve": "14.2.1",


### PR DESCRIPTION
## PR Description

Upgraded the `rollup-plugin-serve` package to avoid the issue appearing while serving the HTML file with the SDK build.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-1161/fix-rollup-plugin-serve-issue)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
