### PR TITLE
feat: add a patch for storejs to expose length of the store

### DIFF
--- a/packages/analytics-js/src/services/StoreManager/storages/LocalStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/LocalStorage.ts
@@ -38,7 +38,7 @@ class LocalStorage implements IStorage {
 
   setItem(key: string, value: any) {
     store.set(key, value);
-    this.length = store.keys().length;
+    this.length = store.len();
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -49,7 +49,7 @@ class LocalStorage implements IStorage {
 
   removeItem(key: string) {
     store.remove(key);
-    this.length = store.keys().length;
+    this.length = store.len();
   }
 
   clear() {

--- a/patches/storejs+2.0.7.patch
+++ b/patches/storejs+2.0.7.patch
@@ -1,0 +1,55 @@
+diff --git a/node_modules/storejs/dist/store.cjs.js b/node_modules/storejs/dist/store.cjs.js
+index 3de4dd1..bea302a 100644
+--- a/node_modules/storejs/dist/store.cjs.js
++++ b/node_modules/storejs/dist/store.cjs.js
+@@ -144,6 +144,9 @@ Store.prototype = {
+       if (arr[i].indexOf(str) > -1) dt[arr[i]] = this.get(arr[i]);
+     }
+     return dt;
++  },
++  len: function len() {
++    return storage.length;
+   }
+ };
+ var _Store = null;
+diff --git a/node_modules/storejs/dist/store.esm.js b/node_modules/storejs/dist/store.esm.js
+index 9c7daf0..dcaa79f 100644
+--- a/node_modules/storejs/dist/store.esm.js
++++ b/node_modules/storejs/dist/store.esm.js
+@@ -142,6 +142,9 @@ Store.prototype = {
+       if (arr[i].indexOf(str) > -1) dt[arr[i]] = this.get(arr[i]);
+     }
+     return dt;
++  },
++  len: function len() {
++    return storage.length;
+   }
+ };
+ var _Store = null;
+diff --git a/node_modules/storejs/dist/store.js b/node_modules/storejs/dist/store.js
+index f5d95a5..ff20315 100644
+--- a/node_modules/storejs/dist/store.js
++++ b/node_modules/storejs/dist/store.js
+@@ -148,6 +148,9 @@
+         if (arr[i].indexOf(str) > -1) dt[arr[i]] = this.get(arr[i]);
+       }
+       return dt;
++    },
++    len: function len() {
++      return storage.length;
+     }
+   };
+   var _Store = null;
+diff --git a/node_modules/storejs/types/index.d.ts b/node_modules/storejs/types/index.d.ts
+index 9ea1ef8..4ae8abe 100644
+--- a/node_modules/storejs/types/index.d.ts
++++ b/node_modules/storejs/types/index.d.ts
+@@ -30,6 +30,8 @@ declare class Store {
+   search(keyword: string): Record<string, any>
+ 
+   clear(): Store
++
++  len(): number
+ }
+ 
+ declare let s: typeof store & Store


### PR DESCRIPTION
## PR Description

Added a patch for storejs to expose the length of the store

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1550/failed-to-save-the-value-for-ack-to-storage-null-is-not-an-object

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the efficiency of setting and removing items in local storage by optimizing how storage size is calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->