### PR TITLE
chore: update plugins and integration sdk base url constants and unit test

### DIFF
--- a/packages/analytics-js/__tests__/components/configManager/cdnPaths.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/cdnPaths.test.ts
@@ -61,10 +61,6 @@ describe('CDN Paths: getIntegrationsCDNPath', () => {
     getSDKUrl.mockImplementation(() => undefined);
 
     const integrationsCDNPath = getIntegrationsCDNPath(dummyVersion, true, undefined);
-    expect(integrationsCDNPath).toBe(`${SDK_CDN_BASE_URL}/beta/3.0.0-beta/modern/${CDN_INT_DIR}`);
-    // TODO: change the above to production URLs when beta phase is done
-    // expect(integrationsCDNPath).toBe(
-    //   `${SDK_CDN_BASE_URL}/latest/${dummyVersion}/modern/${CDN_INT_DIR}`,
-    // );
+    expect(integrationsCDNPath).toBe(`${SDK_CDN_BASE_URL}/${dummyVersion}/modern/${CDN_INT_DIR}`);
   });
 });

--- a/packages/analytics-js/src/constants/urls.ts
+++ b/packages/analytics-js/src/constants/urls.ts
@@ -4,11 +4,8 @@ import { IS_LEGACY_BUILD } from './app';
 const BUILD_TYPE = IS_LEGACY_BUILD ? 'legacy' : 'modern';
 const SDK_CDN_BASE_URL = 'https://cdn.rudderlabs.com';
 const CDN_ARCH_VERSION_DIR = 'v3';
-const DEST_SDK_BASE_URL = `${SDK_CDN_BASE_URL}/beta/3.0.0-beta/${BUILD_TYPE}/${CDN_INT_DIR}`;
-const PLUGINS_BASE_URL = `${SDK_CDN_BASE_URL}/beta/3.0.0-beta/${BUILD_TYPE}/${CDN_PLUGINS_DIR}`;
-// TODO: change the above to production URLs when beta phase is done
-// const DEST_SDK_BASE_URL = `${SDK_CDN_BASE_URL}/latest/${CDN_ARCH_VERSION_DIR}/${BUILD_TYPE}/${CDN_INT_DIR}`;
-// const PLUGINS_BASE_URL = `${SDK_CDN_BASE_URL}/latest/${CDN_ARCH_VERSION_DIR}/${BUILD_TYPE}/${CDN_PLUGINS_DIR}`;
+const DEST_SDK_BASE_URL = `${SDK_CDN_BASE_URL}/${CDN_ARCH_VERSION_DIR}/${BUILD_TYPE}/${CDN_INT_DIR}`;
+const PLUGINS_BASE_URL = `${SDK_CDN_BASE_URL}/${CDN_ARCH_VERSION_DIR}/${BUILD_TYPE}/${CDN_PLUGINS_DIR}`;
 const DEFAULT_CONFIG_BE_URL = 'https://api.rudderstack.com';
 
 export {


### PR DESCRIPTION
## PR Description

- Default constant for plugins and integrations base url has been updated
- beta path in the unit test has been updated

## Linear task (optional)

1. https://linear.app/rudderstack/issue/SDK-1419/update-plugins-and-integration-sdk-base-url-constants-in-the-code
2. https://linear.app/rudderstack/issue/SDK-1422/remove-the-references-to-the-beta-version-in-the-unit-tests

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated analytics integration URLs from beta to production versions.
	- Improved test assertions for analytics integration CDN paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->