### PR TITLE
feat: added custom domain support in ga4

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/GA4/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/GA4/browser.js
@@ -37,6 +37,7 @@ export default class GA4 {
     this.piiPropertiesToIgnore = config.piiPropertiesToIgnore || [];
     this.extendPageViewParams = config.extendPageViewParams || false;
     this.overrideClientAndSessionId = config.overrideClientAndSessionId || false;
+    this.sdkBaseUrl = config.sdkBaseUrl ? config.sdkBaseUrl : 'https://www.googletagmanager.com';
     ({
       shouldApplyDeviceModeTransformation: this.shouldApplyDeviceModeTransformation,
       propagateEventsUntransformedOnError: this.propagateEventsUntransformedOnError,
@@ -44,7 +45,7 @@ export default class GA4 {
     } = destinationInfo ?? {});
   }
 
-  loadScript(measurementId) {
+  loadScript(measurementId, sdkBaseUrl) {
     window.dataLayer = window.dataLayer || [];
     window.gtag =
       window.gtag ||
@@ -128,14 +129,11 @@ export default class GA4 {
       this.sessionNumber = sessionNumber;
     });
 
-    ScriptLoader(
-      'google-analytics 4',
-      `https://www.googletagmanager.com/gtag/js?id=${measurementId}`,
-    );
+    ScriptLoader('google-analytics 4', `${sdkBaseUrl}/gtag/js?id=${measurementId}`);
   }
 
   init() {
-    this.loadScript(this.measurementId);
+    this.loadScript(this.measurementId, this.sdkBaseUrl);
   }
 
   /**


### PR DESCRIPTION
## PR Description

In this PR, we are adding support in GA4 to take `sdkBaseUrl` from the config and load the gtag.js with {sdkBaseUrl}/gtag/js?id=${measurementId}. Default value of `sdkBaseUrl` is `https://www.googletagmanager.com` .

## Linear task (optional)
Resolves INT-1983

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
