### PR TITLE
feat: adding proxy server url for amplitude

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Amplitude/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Amplitude/browser.test.js
@@ -4,6 +4,7 @@ import Amplitude from '../../../src/integrations/Amplitude/browser';
 
 const amplitudeConfig = {
   apiKey: 'abcde',
+  proxyServerUrl : 'http://localhost:3000';
   groupTypeTrait: 'email',
   groupValueTrait: 'age',
   traitsToIncrement: [
@@ -41,6 +42,7 @@ const amplitudeConfig = {
 };
 const amplitudeEUConfig = {
   apiKey: 'abcde',
+  proxyServerUrl: 'https://example.com/',
   residencyServer: 'EU',
   groupTypeTrait: 'email',
   groupValueTrait: 'age',

--- a/packages/analytics-js-integrations/__tests__/integrations/Amplitude/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Amplitude/browser.test.js
@@ -4,7 +4,7 @@ import Amplitude from '../../../src/integrations/Amplitude/browser';
 
 const amplitudeConfig = {
   apiKey: 'abcde',
-  proxyServerUrl : 'http://localhost:3000';
+  proxyServerUrl : 'https://example.com',
   groupTypeTrait: 'email',
   groupValueTrait: 'age',
   traitsToIncrement: [

--- a/packages/analytics-js-integrations/__tests__/integrations/Amplitude/util.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Amplitude/util.test.js
@@ -164,13 +164,13 @@ describe('getDestinationOptions', () => {
 describe('formatUrl', () => {
 
   // Returns the same URL if it starts with "http://" or "https://"
-  it('should return the same URL when it starts with "http://" or "https://"', () => {
+  it('should return the same URL when it starts with "https://"', () => {
     const url = 'https://example.com';
     expect(formatUrl(url)).toBe(url);
   });
 
   // Adds "https://" prefix to the URL if it doesn't start with "http://" or "https://"
-  it('should add https:// prefix to the URL if it does not start with http:// or "https://"', () => {
+  it('should add https:// prefix to the URL if it does not start with "https://"', () => {
     const url = 'example.com';
     expect(formatUrl(url)).toBe('https://example.com');
   });

--- a/packages/analytics-js-integrations/__tests__/integrations/Amplitude/util.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Amplitude/util.test.js
@@ -6,6 +6,7 @@ import {
   getTraitsToSetOnce,
   getTraitsToIncrement,
   getDestinationOptions,
+  formatUrl
 } from '../../../src/integrations/Amplitude/utils';
 
 describe('getTraitsToSetOnce', () => {
@@ -159,3 +160,31 @@ describe('getDestinationOptions', () => {
     expect(result).toEqual({ option3: 'value3', option4: 'value4' });
   });
 });
+
+describe('formatUrl', () => {
+
+  // Returns the same URL if it starts with "http://" or "https://"
+  it('should return the same URL when it starts with "http://" or "https://"', () => {
+    const url = 'https://example.com';
+    expect(formatUrl(url)).toBe(url);
+  });
+
+  // Adds "https://" prefix to the URL if it doesn't start with "http://" or "https://"
+  it('should add https:// prefix to the URL if it does not start with http:// or "https://"', () => {
+    const url = 'example.com';
+    expect(formatUrl(url)).toBe('https://example.com');
+  });
+
+  // Returns "https://" if the input URL is an empty string
+  it('should return "https://" when the input URL is an empty string', () => {
+    const url = '';
+    expect(formatUrl(url)).toBe('https://');
+  });
+
+  // Returns "https://example.com" if the input URL is "example.com"
+  it('should return "https://example.com" when the input URL is "example.com"', () => {
+    const url = 'example.com';
+    expect(formatUrl(url)).toBe('https://example.com');
+  });
+});
+

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
@@ -11,6 +11,7 @@ import {
   getTraitsToIncrement,
   getDestinationOptions,
   getFieldsToUnset,
+  formatUrl
 } from './utils';
 
 const logger = new Logger(DISPLAY_NAME);
@@ -23,6 +24,7 @@ class Amplitude {
     this.name = NAME;
     this.analytics = analytics;
     this.apiKey = config.apiKey;
+    this.proxyServerUrl = config.proxyServerUrl;
     this.residencyServer = config.residencyServer;
     this.trackAllPages = config.trackAllPages || false;
     this.trackNamedPages = config.trackNamedPages || false;
@@ -59,6 +61,10 @@ class Amplitude {
       flushIntervalMillis: this.flushIntervalMillis,
       appVersion: this.versionName,
     };
+
+    if (isDefinedAndNotNullAndNotEmpty(this.proxyServerUrl)) {
+        initOptions.serverUrl = formatUrl(this.proxyServerUrl);
+    }
 
     // EU data residency
     // Relevant doc: https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/#eu-data-residency

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
@@ -64,7 +64,11 @@ class Amplitude {
     };
 
     if (isDefinedAndNotNullAndNotEmpty(this.proxyServerUrl)) {
-        initOptions.serverUrl = formatUrl(this.proxyServerUrl);
+        if (this.proxyServerUrl.startsWith('http://')) {
+          logger.info('Please use a secured proxy server URL');
+        } else {
+          initOptions.serverUrl =  formatUrl(this.proxyServerUrl);
+        }  
     }
 
     // EU data residency

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
@@ -4,6 +4,7 @@ import {
   NAME,
   DISPLAY_NAME,
 } from '@rudderstack/analytics-js-common/constants/integrations/Amplitude/constants';
+import { isDefinedAndNotNullAndNotEmpty } from '../../utils/commonUtils';
 import Logger from '../../utils/logger';
 import { loadNativeSdk } from './nativeSdkLoader';
 import {

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/browser.js
@@ -65,7 +65,7 @@ class Amplitude {
 
     if (isDefinedAndNotNullAndNotEmpty(this.proxyServerUrl)) {
         if (this.proxyServerUrl.startsWith('http://')) {
-          logger.info('Please use a secured proxy server URL');
+          logger.error('Please use a secured proxy server URL');
         } else {
           initOptions.serverUrl =  formatUrl(this.proxyServerUrl);
         }  

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
@@ -50,4 +50,18 @@ const getFieldsToUnset = integrations => {
   }
   return undefined;
 };
-export { getTraitsToSetOnce, getTraitsToIncrement, getDestinationOptions, getFieldsToUnset };
+
+/**
+ * Formats the given URL by adding the "https://" prefix if it doesn't already have it.
+ * 
+ * @param {string} url - The URL to be formatted.
+ * @returns {string} - The formatted URL.
+ */
+function formatUrl(url) {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  } else {
+    return `https://${url}`;
+  }
+}
+export { getTraitsToSetOnce, getTraitsToIncrement, getDestinationOptions, getFieldsToUnset, formatUrl };

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
@@ -60,8 +60,8 @@ const getFieldsToUnset = integrations => {
 function formatUrl(url) {
   if (url.startsWith('https://')) {
     return url;
-  } else {
+  } 
     return `https://${url}`;
-  }
+  
 }
 export { getTraitsToSetOnce, getTraitsToIncrement, getDestinationOptions, getFieldsToUnset, formatUrl };

--- a/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/Amplitude/utils.js
@@ -58,7 +58,7 @@ const getFieldsToUnset = integrations => {
  * @returns {string} - The formatted URL.
  */
 function formatUrl(url) {
-  if (url.startsWith('http://') || url.startsWith('https://')) {
+  if (url.startsWith('https://')) {
     return url;
   } else {
     return `https://${url}`;


### PR DESCRIPTION
## PR Description

Adding proxy server url config for amplitude. 
ref : https://www.docs.developers.amplitude.com/analytics/domain-proxy/

## Linear task (optional)
resolves INT-1016
[Linear task link](https://linear.app/rudderstack/issue/INT-1016/amplitude-in-device-mode-proxy-the-events-delivery-via-customer)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
