### PR TITLE
fix: update dmt plugin to use activeDataplaneUrl state value

### DIFF
--- a/packages/analytics-js-plugins/src/deviceModeTransformation/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeTransformation/index.ts
@@ -54,7 +54,7 @@ const DeviceModeTransformation = (): ExtensionPlugin => ({
           const payload = createPayload(item.event, item.destinationIds, item.token);
 
           httpClient.getAsyncData({
-            url: `${state.lifecycle.dataPlaneUrl.value}/transform`,
+            url: `${state.lifecycle.activeDataplaneUrl.value}/transform`,
             options: {
               method: 'POST',
               data: getDMTDeliveryPayload(payload) as string,


### PR DESCRIPTION
## PR Description

Update DMT plugin to use activeDataplaneUrl state value instead of dataplaneUrl.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-1783/update-dmt-plugin-to-use-activedataplaneurl)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated URL construction in device mode analytics to ensure accurate data tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->