### PR TITLE
feat: gtm messageId support for track and page

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/GoogleTagManager/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/GoogleTagManager/browser.test.js
@@ -1,0 +1,167 @@
+import GoogleTagManager from '../../../src/integrations/GoogleTagManager/browser';
+import { loadNativeSdk } from '../../../src/integrations/GoogleTagManager/nativeSdkLoader';
+
+jest.mock('../../../src/integrations/GoogleTagManager/nativeSdkLoader', () => ({
+  loadNativeSdk: jest.fn(),
+}));
+
+const commonTraits = {
+  name: 'John Doe',
+  email: 'john@example.com',
+};
+
+describe('GoogleTagManager', () => {
+  let googleTagManager;
+  const config = {
+    containerID: 'DUMMY_CONTAINER_ID',
+    serverUrl: 'DUMMY_SERVER_URL',
+  };
+  const analytics = {
+    logLevel: 'debug',
+  };
+  const destinationInfo = {
+    shouldApplyDeviceModeTransformation: true,
+    propagateEventsUntransformedOnError: false,
+    destinationId: 'DUMMY_DESTINATION_ID',
+  };
+
+  beforeEach(() => {
+    googleTagManager = new GoogleTagManager(config, analytics, destinationInfo);
+    window.dataLayer = [];
+  });
+
+  describe('constructor', () => {
+    it('should set instance properties correctly', () => {
+      expect(googleTagManager.analytics).toEqual(analytics);
+      expect(googleTagManager.containerID).toEqual(config.containerID);
+      expect(googleTagManager.serverUrl).toEqual(config.serverUrl);
+      expect(googleTagManager.shouldApplyDeviceModeTransformation).toEqual(true);
+      expect(googleTagManager.propagateEventsUntransformedOnError).toEqual(false);
+      expect(googleTagManager.destinationId).toEqual(destinationInfo.destinationId);
+    });
+  });
+
+  describe('init', () => {
+    it('should call loadNativeSdk with containerID and serverUrl', () => {
+      googleTagManager.init();
+      expect(loadNativeSdk).toHaveBeenCalledWith(config.containerID, config.serverUrl);
+    });
+  });
+
+  describe('isLoaded', () => {
+    it('should return true if dataLayer is loaded', () => {
+      // Mock the push method to simulate that dataLayer is loaded
+      window.dataLayer = [];
+      window.dataLayer.push = function () {}; // Replace native push with a dummy function
+      expect(googleTagManager.isLoaded()).toBe(true);
+    });
+
+    it('should return false if dataLayer is not loaded', () => {
+      delete window.dataLayer;
+      expect(googleTagManager.isLoaded()).toBe(false);
+    });
+  });
+
+  describe('isReady', () => {
+    it('should return the same result as isLoaded', () => {
+      const isLoadedSpy = jest.spyOn(googleTagManager, 'isLoaded').mockReturnValue(true);
+      expect(googleTagManager.isReady()).toBe(true);
+      isLoadedSpy.mockReturnValue(false);
+      expect(googleTagManager.isReady()).toBe(false);
+    });
+  });
+
+  describe('identify', () => {
+    it('should send traits to dataLayer', () => {
+      const rudderElement = {
+        message: {
+          context: {
+            traits: commonTraits,
+          },
+        },
+      };
+      googleTagManager.identify(rudderElement);
+      expect(window.dataLayer[0]).toEqual({ traits: rudderElement.message.context.traits });
+    });
+  });
+
+  describe('track', () => {
+    it('should send track event to dataLayer', () => {
+      const rudderElement = {
+        message: {
+          event: 'Clicked Button',
+          userId: 'user123',
+          anonymousId: 'anon456',
+          context: {
+            traits: commonTraits,
+          },
+          properties: {
+            buttonType: 'primary',
+          },
+          messageId: '123456789',
+        },
+      };
+      googleTagManager.track(rudderElement);
+      const expectedProps = {
+        event: rudderElement.message.event,
+        userId: rudderElement.message.userId,
+        anonymousId: rudderElement.message.anonymousId,
+        traits: rudderElement.message.context.traits,
+        buttonType: 'primary',
+        messageId: rudderElement.message.messageId,
+      };
+      expect(window.dataLayer[0]).toEqual(expectedProps);
+    });
+  });
+
+  describe('page', () => {
+    it('should send page view event to dataLayer', () => {
+      const rudderElement = {
+        message: {
+          name: 'Homepage',
+          userId: 'user123',
+          anonymousId: 'anon456',
+          context: {
+            traits: commonTraits,
+          },
+          properties: {
+            category: 'landing',
+          },
+          messageId: '987654321',
+        },
+      };
+      googleTagManager.page(rudderElement);
+      const expectedProps = {
+        event: 'Viewed landing Homepage page',
+        userId: rudderElement.message.userId,
+        anonymousId: rudderElement.message.anonymousId,
+        traits: rudderElement.message.context.traits,
+        category: 'landing',
+        messageId: rudderElement.message.messageId,
+      };
+      expect(window.dataLayer[0]).toEqual(expectedProps);
+    });
+
+    it('should default to "Viewed a Page" event if no page name or category provided', () => {
+      const rudderElement = {
+        message: {
+          userId: 'user123',
+          anonymousId: 'anon456',
+          context: {
+            traits: commonTraits,
+          },
+          messageId: '987654321',
+        },
+      };
+      googleTagManager.page(rudderElement);
+      const expectedProps = {
+        event: 'Viewed a Page',
+        userId: rudderElement.message.userId,
+        anonymousId: rudderElement.message.anonymousId,
+        traits: rudderElement.message.context.traits,
+        messageId: rudderElement.message.messageId,
+      };
+      expect(window.dataLayer[0]).toEqual(expectedProps);
+    });
+  });
+});

--- a/packages/analytics-js-integrations/src/integrations/GoogleTagManager/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/GoogleTagManager/browser.js
@@ -58,6 +58,7 @@ class GoogleTagManager {
       // it'll be null/undefined before identify call is made
       traits: rudderMessage.context.traits,
       ...rudderMessage.properties,
+      messageId: rudderMessage.messageId,
     };
     this.sendToGTMDatalayer(props);
   }
@@ -87,6 +88,7 @@ class GoogleTagManager {
       // it'll be null/undefined before identify call is made
       traits: rudderMessage.context.traits,
       ...rudderMessage.properties,
+      messageId: rudderMessage.messageId,
     };
 
     this.sendToGTMDatalayer(props);


### PR DESCRIPTION
## PR Description

user ask : to support messageId in track and page call in order to deduplicate events.
ref : https://developers.google.com/tag-platform/tag-manager/datalayer#one_push_multiple_variables

## Linear task (optional)

Resolves INT-2092

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Google Tag Manager integration to include `messageId` in event properties, improving tracking precision.
- **Tests**
	- Added comprehensive tests for Google Tag Manager integration, covering initialization, user identification, event tracking, and page views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->