### PR TITLE
fix(analytics-js-loading-scripts): add version in polyfill io url

### DIFF
--- a/examples/v3-beacon/index.html
+++ b/examples/v3-beacon/index.html
@@ -66,7 +66,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/examples/v3-legacy-minimum-plugins/index.html
+++ b/examples/v3-legacy-minimum-plugins/index.html
@@ -66,7 +66,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/examples/v3-legacy/index.html
+++ b/examples/v3-legacy/index.html
@@ -66,7 +66,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/examples/v3-minimum-plugins/index.html
+++ b/examples/v3-minimum-plugins/index.html
@@ -66,7 +66,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/examples/v3/index.html
+++ b/examples/v3/index.html
@@ -66,7 +66,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/analytics-js/public/index-legacy-only.html
+++ b/packages/analytics-js/public/index-legacy-only.html
@@ -62,7 +62,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -62,7 +62,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/loading-scripts/src/index.ts
+++ b/packages/loading-scripts/src/index.ts
@@ -83,7 +83,7 @@ window.rudderAnalyticsMount = () => {
 if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
   const rudderAnalyticsPromisesScript = document.createElement('script');
   rudderAnalyticsPromisesScript.src =
-    'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+    'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
   rudderAnalyticsPromisesScript.async = asyncScript;
   if (document.head) {
     document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/sanity-suite/public/v1.1/index-cdn.html
+++ b/packages/sanity-suite/public/v1.1/index-cdn.html
@@ -106,7 +106,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/index-local.html
+++ b/packages/sanity-suite/public/v1.1/index-local.html
@@ -113,7 +113,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/index-npm.html
+++ b/packages/sanity-suite/public/v1.1/index-npm.html
@@ -82,7 +82,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v1.1/integrations/index-cdn.html
@@ -96,7 +96,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/integrations/index-local.html
+++ b/packages/sanity-suite/public/v1.1/integrations/index-local.html
@@ -98,7 +98,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v1.1/integrations/index-npm.html
@@ -68,7 +68,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v1.1/manualLoadCall/index-cdn.html
@@ -96,7 +96,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v1.1/manualLoadCall/index-local.html
@@ -98,7 +98,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v1.1/manualLoadCall/index-npm.html
@@ -68,7 +68,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/index-cdn.html
+++ b/packages/sanity-suite/public/v3/index-cdn.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);
@@ -138,7 +138,6 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
       crossorigin="anonymous"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>
       .collapsed-row pre {

--- a/packages/sanity-suite/public/v3/index-local.html
+++ b/packages/sanity-suite/public/v3/index-local.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);
@@ -142,9 +142,6 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
       crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/index-npm.html
+++ b/packages/sanity-suite/public/v3/index-npm.html
@@ -63,7 +63,7 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
       crossorigin="anonymous"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CglobalThis%2CCMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CCMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"></script>
     <script>
       if (typeof globalThis === 'undefined') {
         Object.defineProperty(Object.prototype, '__globalThis_magic__', {

--- a/packages/sanity-suite/public/v3/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v3/integrations/index-cdn.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);
@@ -125,9 +125,6 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
       crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/integrations/index-local.html
+++ b/packages/sanity-suite/public/v3/integrations/index-local.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);
@@ -126,9 +126,6 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
       crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm.html
@@ -54,7 +54,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CglobalThis%2CMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script>
       if (typeof globalThis === 'undefined') {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);
@@ -125,9 +125,6 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
       crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);
@@ -126,9 +126,6 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
       crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
@@ -54,7 +54,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CglobalThis%2CMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script>
       if (typeof globalThis === 'undefined') {


### PR DESCRIPTION
## PR Description

POlyfill io url returns empty file if version is not defined in the query params. It might be a glitch on their side or a breaking change they introduced.

To rectify IE11 loading, changed the loading snippet accordingly

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-1392/js-sdk-snippet-ie11-polyfill-url-issue)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
