### PR TITLE
feat: onboard new destination commandbar

### DIFF
--- a/packages/analytics-js-common/src/constants/destDisplayNamesToFileNamesMap.ts
+++ b/packages/analytics-js-common/src/constants/destDisplayNamesToFileNamesMap.ts
@@ -152,6 +152,8 @@ import {
   SprigDirectoryName,
   SpotifyPixelDisplayName,
   SpotifyPixelDirectoryName,
+  CommandBarDisplayName,
+  CommandBarDirectoryName,
 } from './destinationNames';
 
 // The destination directory name is used as the destination SDK file name in CDN
@@ -231,7 +233,8 @@ const destDisplayNamesToFileNamesMap: Record<string, string> = {
   [TiktokAdsDisplayName]: TiktokAdsDirectoryName,
   [ActiveCampaignDisplayName]: ActiveCampaignDirectoryName,
   [SprigDisplayName]: SprigDirectoryName,
-  [SpotifyPixelDisplayName] : SpotifyPixelDirectoryName
+  [SpotifyPixelDisplayName]: SpotifyPixelDirectoryName,
+  [CommandBarDisplayName]: CommandBarDirectoryName,
 };
 
 export { destDisplayNamesToFileNamesMap };

--- a/packages/analytics-js-common/src/constants/destinationNames.ts
+++ b/packages/analytics-js-common/src/constants/destinationNames.ts
@@ -302,3 +302,7 @@ export {
   DISPLAY_NAME as SpotifyPixelDisplayName,
   DIR_NAME as SpotifyPixelDirectoryName,
 } from './integrations/SpotifyPixel/constants';
+export {
+  DISPLAY_NAME as CommandBarDisplayName,
+  DIR_NAME as CommandBarDirectoryName,
+} from './integrations/CommandBar/constants';

--- a/packages/analytics-js-common/src/constants/integrations/CommandBar/constants.ts
+++ b/packages/analytics-js-common/src/constants/integrations/CommandBar/constants.ts
@@ -1,0 +1,21 @@
+const DIR_NAME = 'CommandBar';
+const NAME = 'COMMANDBAR';
+const DISPLAY_NAME = 'CommandBar';
+
+const DISPLAY_NAME_TO_DIR_NAME_MAP = { [DISPLAY_NAME]: DIR_NAME };
+const CNameMapping = {
+  [NAME]: NAME,
+  'Command Bar': NAME,
+  'Commandbar': NAME,
+  COMMAND_BAR: NAME,
+  commandbar: NAME,
+};
+
+export {
+  NAME,
+  CNameMapping,
+  DISPLAY_NAME_TO_DIR_NAME_MAP,
+  DISPLAY_NAME,
+  DIR_NAME,
+};
+

--- a/packages/analytics-js-common/src/v1.1/utils/client_server_name.js
+++ b/packages/analytics-js-common/src/v1.1/utils/client_server_name.js
@@ -75,6 +75,7 @@ const clientToServerNames = {
   ACTIVE_CAMPAIGN: 'ActiveCampaign',
   SPRIG: 'Sprig',
   SPOTIFYPIXEL:'Spotify Pixel',
+  COMMANDBAR:'CommandBar',
 };
 
 export { clientToServerNames };

--- a/packages/analytics-js-common/src/v1.1/utils/config_to_integration_names.js
+++ b/packages/analytics-js-common/src/v1.1/utils/config_to_integration_names.js
@@ -76,6 +76,7 @@ const configToIntNames = {
   ACTIVE_CAMPAIGN: 'ActiveCampaign',
   SPRIG: 'Sprig',
   SPOTIFYPIXEL: 'SpotifyPixel',
+  COMMANDBAR: 'CommandBar',
 };
 
 export { configToIntNames };

--- a/packages/analytics-js-common/src/v1.1/utils/integration_cname.js
+++ b/packages/analytics-js-common/src/v1.1/utils/integration_cname.js
@@ -74,6 +74,7 @@ import { CNameMapping as TiktokAds } from '../../constants/integrations/TiktokAd
 import { CNameMapping as ActiveCampaign } from '../../constants/integrations/ActiveCampaign/constants';
 import { CNameMapping as Sprig } from '../../constants/integrations/Sprig/constants';
 import { CNameMapping as SpotifyPixel } from '../../constants/integrations/SpotifyPixel/constants';
+import { CNameMapping as CommandBar } from '../../constants/integrations/CommandBar/constants';
 // for sdk side native integration identification
 // add a mapping from common names to index.js exported key names as identified by Rudder
 const commonNames = {
@@ -84,6 +85,7 @@ const commonNames = {
   ...BingAds,
   ...Braze,
   ...Bugsnag,
+  ...CommandBar,
   ...Chartbeat,
   ...Clevertap,
   ...Comscore,
@@ -153,7 +155,7 @@ const commonNames = {
   ...TiktokAds,
   ...ActiveCampaign,
   ...Sprig,
-  ...SpotifyPixel
+  ...SpotifyPixel,
 };
 
 export { commonNames };

--- a/packages/analytics-js-integrations/__tests__/integrations/CommandBar/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/CommandBar/browser.test.js
@@ -1,0 +1,115 @@
+import CommandBar from '../../../src/integrations/CommandBar/browser';
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+const destinationInfo = {
+  areTransformationsConnected: false,
+  destinationId: 'sample-destination-id',
+};
+
+describe('CommandBar init tests', () => {
+  let Commandbar;
+
+  test('Testing init call of CommandBar', () => {
+    Commandbar = new CommandBar({ orgId: '12567839' }, { loglevel: 'debug' }, destinationInfo);
+    Commandbar.init();
+    expect(typeof window.CommandBar).toBe('object');
+  });
+});
+
+describe('CommandBar Track event', () => {
+  let Commandbar;
+  Commandbar = new CommandBar({ orgId: '12567839' }, { loglevel: 'debug' }, destinationInfo);
+  Commandbar.init();
+  window.CommandBar.trackEvent = jest.fn();
+  test('Testing Track Events', () => {
+    Commandbar.track({
+      message: {
+        context: {},
+        event: 'dummyEventName',
+        properties: {
+          customProp: 'testProp',
+        },
+      },
+    });
+    expect(window.CommandBar.trackEvent.mock.calls[0][0]).toEqual('dummyEventName');
+    expect(window.CommandBar.trackEvent.mock.calls[0][1]).toEqual({});
+  });
+});
+describe('CommandBar Identify event', () => {
+  let Commandbar;
+  Commandbar = new CommandBar({ orgId: '12567839' }, { loglevel: 'debug' }, destinationInfo);
+  Commandbar.init();
+  window.CommandBar.boot = jest.fn();
+  test('Testing Identify sending traits in context and hmacId as well', () => {
+    Commandbar.identify({
+      message: {
+        userId: 'rudder01',
+        context: {
+          traits: {
+            email: 'abc@ruddertack.com',
+            isRudderEvents: true,
+            hmacId: 'hmacUserId',
+          },
+        },
+      },
+    });
+    expect(window.CommandBar.boot.mock.calls[0][0]).toEqual('rudder01');
+    expect(window.CommandBar.boot.mock.calls[0][1]).toEqual({
+      email: 'abc@ruddertack.com',
+      isRudderEvents: true,
+    });
+    expect(window.CommandBar.boot.mock.calls[0][2]).toEqual({
+      hmac: 'hmacUserId',
+    });
+  });
+  test('Testing Identify sending traits in message and hmacId in traits.context ', () => {
+    Commandbar.identify({
+      message: {
+        userId: 'rudder01',
+        context: {
+          traits: {
+            email: 'abc@ruddertack.com',
+            isRudderEvents: true,
+          },
+        },
+        traits: {
+          hmacId: 'hmacUserId',
+        },
+      },
+    });
+    expect(window.CommandBar.boot.mock.calls[0][0]).toEqual('rudder01');
+    expect(window.CommandBar.boot.mock.calls[0][1]).toEqual({
+      email: 'abc@ruddertack.com',
+      isRudderEvents: true,
+    });
+    expect(window.CommandBar.boot.mock.calls[0][2]).toEqual({
+      hmac: 'hmacUserId',
+    });
+  });
+  test('Testing Identify no traits or hmacId passed ', () => {
+    Commandbar.identify({
+      message: {
+        userId: 'rudder01',
+        context: {
+          traits: {
+            email: 'abc@ruddertack.com',
+            isRudderEvents: true,
+          },
+        },
+        traits: {
+          hmacId: 'hmacUserId',
+        },
+      },
+    });
+    expect(window.CommandBar.boot.mock.calls[0][0]).toEqual('rudder01');
+    expect(window.CommandBar.boot.mock.calls[0][1]).toEqual({
+      email: 'abc@ruddertack.com',
+      isRudderEvents: true,
+    });
+    expect(window.CommandBar.boot.mock.calls[0][2]).toEqual({
+      hmac: 'hmacUserId',
+    });
+  });
+});

--- a/packages/analytics-js-integrations/src/integrations/CommandBar/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/CommandBar/browser.js
@@ -1,0 +1,78 @@
+/* eslint-disable class-methods-use-this */
+import {
+  NAME,
+  DISPLAY_NAME,
+} from '@rudderstack/analytics-js-common/constants/integrations/CommandBar/constants';
+import Logger from '../../utils/logger';
+import { loadNativeSdk } from './nativeSdkLoader';
+
+const logger = new Logger(DISPLAY_NAME);
+
+class CommandBar {
+  constructor(config, analytics, destinationInfo) {
+    if (analytics.logLevel) {
+      logger.setLogLevel(analytics.logLevel);
+    }
+    this.analytics = analytics;
+    this.orgId = config.orgId;
+    this.name = NAME;
+    ({
+      shouldApplyDeviceModeTransformation: this.shouldApplyDeviceModeTransformation,
+      propagateEventsUntransformedOnError: this.propagateEventsUntransformedOnError,
+      destinationId: this.destinationId,
+    } = destinationInfo ?? {});
+  }
+
+  init() {
+    loadNativeSdk(this.orgId);
+  }
+
+  isLoaded() {
+    return !!(window.CommandBar && typeof window.CommandBar === 'object');
+  }
+
+  isReady() {
+    return this.isLoaded();
+  }
+
+  /**
+   * Idenitfies a user with userId and traits
+   * Commandbar doc: https://www.commandbar.com/docs/sdk/lifecycle/boot/
+   * @param {*} rudderElement
+   * @returns
+   */
+  identify(rudderElement) {
+    const { message } = rudderElement;
+    const { traits, userId, context } = message;
+    const userTraits = { ...context.traits, ...traits };
+    const { hmacId } = userTraits;
+    if (!userId) {
+      logger.error('userId from identify call is missing');
+      return;
+    }
+
+    const instanceAttributes = {}; // stores commandBar options associated with the current session.
+
+    if (hmacId) {
+      instanceAttributes.hmac = hmacId;
+      delete userTraits.hmacId;
+    }
+    window.CommandBar.boot(userId, userTraits, instanceAttributes);
+  }
+  /**
+   * ref: https://www.commandbar.com/docs/sdk/events/trackevent/
+   * Track - tracks an event for an user
+   * @param {Track} track
+   */
+  track(rudderElement) {
+    const { message } = rudderElement;
+    const { event } = message;
+    if (!event) {
+      logger.error('event name from track call is missing');
+      return;
+    }
+    window.CommandBar.trackEvent(event, {});
+  }
+}
+
+export default CommandBar;

--- a/packages/analytics-js-integrations/src/integrations/CommandBar/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/CommandBar/browser.js
@@ -28,7 +28,7 @@ class CommandBar {
   }
 
   isLoaded() {
-    return !!(window.CommandBar && typeof window.CommandBar === 'object');
+    return window.CommandBar && typeof window.CommandBar.shareState === 'function';
   }
 
   isReady() {

--- a/packages/analytics-js-integrations/src/integrations/CommandBar/index.js
+++ b/packages/analytics-js-integrations/src/integrations/CommandBar/index.js
@@ -1,0 +1,1 @@
+export { default as CommandBar } from './browser';

--- a/packages/analytics-js-integrations/src/integrations/CommandBar/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/CommandBar/nativeSdkLoader.js
@@ -1,0 +1,85 @@
+import { LOAD_ORIGIN } from '@rudderstack/analytics-js-common/v1.1/utils/constants';
+
+function loadNativeSdk(orgId) {
+  var o = orgId,
+    n = ['Object.assign', 'Symbol', 'Symbol.for'].join('%2C'),
+    a = window;
+  function r(o, n) {
+    void 0 === n && (n = !1),
+      'complete' !== document.readyState &&
+        window.addEventListener('load', r.bind(null, o, n), { capture: !1, once: !0 });
+    var a = document.createElement('script');
+    a.setAttribute('data-loader', LOAD_ORIGIN);
+    (a.type = 'text/javascript'), (a.async = n), (a.src = o), document.head.appendChild(a);
+  }
+  function t() {
+    var n;
+    if (void 0 === a.CommandBar) {
+      delete a.__CommandBarBootstrap__;
+      var t = Symbol.for('CommandBar::configuration'),
+        e = Symbol.for('CommandBar::orgConfig'),
+        i = Symbol.for('CommandBar::disposed'),
+        c = Symbol.for('CommandBar::isProxy'),
+        m = Symbol.for('CommandBar::queue'),
+        d = Symbol.for('CommandBar::unwrap'),
+        l = Symbol.for('CommandBar::eventSubscriptions'),
+        s = [],
+        u = localStorage.getItem('commandbar.lc'),
+        f = u && u.includes('local') ? 'http://localhost:8000' : 'https://api.commandbar.com',
+        p = Object.assign(
+          (((n = {})[t] = { uuid: o }),
+          (n[e] = {}),
+          (n[i] = !1),
+          (n[c] = !0),
+          (n[m] = new Array()),
+          (n[d] = function () {
+            return p;
+          }),
+          (n[l] = void 0),
+          n),
+          a.CommandBar,
+        ),
+        b = ['addCommand', 'boot', 'addEventSubscriber', 'addRecordAction', 'setFormFactor'],
+        y = p;
+      Object.assign(p, {
+        shareCallbacks: function () {
+          return {};
+        },
+        shareContext: function () {
+          return {};
+        },
+      }),
+        (a.CommandBar = new Proxy(p, {
+          get: function (o, n) {
+            return n in y
+              ? p[n]
+              : 'then' !== n
+                ? b.includes(n)
+                  ? function () {
+                      var o = Array.prototype.slice.call(arguments);
+                      return new Promise(function (a, r) {
+                        o.unshift(n, a, r), p[m].push(o);
+                      });
+                    }
+                  : function () {
+                      var o = Array.prototype.slice.call(arguments);
+                      o.unshift(n), p[m].push(o);
+                    }
+                : void 0;
+          },
+        })),
+        null !== u && s.push('lc='.concat(u)),
+        s.push('version=2'),
+        r(''.concat(f, '/latest/').concat(o, '?').concat(s.join('&')), !0);
+    }
+  }
+  void 0 === Object.assign || 'undefined' == typeof Symbol || void 0 === Symbol.for
+    ? ((a.__CommandBarBootstrap__ = t),
+      r(
+        'https://polyfill.io/v3/polyfill.min.js?version=3.101.0&callback=__CommandBarBootstrap__&features=' +
+          n,
+      ))
+    : t();
+}
+
+export { loadNativeSdk };

--- a/packages/analytics-js-integrations/src/integrations/index.js
+++ b/packages/analytics-js-integrations/src/integrations/index.js
@@ -74,6 +74,7 @@ import * as TiktokAds from './TiktokAds';
 import * as ActiveCampaign from './ActiveCampaign';
 import * as Sprig from './Sprig';
 import * as SpotifyPixel from './SpotifyPixel';
+import * as CommandBar from './CommandBar';
 // the key names should match the destination.name value to keep parity everywhere
 // (config-plan name, native destination.name , exported integration name(this one below))
 
@@ -88,6 +89,7 @@ const integrations = {
   CLEVERTAP: Clevertap.default,
   COMSCORE: Comscore.default,
   CRITEO: Criteo.default,
+  COMMANDBAR: CommandBar.default,
   CUSTOMERIO: CustomerIO.default,
   DCM_FLOODLIGHT: DCMFloodlight.default,
   DRIP: Drip.default,


### PR DESCRIPTION
## PR Description
Onboard new destination commandbar
CommandBar is device mode only destination supports two calls:
trackevent -> for event tracking -> mapped to rudderstack's track call
boot -> for user identification -> mapped to rudderstack's identify call

## Linear task (optional)

Linear task link
Resolves INT-1311


## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
