### PR TITLE
fix: reddit pixel isLoaded

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/RedditPixel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/RedditPixel/browser.js
@@ -24,7 +24,7 @@ class RedditPixel {
       logger.setLogLevel(analytics.logLevel);
     }
     this.analytics = analytics;
-    this.advertiserId = config.advertiserId;
+    this.pixelId = config.advertiserId;
     this.name = NAME;
     this.eventMappingFromConfig = config.eventMappingFromConfig;
     ({
@@ -35,11 +35,11 @@ class RedditPixel {
   }
 
   init() {
-    loadNativeSdk(this.advertiserId);
+    loadNativeSdk(this.pixelId);
   }
 
   isLoaded() {
-    return !!(window.rdt && window.rdt.pixelId === this.advertiserId);
+    return !!(window.rdt && window.rdt.pixelId === this.pixelId);
   }
 
   isReady() {

--- a/packages/analytics-js-integrations/src/integrations/RedditPixel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/RedditPixel/browser.js
@@ -39,7 +39,7 @@ class RedditPixel {
   }
 
   isLoaded() {
-    return !!(window.rdt && window.rdt.advertiserId === this.advertiserId);
+    return !!(window.rdt && window.rdt.pixelId === this.advertiserId);
   }
 
   isReady() {

--- a/packages/analytics-js-integrations/src/integrations/RedditPixel/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/RedditPixel/nativeSdkLoader.js
@@ -1,6 +1,6 @@
 import { LOAD_ORIGIN } from '@rudderstack/analytics-js-common/v1.1/utils/constants';
 
-function loadNativeSdk(advertiserId) {
+function loadNativeSdk(pixelId) {
   !(function (w, d) {
     if (!w.rdt) {
       var p = (w.rdt = function () {
@@ -15,7 +15,7 @@ function loadNativeSdk(advertiserId) {
     }
   })(window, document);
 
-  window.rdt('init', advertiserId);
+  window.rdt('init', pixelId);
 }
 
 export { loadNativeSdk };


### PR DESCRIPTION
## PR Description

Resolves INT-1549
Reddit recently updated their SDK with the following changes:
'advertiserId' has been replaced with 'pixelId'
https://github.com/reddit/reddit-gtm-template/pull/28

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-1549/events-not-flowing-to-reddit-pixel-destination

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
