### PR TITLE
feat(analytics-js): auto expose new instance to window.rudderanalytics

### DIFF
--- a/.github/workflows/build-and-quality-checks-v3.yml
+++ b/.github/workflows/build-and-quality-checks-v3.yml
@@ -34,10 +34,6 @@ jobs:
           npm run check:circular
           npm run check:duplicates
 
-      - name: Execute security checks
-        run: |
-          npm run check:security
-
       - name: Execute bundle size checks
         uses: rudderlabs/github-action-check-size-limit@v2.7.0
         env:
@@ -49,3 +45,7 @@ jobs:
           clean_script: clean
           script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --exclude=@rudderstack/analytics-js-sanity-suite,@rudderstack/analytics-js-loading-scripts
           is_monorepo: true
+
+      - name: Execute security checks
+        run: |
+          npm run check:security

--- a/examples/angular/sample-app/src/app/app.component.ts
+++ b/examples/angular/sample-app/src/app/app.component.ts
@@ -35,8 +35,6 @@ export class AppComponent implements OnInit, OnDestroy {
     this.analytics.ready(() => {
       console.log('We are all set!!!');
     });
-
-    window.rudderanalytics = this.analytics;
   }
 
   page() {

--- a/examples/gatsby/sample-gatsby-site/src/pages/index.tsx
+++ b/examples/gatsby/sample-gatsby-site/src/pages/index.tsx
@@ -180,8 +180,6 @@ const IndexPage: React.FC<PageProps> = () => {
     analytics.ready(() => {
       console.log('We are all set!!!');
     });
-
-    window.rudderanalytics = analytics;
   }, []);
 
   return (

--- a/examples/nextjs/hooks/sample-app/src/app/useRudderAnalytics.ts
+++ b/examples/nextjs/hooks/sample-app/src/app/useRudderAnalytics.ts
@@ -16,7 +16,6 @@ const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
           console.log('We are all set!!!');
         });
 
-        window.rudderanalytics = analyticsInstance;
         setAnalytics(analyticsInstance);
       };
 

--- a/examples/nextjs/js/sample-app/src/app/page.js
+++ b/examples/nextjs/js/sample-app/src/app/page.js
@@ -18,9 +18,8 @@ export default function Home() {
       analytics.ready(() => {
         console.log('We are all set!!!');
       });
-
-      window.rudderanalytics = analytics;
     };
+
     initialize();
   }, []);
 

--- a/examples/nextjs/page-router/sample-app/src/useRudderAnalytics.ts
+++ b/examples/nextjs/page-router/sample-app/src/useRudderAnalytics.ts
@@ -16,7 +16,6 @@ const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
           console.log('We are all set!!!');
         });
 
-        window.rudderanalytics = analyticsInstance;
         setAnalytics(analyticsInstance);
       };
 

--- a/examples/nextjs/ts/sample-app/src/app/page.tsx
+++ b/examples/nextjs/ts/sample-app/src/app/page.tsx
@@ -18,9 +18,8 @@ export default function Home() {
       analytics.ready(() => {
         console.log('We are all set!!!');
       });
-
-      window.rudderanalytics = analytics;
     };
+
     initialize();
   }, []);
 

--- a/examples/reactjs/hooks/sample-app/src/useRudderAnalytics.ts
+++ b/examples/reactjs/hooks/sample-app/src/useRudderAnalytics.ts
@@ -13,7 +13,6 @@ const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
         console.log('We are all set!!!');
       });
 
-      window.rudderanalytics = analyticsInstance;
       setAnalytics(analyticsInstance);
     }
   }, [analytics]);

--- a/examples/reactjs/js/sample-app/src/App.js
+++ b/examples/reactjs/js/sample-app/src/App.js
@@ -16,8 +16,6 @@ function App() {
     analytics.ready(() => {
       console.log('We are all set!!!');
     });
-
-    window.rudderanalytics = analytics;
   }, []);
 
   const page = () => {

--- a/examples/reactjs/ts/sample-app/src/App.tsx
+++ b/examples/reactjs/ts/sample-app/src/App.tsx
@@ -16,8 +16,6 @@ function App() {
     analytics.ready(() => {
       console.log('We are all set!!!');
     });
-
-    window.rudderanalytics = analytics;
   }, []);
 
   const page = () => {

--- a/examples/reactjs/vite/sample-app/src/App.tsx
+++ b/examples/reactjs/vite/sample-app/src/App.tsx
@@ -16,8 +16,6 @@ function App() {
     analytics.ready(() => {
       console.log('We are all set!!!');
     });
-
-    window.rudderanalytics = analytics;
   }, []);
 
   const page = () => {

--- a/examples/symfony/sample/assets/app.js
+++ b/examples/symfony/sample/assets/app.js
@@ -11,6 +11,5 @@ import './styles/app.css';
 
 const analytics = new RudderAnalytics();
 analytics.load('<writeKey>', '<dataplaneUrl');
-window.rudderanalytics = analytics;
 
 window.rudderanalytics.page();

--- a/examples/v3-beacon/index.html
+++ b/examples/v3-beacon/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>RudderStack JS SDK v3 Beacon Example</title>
     <script>
-      window.RudderSnippetVersion = "3.0.0-beta.13";
+      window.RudderSnippetVersion = "3.0.0-beta.18";
       var sdkBaseUrl = 'https://cdn.rudderlabs.com/v3';
       var sdkName = 'rsa.min.js';
       var asyncScript = true;

--- a/examples/v3-legacy-minimum-plugins/index.html
+++ b/examples/v3-legacy-minimum-plugins/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>RudderStack JS SDK v3 Example</title>
     <script>
-      window.RudderSnippetVersion = "3.0.0-beta.13";
+      window.RudderSnippetVersion = "3.0.0-beta.18";
       var sdkBaseUrl = 'https://cdn.rudderlabs.com/v3';
       var sdkName = 'rsa.min.js';
       var asyncScript = true;

--- a/examples/v3-legacy/index.html
+++ b/examples/v3-legacy/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>RudderStack JS SDK v3 Example</title>
     <script>
-      window.RudderSnippetVersion = "3.0.0-beta.13";
+      window.RudderSnippetVersion = "3.0.0-beta.18";
       var sdkBaseUrl = 'https://cdn.rudderlabs.com/v3';
       var sdkName = 'rsa.min.js';
       var asyncScript = true;

--- a/examples/v3-minimum-plugins/index.html
+++ b/examples/v3-minimum-plugins/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>RudderStack JS SDK v3 Example</title>
     <script>
-      window.RudderSnippetVersion = "3.0.0-beta.13";
+      window.RudderSnippetVersion = "3.0.0-beta.18";
       var sdkBaseUrl = 'https://cdn.rudderlabs.com/v3';
       var sdkName = 'rsa.min.js';
       var asyncScript = true;

--- a/examples/v3/index.html
+++ b/examples/v3/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>RudderStack JS SDK v3 Example</title>
     <script>
-      window.RudderSnippetVersion = "3.0.0-beta.13";
+      window.RudderSnippetVersion = "3.0.0-beta.18";
       var sdkBaseUrl = 'https://cdn.rudderlabs.com/v3';
       var sdkName = 'rsa.min.js';
       var asyncScript = true;

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -1,4 +1,4 @@
-import { LoadOptions } from '@rudderstack/analytics-js-common/types/LoadOptions';
+import type { LoadOptions } from '@rudderstack/analytics-js-common/types/LoadOptions';
 import { RudderAnalytics } from '../../src/app/RudderAnalytics';
 import { Analytics } from '../../src/components/core/Analytics';
 
@@ -31,6 +31,20 @@ describe('Core - Rudder Analytics Facade', () => {
   afterEach(() => {
     (rudderAnalytics as any).globalSingleton = null;
     jest.resetAllMocks();
+  });
+
+  it('should return the global singleton from "rudderanalytics" global object', done => {
+    const expectedPreloadedEvents = [
+      ['consent', { sendPageEvent: true }],
+      ['consent', { sendPageEvent: false }],
+      ['track'],
+      ['track'],
+    ];
+    const globalSingleton = rudderAnalytics;
+
+    expect(window.RudderStackGlobals?.app?.preloadedEventsBuffer).toEqual(expectedPreloadedEvents);
+    expect(window.rudderanalytics).toEqual(globalSingleton);
+    done();
   });
 
   it('should return the global singleton if it exists', () => {

--- a/packages/analytics-js/public/index-legacy-only.html
+++ b/packages/analytics-js/public/index-legacy-only.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <script>
-      window.RudderSnippetVersion = "3.0.0-beta.13";
+      window.RudderSnippetVersion = "3.0.0-beta.18";
       var sdkBaseUrl = 'https://cdn.rudderlabs.com/v3';
       var sdkName = 'rsa.min.js';
       var asyncScript = true;

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <script>
-      window.RudderSnippetVersion = "3.0.0-beta.13";
+      window.RudderSnippetVersion = "3.0.0-beta.18";
       var sdkBaseUrl = 'https://cdn.rudderlabs.com/v3';
       var sdkName = 'rsa.min.js';
       var asyncScript = true;

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -83,6 +83,10 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
 
     // start loading if a load event was buffered or wait for explicit load call
     this.triggerBufferedLoadEvent();
+
+    // Assign to global "rudderanalytics" object after processing the preload buffer (if any exists)
+    // for CDN bundling IIFE exports covers this but for npm ESM and CJS bundling has to be done explicitly
+    (globalThis as typeof window).rudderanalytics = this;
   }
 
   /**

--- a/packages/sanity-suite/src/index-npm.ts
+++ b/packages/sanity-suite/src/index-npm.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { RudderAnalytics, type LoadOptions } from '@rudderstack/analytics-js/legacy';
+import { RudderAnalytics, type LoadOptions } from '@rudderstack/analytics-js';
 import { initSanitySuite } from './testBook';
 
 const getWriteKey = () => {
@@ -52,8 +52,6 @@ const sanitySuiteApp = () => {
     console.log('We are all set!!!');
     initSanitySuite();
   });
-
-  window.rudderanalytics = rudderAnalytics;
 };
 
 sanitySuiteApp();


### PR DESCRIPTION
## PR Description

Users have issues remembering to assign new Rudderanalytics instances to window.rudderanalytics. This change will auto assign the object.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-1057/auto-assign-rudderanalytics-instance-to-global-object-in-constructor)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
