### PR TITLE
fix: ninetailed: modify page support

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Ninetailed/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Ninetailed/browser.test.js
@@ -46,7 +46,7 @@ describe('Ninetailed Event APIs', () => {
   describe('Page', () => {
     let nt;
     beforeEach(() => {
-      nt = new Ninetailed({}, { loglevel: 'DEBUG' }, destinationInfo);
+      nt = new Ninetailed({ sendPageInDevice: true }, { loglevel: 'DEBUG' }, destinationInfo);
       window.ninetailed.page = jest.fn();
     });
     afterAll(() => {
@@ -78,6 +78,15 @@ describe('Ninetailed Event APIs', () => {
         },
       });
       expect(window.ninetailed.page.mock.calls[0][0]).toEqual(undefined);
+    });
+    test('send page events toggle off', () => {
+      nt = new Ninetailed({ sendPageInDevice: false }, { loglevel: 'DEBUG' }, destinationInfo);
+      nt.page({
+        message: {
+          context: {},
+        },
+      });
+      expect(window.ninetailed.page).toHaveBeenCalledTimes(0);
     });
   });
   describe('Track', () => {

--- a/packages/analytics-js-integrations/src/integrations/Ninetailed/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Ninetailed/browser.js
@@ -14,6 +14,7 @@ class Ninetailed {
     }
     this.analytics = analytics;
     this.name = NAME;
+    this.sendPageEvents = config.sendPageInDevice;
     ({
       shouldApplyDeviceModeTransformation: this.shouldApplyDeviceModeTransformation,
       propagateEventsUntransformedOnError: this.propagateEventsUntransformedOnError,
@@ -51,14 +52,16 @@ class Ninetailed {
     window.ninetailed.track(event, properties);
   }
   page(rudderElement) {
-    const { message } = rudderElement;
-    const { properties } = message;
-    if (properties) {
-      properties.url = window.location.href;
-      window.ninetailed.page(properties);
-      return;
+    if (this.sendPageEvents) {
+      const { message } = rudderElement;
+      const { properties } = message;
+      if (properties) {
+        properties.url = window.location.href;
+        window.ninetailed.page(properties);
+        return;
+      }
+      window.ninetailed.page();
     }
-    window.ninetailed.page();
   }
 }
 


### PR DESCRIPTION
## PR Description

Modifying page support for ninetailed.
It is recommended to use ninetailed page calls directly and not via RS to avoid delays and hence a toggle is provided in the Rudderstack Destination Configuration UI on the same note.

## Linear task (optional)

Linear task link
Resolves INT-1887

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a toggle for sending page events in the Ninetailed integration, allowing for more flexible analytics configurations.
- **Tests**
	- Updated test cases to cover the new toggle functionality for page events in Ninetailed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->