### PR TITLE
feat(analytics-js): change default value of storage migrate flag to true

### DIFF
--- a/packages/analytics-js/src/state/slices/loadOptions.ts
+++ b/packages/analytics-js/src/state/slices/loadOptions.ts
@@ -34,7 +34,7 @@ const defaultLoadOptions: LoadOptions = {
     encryption: {
       version: DEFAULT_STORAGE_ENCRYPTION_VERSION,
     },
-    migrate: false,
+    migrate: true,
   },
   sendAdblockPageOptions: {},
 };


### PR DESCRIPTION
## PR Description

Change the value of storage migrate loadOption to true to assist existing users migrate

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-1208/set-storageencryptionmigrate-default-value-true)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
