### PR TITLE
chore: add typesVersions declaration

### DIFF
--- a/packages/analytics-js-integrations/package.json
+++ b/packages/analytics-js-integrations/package.json
@@ -18,6 +18,13 @@
     }
   },
   "types": "./dist/npm/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/npm/index.d.ts"
+      ]
+    }
+  },
   "publishConfig": {},
   "files": [
     "dist/npm",

--- a/packages/analytics-js-plugins/package.json
+++ b/packages/analytics-js-plugins/package.json
@@ -12,12 +12,19 @@
       "import": "./dist/npm/modern/esm/index.js"
     },
     "./legacy": {
-      "types": "./index.d.ts",
+      "types": "./dist/npm/index.d.ts",
       "require": "./dist/npm/legacy/cjs/index.js",
       "import": "./dist/npm/legacy/esm/index.js"
     }
   },
   "types": "./dist/npm/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/npm/index.d.ts"
+      ]
+    }
+  },
   "publishConfig": {},
   "files": [
     "dist/npm",

--- a/packages/analytics-js-service-worker/package.json
+++ b/packages/analytics-js-service-worker/package.json
@@ -10,6 +10,13 @@
     "types": "./dist/npm/index.d.ts"
   },
   "types": "./dist/npm/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/npm/index.d.ts"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -27,6 +27,13 @@
     }
   },
   "types": "./dist/npm/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/npm/index.d.ts"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## PR Description

Added missing `typesVersions` declaration for older Typescript versions.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1456/add-typeversions-declaration-in-analytics-js-package-to-support

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
