### PR TITLE
feat: add autoConfig support in FBPixel, add tests

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/browser.test.js
@@ -1,6 +1,8 @@
 import FacebookPixel from '../../../src/integrations/FacebookPixel/browser';
 
-beforeAll(() => {});
+beforeAll(() => {
+  window.fbq = jest.fn();
+});
 
 afterAll(() => {
   jest.restoreAllMocks();
@@ -57,7 +59,7 @@ describe('FacebookPixel init tests', () => {
     });
   });
 
-  test('Testing init call of Facebook Pixel with identified user and updated mapping false', () => {
+  test('Testing init call of Facebook Pixel with identified user and updated mapping false and autoConfig configured', () => {
     const mockAnalytics = {
       getUserTraits: jest.fn(() => ({
         firstName: 'rudder',
@@ -68,12 +70,13 @@ describe('FacebookPixel init tests', () => {
       getUserId: jest.fn(() => 'testUserID'),
     };
     facebookPixel = new FacebookPixel(
-      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: false },
+      { pixelId: '12567839', advancedMapping: true, useUpdatedMapping: false, autoConfig: true },
       mockAnalytics,
       destinationInfo,
     );
     facebookPixel.init();
     expect(typeof window.fbq).toBe('function');
+    expect(window.fbq).toHaveBeenCalledWith('set', 'autoConfig', true, '12567839');
     expect(facebookPixel.userPayload).toStrictEqual({
       email: 'abcd@rudderstack.com',
       firstName: 'rudder',

--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
@@ -36,7 +36,7 @@ class FacebookPixel {
     if (analytics.logLevel) {
       logger.setLogLevel(analytics.logLevel);
     }
-    this.autoConfig = config.autoConfig;
+    this.autoConfig = (config.autoConfig === undefined ? true : config.autoConfig);
     this.blacklistPiiProperties = config.blacklistPiiProperties;
     this.categoryToContent = config.categoryToContent || [];
     this.pixelId = config.pixelId;

--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
@@ -36,6 +36,7 @@ class FacebookPixel {
     if (analytics.logLevel) {
       logger.setLogLevel(analytics.logLevel);
     }
+    this.autoConfig = config.autoConfig;
     this.blacklistPiiProperties = config.blacklistPiiProperties;
     this.categoryToContent = config.categoryToContent || [];
     this.pixelId = config.pixelId;
@@ -72,6 +73,7 @@ class FacebookPixel {
     window.fbq.allowDuplicatePageViews = true; // enables fb
     window.fbq.version = '2.0';
     window.fbq.queue = [];
+    window.fbq('set', 'autoConfig', this.autoConfig, this.pixelId); // toggle autoConfig : sends button click and page metadata
     if (this.advancedMapping) {
       if (this.useUpdatedMapping) {
         const userData = {


### PR DESCRIPTION
## PR Description

The Meta Pixel will send button click and page metadata (such as data structured according to Opengraph or Schema.org formats) from your website to improve your ads delivery and measurement and automate your Pixel setup. To configure the Meta Pixel to not send this additional information, we are introducing a UI toggle

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-2061/facebook-pixel-is-there-any-way-we-could-add-this-as-a-toggle-in-the

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the Facebook Pixel integration with an `autoConfig` option to better manage analytics configurations.
	- Added functionality to track button clicks and page metadata using Facebook Pixel.

- **Tests**
	- Updated tests to include checks for the new `autoConfig` setting in Facebook Pixel integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->