### PR TITLE
refactor: log warning instead error when a storage capability is unavailable

### DIFF
--- a/packages/analytics-js-plugins/__fixtures__/msw.handlers.js
+++ b/packages/analytics-js-plugins/__fixtures__/msw.handlers.js
@@ -40,6 +40,11 @@ const handlers = [
       status: 500,
     });
   }),
+  http.get(`https://asdf.com/bugsnag.min.js`, () => {
+    return new HttpResponse(errorMessage, {
+      status: 404,
+    });
+  }),
 ];
 
 export { handlers };

--- a/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
@@ -17,6 +17,7 @@ import {
   onError,
   getAppStateForMetadata,
 } from '../../src/bugsnag/utils';
+import { server } from '../../__fixtures__/msw.server';
 
 describe('Bugsnag utilities', () => {
   describe('isApiKeyValid', () => {
@@ -263,6 +264,13 @@ describe('Bugsnag utilities', () => {
   });
 
   describe('loadBugsnagSDK', () => {
+    beforeAll(() => {
+      server.listen();
+    });
+
+    afterAll(() => {
+      server.close();
+    });
     let insertBeforeSpy: any;
 
     class MockLogger implements ILogger {

--- a/packages/analytics-js/src/components/capabilitiesManager/detection/storage.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/detection/storage.ts
@@ -69,7 +69,7 @@ const isStorageAvailable = (
     if (isStorageQuotaExceeded(err)) {
       reason = 'full';
     }
-    logger?.error(`${msgPrefix}${reason}.`, err);
+    logger?.warn(`${msgPrefix}${reason}.`, err);
     return false;
   }
 };


### PR DESCRIPTION
## PR Description

- log warning instead error when a storage capability is unavailable
- Fixed flaky test cases for bugsnag

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
