### PR TITLE
fix: making the error message as warn

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/LinkedInInsightTag/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/LinkedInInsightTag/browser.js
@@ -64,7 +64,7 @@ class LinkedInInsightTag {
       false,
     );
     if (!eventMapping[trimmedEvent]) {
-      logger.error(
+      logger.warn(
         `The "${event}" event is not mapped in the destination dashboard. It'll be skipped`,
       );
       return;


### PR DESCRIPTION
## PR Description

A user has asked for this alteration, as they choose not to map all the events for LinkedIn insight tag

## Linear task (optional)

resolves INT-1985

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
