### PR TITLE
fix: remove unnecessary window globals declarations

### DIFF
--- a/packages/analytics-js/src/index.ts
+++ b/packages/analytics-js/src/index.ts
@@ -1,6 +1,5 @@
 import type { RudderAnalytics } from './app/RudderAnalytics';
 import type { RudderAnalyticsPreloader } from './components/preloadBuffer/types';
-import type { IRudderStackGlobals } from './app/IRudderStackGlobals';
 
 export {
   type AnonymousIdOptions,
@@ -21,7 +20,6 @@ export { type LogLevel } from '@rudderstack/analytics-js-common/types/Logger';
 export { type PluginName } from '@rudderstack/analytics-js-common/types/PluginsManager';
 export { type IdentifyTraits } from '@rudderstack/analytics-js-common/types/traits';
 export { RudderAnalytics } from './app/RudderAnalytics';
-export { type IRudderStackGlobals } from './app/IRudderStackGlobals';
 export {
   type RudderAnalyticsPreloader,
   type PreloadedEventCall,
@@ -30,7 +28,6 @@ export {
 declare global {
   interface Window {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
-    RudderStackGlobals: IRudderStackGlobals;
     rudderAnalyticsMount: () => void;
     rudderAnalyticsBuildType: 'legacy' | 'modern';
   }

--- a/packages/analytics-js/src/index.ts
+++ b/packages/analytics-js/src/index.ts
@@ -28,7 +28,5 @@ export {
 declare global {
   interface Window {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
-    rudderAnalyticsMount: () => void;
-    rudderAnalyticsBuildType: 'legacy' | 'modern';
   }
 }

--- a/packages/analytics-js/src/types/rudderanalytics.d.ts
+++ b/packages/analytics-js/src/types/rudderanalytics.d.ts
@@ -9,7 +9,6 @@ declare global {
   interface Window {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
     RudderStackGlobals: IRudderStackGlobals;
-    rudderAnalyticsMount: () => void;
     rudderAnalyticsBuildType: 'legacy' | 'modern';
     RudderSnippetVersion?: string;
   }

--- a/packages/analytics-js/src/types/rudderanalytics.d.ts
+++ b/packages/analytics-js/src/types/rudderanalytics.d.ts
@@ -9,7 +9,6 @@ declare global {
   interface Window {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
     RudderStackGlobals: IRudderStackGlobals;
-    rudderAnalyticsBuildType: 'legacy' | 'modern';
     RudderSnippetVersion?: string;
   }
 }

--- a/packages/loading-scripts/src/types/rudderanalytics.d.ts
+++ b/packages/loading-scripts/src/types/rudderanalytics.d.ts
@@ -1,5 +1,4 @@
 import type {
-  IRudderStackGlobals,
   RudderAnalytics,
   PreloadedEventCall,
   RudderAnalyticsPreloader,
@@ -8,7 +7,6 @@ import type {
 declare global {
   interface Window {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
-    RudderStackGlobals: IRudderStackGlobals;
     rudderAnalyticsMount: () => void;
     rudderAnalyticsBuildType: 'legacy' | 'modern';
     RudderSnippetVersion?: string;

--- a/packages/sanity-suite/src/types/rudderanalytics.d.ts
+++ b/packages/sanity-suite/src/types/rudderanalytics.d.ts
@@ -7,7 +7,5 @@ import type {
 declare global {
   interface Window {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
-    rudderAnalyticsBuildType: 'legacy' | 'modern';
-    RudderSnippetVersion?: string;
   }
 }

--- a/packages/sanity-suite/src/types/rudderanalytics.d.ts
+++ b/packages/sanity-suite/src/types/rudderanalytics.d.ts
@@ -1,5 +1,4 @@
 import type {
-  IRudderStackGlobals,
   RudderAnalytics,
   PreloadedEventCall,
   RudderAnalyticsPreloader,
@@ -8,8 +7,6 @@ import type {
 declare global {
   interface Window {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
-    RudderStackGlobals: IRudderStackGlobals;
-    rudderAnalyticsMount: () => void;
     rudderAnalyticsBuildType: 'legacy' | 'modern';
     RudderSnippetVersion?: string;
   }


### PR DESCRIPTION
## PR Description

Excluded unwanted window globals declarations and exports from the package.
Please take a look at the linked Linear ticket for more details.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1588/fix-exported-window-globals-type-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
