### PR TITLE
fix: remove MutationObserver and make polyfill checks consistent

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,9 +5,9 @@
     },
     "lintAllEsApis": true,
     "polyfills": [
-      "Promise",
       "URL",
       "URLSearchParams",
+      "Promise",
       "Number.isNaN",
       "Number.isInteger",
       "Array.from",
@@ -16,15 +16,18 @@
       "String.prototype.endsWith",
       "String.prototype.startsWith",
       "String.prototype.includes",
+      "String.prototype.replaceAll",
+      "String.fromCodePoint",
       "Object.entries",
       "Object.values",
-      "Element.prototype.dataset",
-      "String.prototype.replaceAll",
+      "Object.assign",
       "TextEncoder",
       "TextDecoder",
-      "String.fromCodePoint",
+      "CustomEvent",
       "requestAnimationFrame",
-      "cancelAnimationFrame"
+      "cancelAnimationFrame",
+      "navigator.sendBeacon",
+      "Uint8Array"
     ]
   },
   "env": {

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: 'BUG : <Title>'
 labels: bug, open source
-assignees: MoumitaM
+assignees: rudderlabs/js-sdk
 ---
 
 **Describe the bug**
@@ -25,13 +25,17 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional Information (please complete the following information):**
 
-- SDK installation: NPM/CDN
-- CDN URL: (if applicable)
-- NPM Version: (if applicable)
+- SDK installation type: NPM/CDN
+- SDK CDN URL: (if applicable)
+- SDK version: (for NPM installation)
+- Node version: (if applicable)
+- NPM version: (if applicable)
+- TypeScript version: (if applicable)
 - Webpage URL: (where the SDK is installed, if applicable)
-- Share the event payload
-- Integration that has the issue (if applicable)
-- Used JS Framework (e.g: NextJS, ReactJs, Vue) (if applicable)
+- Share the event payload: (if applicable)
+- Integration that has the issue: (if applicable)
+- Framework and version(e.g: Next.js, React, Vue): (if applicable)
+- Bundling toolset (e.g: Webpack, Rollup): (if applicable)
 
 **Desktop (please complete the following information):**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: 'Feature Request: <Title>'
 labels: open source
-assignees: saikumarrs
+assignees: rudderlabs/js-sdk
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/packages/analytics-js/src/components/capabilitiesManager/detection/dom.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/detection/dom.ts
@@ -1,36 +1,39 @@
-import { isFunction, isUndefined } from '@rudderstack/analytics-js-common/utilities/checks';
+import { isFunction } from '@rudderstack/analytics-js-common/utilities/checks';
 
 const isDatasetAvailable = (): boolean => {
-  const testElement = document.createElement('div');
+  const testElement = globalThis.document.createElement('div');
   testElement.setAttribute('data-a-b', 'c');
   return testElement.dataset ? testElement.dataset.aB === 'c' : false;
 };
 
 const legacyJSEngineRequiredPolyfills: Record<string, () => boolean> = {
-  URL: () => !isFunction(globalThis.URL) || !globalThis.URLSearchParams,
-  MutationObserver: () => isUndefined(MutationObserver),
-  Promise: () => isUndefined(Promise),
-  'Number.isNaN': () => !Number.isNaN,
-  'Number.isInteger': () => !Number.isInteger,
-  'Array.from': () => !Array.from,
-  'Array.prototype.find': () => !Array.prototype.find,
-  'Array.prototype.includes': () => !Array.prototype.includes,
-  'String.prototype.endsWith': () => !String.prototype.endsWith,
-  'String.prototype.startsWith': () => !String.prototype.startsWith,
-  'String.prototype.includes': () => !String.prototype.includes,
-  'Object.entries': () => !Object.entries,
-  'Object.values': () => !Object.values,
-  'Object.assign': () => typeof Object.assign !== 'function',
+  // Ideally, we should separate the checks for URL and URLSearchParams but
+  // the polyfill service serves them under the same feature name, "URL".
+  URL: () => !isFunction(globalThis.URL) || !isFunction(globalThis.URLSearchParams),
+  Promise: () => !isFunction(globalThis.Promise),
+  'Number.isNaN': () => !isFunction(globalThis.Number.isNaN),
+  'Number.isInteger': () => !isFunction(globalThis.Number.isInteger),
+  'Array.from': () => !isFunction(globalThis.Array.from),
+  'Array.prototype.find': () => !isFunction(globalThis.Array.prototype.find),
+  'Array.prototype.includes': () => !isFunction(globalThis.Array.prototype.includes),
+  'String.prototype.endsWith': () => !isFunction(globalThis.String.prototype.endsWith),
+  'String.prototype.startsWith': () => !isFunction(globalThis.String.prototype.startsWith),
+  'String.prototype.includes': () => !isFunction(globalThis.String.prototype.includes),
+  'String.prototype.replaceAll': () => !isFunction(globalThis.String.prototype.replaceAll),
+  'String.fromCodePoint': () => !isFunction(globalThis.String.fromCodePoint),
+  'Object.entries': () => !isFunction(globalThis.Object.entries),
+  'Object.values': () => !isFunction(globalThis.Object.values),
+  'Object.assign': () => !isFunction(globalThis.Object.assign),
   'Element.prototype.dataset': () => !isDatasetAvailable(),
-  'String.prototype.replaceAll': () => !String.prototype.replaceAll,
-  TextEncoder: () => isUndefined(TextEncoder) || isUndefined(TextDecoder),
-  'String.fromCodePoint': () => !String.fromCodePoint,
+  // Ideally, we should separate the checks for TextEncoder and TextDecoder but
+  // the polyfill service serves them under the same feature name, "TextEncoder".
+  TextEncoder: () => !isFunction(globalThis.TextEncoder) || !isFunction(globalThis.TextDecoder),
   requestAnimationFrame: () =>
     !isFunction(globalThis.requestAnimationFrame) || !isFunction(globalThis.cancelAnimationFrame),
   CustomEvent: () => !isFunction(globalThis.CustomEvent),
-  /* eslint-disable-next-line */
-  'navigator.sendBeacon': () => !isFunction(navigator.sendBeacon),
-  ArrayBuffer: () => !isFunction(Uint8Array),
+  'navigator.sendBeacon': () => !isFunction(globalThis.navigator.sendBeacon),
+  // Note, the polyfill service serves both ArrayBuffer and Uint8Array under the same feature name, "ArrayBuffer".
+  ArrayBuffer: () => !isFunction(globalThis.Uint8Array),
 };
 
 const isLegacyJSEngine = (): boolean => {


### PR DESCRIPTION
## PR Description

- Removed MutationObserver polyfill as it's unused.
- Made all the polyfill detection checks consistent.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1589/remove-mutationobserver-polyfill-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
