### PR TITLE
fix: replace polyfillio with fastly

### DIFF
--- a/packages/analytics-js/public/index-legacy-only.html
+++ b/packages/analytics-js/public/index-legacy-only.html
@@ -62,7 +62,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -62,7 +62,7 @@
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement('script');
         rudderAnalyticsPromisesScript.src =
-          'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+          'https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/analytics-js/rollup.config.mjs
+++ b/packages/analytics-js/rollup.config.mjs
@@ -42,10 +42,9 @@ const modName = 'rudderanalytics';
 const remotePluginsExportsFilename = `rsa-plugins`;
 const remotePluginsHostPromise = 'Promise.resolve(window.RudderStackGlobals && window.RudderStackGlobals.app && window.RudderStackGlobals.app.pluginsCDNPath ? "" + window.RudderStackGlobals.app.pluginsCDNPath + "/' + `${remotePluginsExportsFilename}.js` + '" : ' + `"${remotePluginsBasePath}/${remotePluginsExportsFilename}.js` + '")';
 const moduleType = process.env.MODULE_TYPE || 'cdn';
-const isNpmPackageBuild = moduleType === 'npm';
 const isCDNPackageBuild = moduleType === 'cdn';
 let bugsnagSDKUrl = 'https://d2wy8f7a9ursnm.cloudfront.net/v6/bugsnag.min.js';
-let polyfillIoUrl = 'https://polyfill.io/v3/polyfill.min.js';
+let polyfillIoUrl = 'https://polyfill-fastly.io/v3/polyfill.min.js';
 
 // For Chrome extension as content script any references in code to third party URLs
 // throw violations at approval phase even if relevant code is not used

--- a/packages/analytics-v1.1/rollup-configs/rollup.utilities.mjs
+++ b/packages/analytics-v1.1/rollup-configs/rollup.utilities.mjs
@@ -21,7 +21,7 @@ dotenv.config();
 
 const isContentScriptBuild = process.env.NO_EXTERNAL_HOST;
 let bugsnagSDKUrl = 'https://d2wy8f7a9ursnm.cloudfront.net/v6/bugsnag.min.js';
-let polyfillIoUrl = 'https://polyfill.io/v3/polyfill.min.js';
+let polyfillIoUrl = 'https://polyfill-fastly.io/v3/polyfill.min.js';
 let googleAdsSDKUrl = '//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';
 
 // For Chrome extension as content script any references in code to third party URLs

--- a/packages/loading-scripts/src/index.ts
+++ b/packages/loading-scripts/src/index.ts
@@ -55,7 +55,7 @@ try {
 
 window.rudderAnalyticsMount = () => {
   /* eslint-disable */
-  // globalThis polyfill as polyfill.io one does not work in legacy safari
+  // globalThis polyfill as polyfill-fastly.io one does not work in legacy safari
   if (typeof globalThis === 'undefined') {
     Object.defineProperty(Object.prototype, '__globalThis_magic__', {
       get: function get() {
@@ -83,7 +83,7 @@ window.rudderAnalyticsMount = () => {
 if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
   const rudderAnalyticsPromisesScript = document.createElement('script');
   rudderAnalyticsPromisesScript.src =
-    'https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
+    'https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount';
   rudderAnalyticsPromisesScript.async = asyncScript;
   if (document.head) {
     document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/sanity-suite/public/v1.1/index-cdn.html
+++ b/packages/sanity-suite/public/v1.1/index-cdn.html
@@ -106,7 +106,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/index-local.html
+++ b/packages/sanity-suite/public/v1.1/index-local.html
@@ -113,7 +113,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/index-npm.html
+++ b/packages/sanity-suite/public/v1.1/index-npm.html
@@ -82,7 +82,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v1.1/integrations/index-cdn.html
@@ -96,7 +96,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/integrations/index-local.html
+++ b/packages/sanity-suite/public/v1.1/integrations/index-local.html
@@ -98,7 +98,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v1.1/integrations/index-npm.html
@@ -68,7 +68,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v1.1/manualLoadCall/index-cdn.html
@@ -96,7 +96,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v1.1/manualLoadCall/index-local.html
@@ -98,7 +98,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v1.1/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v1.1/manualLoadCall/index-npm.html
@@ -68,7 +68,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=MutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/index-cdn.html
+++ b/packages/sanity-suite/public/v3/index-cdn.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/sanity-suite/public/v3/index-local.html
+++ b/packages/sanity-suite/public/v3/index-local.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/sanity-suite/public/v3/index-npm.html
+++ b/packages/sanity-suite/public/v3/index-npm.html
@@ -63,7 +63,7 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
       crossorigin="anonymous"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CCMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"></script>
+    <script src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CCMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"></script>
     <script>
       if (typeof globalThis === 'undefined') {
         Object.defineProperty(Object.prototype, '__globalThis_magic__', {

--- a/packages/sanity-suite/public/v3/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v3/integrations/index-cdn.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/sanity-suite/public/v3/integrations/index-local.html
+++ b/packages/sanity-suite/public/v3/integrations/index-local.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/sanity-suite/public/v3/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm.html
@@ -54,7 +54,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script>
       if (typeof globalThis === 'undefined') {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
@@ -63,7 +63,7 @@
       };
       if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
         var rudderAnalyticsPromisesScript = document.createElement("script");
-        rudderAnalyticsPromisesScript.src = "https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
+        rudderAnalyticsPromisesScript.src = "https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount";
         rudderAnalyticsPromisesScript.async = asyncScript;
         if (document.head) {
           document.head.appendChild(rudderAnalyticsPromisesScript);

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
@@ -54,7 +54,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://polyfill.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
+      src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CglobalThis%2CMutationObserver%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CString.prototype.endsWith%2CString.prototype.includes%2CString.prototype.startsWith%2CObject.entries%2CObject.values%2CElement.prototype.dataset%2CString.prototype.replaceAll"
     ></script>
     <script>
       if (typeof globalThis === 'undefined') {


### PR DESCRIPTION
## PR Description

We're now using fastly polyfill service instead of polyfill.io.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1405/use-fastly-instead-of-polyfillio

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source URL for polyfill scripts across various files to use a new domain (`polyfill-fastly.io`) for improved compatibility and performance. This affects the loading of essential web features in legacy and modern browsers alike.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->