### PR TITLE
feat: initialize iubenda consent manager plugin

### DIFF
--- a/packages/analytics-js-common/src/types/Consent.ts
+++ b/packages/analytics-js-common/src/types/Consent.ts
@@ -24,7 +24,7 @@ export type ConsentManagementProviderMetadata = {
   resolutionStrategy: ConsentResolutionStrategy;
 };
 
-export type ConsentManagementProvider = 'oneTrust' | 'ketch' | 'custom';
+export type ConsentManagementProvider = 'iubenda' | 'oneTrust' | 'ketch' | 'custom';
 
 export type ConsentResolutionStrategy = 'and' | 'or';
 

--- a/packages/analytics-js-common/src/types/Consent.ts
+++ b/packages/analytics-js-common/src/types/Consent.ts
@@ -45,3 +45,7 @@ export type ConsentsInfo = {
 export type KetchConsentPurpose = {
   purpose: string;
 };
+
+export type IubendaConsentPurpose = {
+  purpose: string;
+};

--- a/packages/analytics-js-common/src/types/Destination.ts
+++ b/packages/analytics-js-common/src/types/Destination.ts
@@ -2,6 +2,7 @@ import type { Conversion, EventFilteringOption, EventMapping } from './LoadOptio
 import type {
   OneTrustCookieCategory,
   KetchConsentPurpose,
+  IubendaConsentPurpose,
   ConsentManagementProvider,
 } from './Consent';
 
@@ -35,6 +36,7 @@ export type ConsentManagementProviderConfig = {
 export type DestinationConfig = {
   blacklistedEvents: DestinationEvent[];
   whitelistedEvents: DestinationEvent[];
+  iubendaConsentPurposes?: IubendaConsentPurpose[];
   oneTrustCookieCategories?: OneTrustCookieCategory[];
   ketchConsentPurposes?: KetchConsentPurpose[];
   consentManagement?: ConsentManagementProviderConfig[];

--- a/packages/analytics-js-common/src/types/PluginsManager.ts
+++ b/packages/analytics-js-common/src/types/PluginsManager.ts
@@ -20,6 +20,7 @@ export type PluginName =
   | 'ErrorReporting'
   | 'ExternalAnonymousId'
   | 'GoogleLinker'
+  | 'IubendaConsentManager'
   | 'KetchConsentManager'
   | 'NativeDestinationQueue'
   | 'OneTrustConsentManager'

--- a/packages/analytics-js-plugins/rollup.config.mjs
+++ b/packages/analytics-js-plugins/rollup.config.mjs
@@ -44,6 +44,7 @@ const pluginsMap = {
   './ErrorReporting': './src/errorReporting/index.ts',
   './ExternalAnonymousId': './src/externalAnonymousId/index.ts',
   './GoogleLinker': './src/googleLinker/index.ts',
+  './IubendaConsentManager': './src/IubendaConsentManager/index.ts',
   './KetchConsentManager': './src/ketchConsentManager/index.ts',
   './NativeDestinationQueue': './src/nativeDestinationQueue/index.ts',
   './OneTrustConsentManager': './src/oneTrustConsentManager/index.ts',

--- a/packages/analytics-js-plugins/src/index.ts
+++ b/packages/analytics-js-plugins/src/index.ts
@@ -6,6 +6,7 @@ export { default as DeviceModeTransformation } from './deviceModeTransformation'
 export { default as ErrorReporting } from './errorReporting';
 export { default as ExternalAnonymousId } from './externalAnonymousId';
 export { default as GoogleLinker } from './googleLinker';
+export { default as IubendaConsentManager } from './iubendaConsentManager';
 export { default as NativeDestinationQueue } from './nativeDestinationQueue';
 export { default as OneTrustConsentManager } from './oneTrustConsentManager';
 export { default as KetchConsentManager } from './ketchConsentManager';

--- a/packages/analytics-js-plugins/src/iubendaConsentManager/constants.ts
+++ b/packages/analytics-js-plugins/src/iubendaConsentManager/constants.ts
@@ -1,0 +1,3 @@
+const IUBENDA_CONSENT_MANAGER_PLUGIN = 'IubendaConsentManagerPlugin';
+
+export { IUBENDA_CONSENT_MANAGER_PLUGIN };

--- a/packages/analytics-js-plugins/src/iubendaConsentManager/index.ts
+++ b/packages/analytics-js-plugins/src/iubendaConsentManager/index.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable no-param-reassign */
+import type { ApplicationState } from '@rudderstack/analytics-js-common/types/ApplicationState';
+import type { DestinationConfig } from '@rudderstack/analytics-js-common/types/Destination';
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import type { ExtensionPlugin } from '@rudderstack/analytics-js-common/types/PluginEngine';
+import type { IStoreManager } from '@rudderstack/analytics-js-common/types/Store';
+import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/ErrorHandler';
+import type { PluginName } from '@rudderstack/analytics-js-common/types/PluginsManager';
+import { IUBENDA_CONSENT_MANAGER_PLUGIN } from './constants';
+import { DESTINATION_CONSENT_STATUS_ERROR } from './logMessages';
+
+const pluginName: PluginName = 'IubendaConsentManager';
+
+const IubendaConsentManager = (): ExtensionPlugin => ({
+  name: pluginName,
+  deps: [],
+  initialize: (state: ApplicationState) => {
+    state.plugins.loadedPlugins.value = [...state.plugins.loadedPlugins.value, pluginName];
+  },
+  consentManager: {
+    init(state: ApplicationState, logger?: ILogger): void {
+      // Nothing to initialize
+    },
+
+    updateConsentsInfo(
+      state: ApplicationState,
+      storeManager?: IStoreManager,
+      logger?: ILogger,
+    ): void {
+      // Nothing to update. Already provided by the user
+    },
+
+    isDestinationConsented(
+      state: ApplicationState,
+      destConfig: DestinationConfig,
+      errorHandler?: IErrorHandler,
+      logger?: ILogger,
+    ): boolean {
+      if (!state.consents.initialized.value) {
+        return true;
+      }
+
+      const allowedConsentIds = state.consents.data.value.allowedConsentIds as string[];
+
+      try {
+        const { consentManagement } = destConfig;
+
+        // If the destination does not have consent management config, events should be sent.
+        if (!consentManagement) {
+          return true;
+        }
+
+        // Get the corresponding consents for the destination
+        const cmpConfig = consentManagement.find(c => c.provider === state.consents.provider.value);
+
+        // If there are no consents configured for the destination for the current provider, events should be sent.
+        if (!cmpConfig?.consents) {
+          return true;
+        }
+
+        const configuredConsents = cmpConfig.consents.map(c => c.consent.trim()).filter(n => n);
+        const resolutionStrategy =
+          cmpConfig.resolutionStrategy ?? state.consents.resolutionStrategy.value;
+
+        // match the configured consents with user provided consents as per
+        // the configured resolution strategy
+        const matchPredicate = (consent: string) => allowedConsentIds.includes(consent);
+        switch (resolutionStrategy) {
+          case 'or':
+            return configuredConsents.some(matchPredicate) || configuredConsents.length === 0;
+          case 'and':
+          default:
+            return configuredConsents.every(matchPredicate);
+        }
+      } catch (err) {
+        errorHandler?.onError(err, IUBENDA_CONSENT_MANAGER_PLUGIN, DESTINATION_CONSENT_STATUS_ERROR);
+        return true;
+      }
+    },
+  },
+});
+
+export { IubendaConsentManager };
+
+export default IubendaConsentManager;

--- a/packages/analytics-js-plugins/src/iubendaConsentManager/index.ts
+++ b/packages/analytics-js-plugins/src/iubendaConsentManager/index.ts
@@ -8,7 +8,8 @@ import type { IStoreManager } from '@rudderstack/analytics-js-common/types/Store
 import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/ErrorHandler';
 import type { PluginName } from '@rudderstack/analytics-js-common/types/PluginsManager';
 import { IUBENDA_CONSENT_MANAGER_PLUGIN } from './constants';
-import { DESTINATION_CONSENT_STATUS_ERROR } from './logMessages';
+import { checks, storages, string } from '../shared-chunks/common';
+import { DESTINATION_CONSENT_STATUS_ERROR, IUBENDA_ACCESS_ERROR } from './logMessages';
 
 const pluginName: PluginName = 'IubendaConsentManager';
 
@@ -28,7 +29,39 @@ const IubendaConsentManager = (): ExtensionPlugin => ({
       storeManager?: IStoreManager,
       logger?: ILogger,
     ): void {
-      // Nothing to update. Already provided by the user
+      // eslint-disable-next-line no-underscore-dangle
+      if (!(globalThis as any)._iub) {
+        logger?.error(IUBENDA_ACCESS_ERROR(IUBENDA_CONSENT_MANAGER_PLUGIN));
+        state.consents.initialized.value = false;
+        return;
+      }
+
+      // eslint-disable-next-line no-underscore-dangle
+      if (!(globalThis as any)._iub?.cs?.consent?.purposes) {
+        state.consents.initialized.value = false;
+        return;
+      }
+
+      try {
+        const allowedConsentIds: string[] = [];
+        const deniedConsentIds: string[] = [];
+
+        // eslint-disable-next-line no-underscore-dangle
+        Object.entries((globalThis as any)._iub.cs.api.getPreferences()).forEach(e => {
+          const purposeCode = e[0];
+          const isConsented = e[1];
+          if (isConsented) {
+            allowedConsentIds.push(purposeCode);
+          } else {
+            deniedConsentIds.push(purposeCode);
+          }
+        })
+
+        state.consents.initialized.value = true;
+        state.consents.data.value = { allowedConsentIds, deniedConsentIds };
+      } catch (err) {
+        logger?.error(IUBENDA_ACCESS_ERROR(IUBENDA_CONSENT_MANAGER_PLUGIN), err);
+      }
     },
 
     isDestinationConsented(
@@ -40,39 +73,45 @@ const IubendaConsentManager = (): ExtensionPlugin => ({
       if (!state.consents.initialized.value) {
         return true;
       }
-
       const allowedConsentIds = state.consents.data.value.allowedConsentIds as string[];
+      const matchPredicate = (consent: string) => allowedConsentIds.includes(consent);
 
       try {
-        const { consentManagement } = destConfig;
+        const { iubendaConsentPurposes, consentManagement } = destConfig;
 
         // If the destination does not have consent management config, events should be sent.
-        if (!consentManagement) {
-          return true;
+        if (consentManagement) {
+          // Get the corresponding consents for the destination
+          const cmpConfig = consentManagement.find(c => c.provider === state.consents.provider.value);
+
+          // If there are no consents configured for the destination for the current provider, events should be sent.
+          if (!cmpConfig?.consents) {
+            return true;
+          }
+
+          const configuredConsents = cmpConfig.consents.map(c => c.consent.trim()).filter(n => n);
+          const resolutionStrategy =
+            cmpConfig.resolutionStrategy ?? state.consents.resolutionStrategy.value;
+  
+          // match the configured consents with user provided consents as per
+          // the configured resolution strategy
+          switch (resolutionStrategy) {
+            case 'or':
+              return configuredConsents.some(matchPredicate) || configuredConsents.length === 0;
+            case 'and':
+            default:
+              return configuredConsents.every(matchPredicate);
+          }
         }
 
-        // Get the corresponding consents for the destination
-        const cmpConfig = consentManagement.find(c => c.provider === state.consents.provider.value);
+        if (iubendaConsentPurposes) {
+          const configuredConsents = iubendaConsentPurposes.map(p => p.purpose.trim()).filter(n => n);
 
-        // If there are no consents configured for the destination for the current provider, events should be sent.
-        if (!cmpConfig?.consents) {
-          return true;
+          // Check if any of the destination's mapped ketch purposes are consented by the user in the browser.
+          return configuredConsents.some(matchPredicate) || configuredConsents.length === 0;
         }
 
-        const configuredConsents = cmpConfig.consents.map(c => c.consent.trim()).filter(n => n);
-        const resolutionStrategy =
-          cmpConfig.resolutionStrategy ?? state.consents.resolutionStrategy.value;
-
-        // match the configured consents with user provided consents as per
-        // the configured resolution strategy
-        const matchPredicate = (consent: string) => allowedConsentIds.includes(consent);
-        switch (resolutionStrategy) {
-          case 'or':
-            return configuredConsents.some(matchPredicate) || configuredConsents.length === 0;
-          case 'and':
-          default:
-            return configuredConsents.every(matchPredicate);
-        }
+        return true;
       } catch (err) {
         errorHandler?.onError(err, IUBENDA_CONSENT_MANAGER_PLUGIN, DESTINATION_CONSENT_STATUS_ERROR);
         return true;

--- a/packages/analytics-js-plugins/src/iubendaConsentManager/index.ts
+++ b/packages/analytics-js-plugins/src/iubendaConsentManager/index.ts
@@ -47,7 +47,9 @@ const IubendaConsentManager = (): ExtensionPlugin => ({
         const deniedConsentIds: string[] = [];
 
         // eslint-disable-next-line no-underscore-dangle
-        Object.entries((globalThis as any)._iub.cs.api.getPreferences()).forEach(e => {
+        const { purposes = {} } = (globalThis as any)._iub.cs.api.getPreferences();
+
+        Object.entries(purposes).forEach(e => {
           const purposeCode = e[0];
           const isConsented = e[1];
           if (isConsented) {

--- a/packages/analytics-js-plugins/src/iubendaConsentManager/logMessages.ts
+++ b/packages/analytics-js-plugins/src/iubendaConsentManager/logMessages.ts
@@ -1,0 +1,3 @@
+const DESTINATION_CONSENT_STATUS_ERROR = `Failed to determine the consent status for the destination. Please check the destination configuration and try again.`;
+
+export { DESTINATION_CONSENT_STATUS_ERROR };

--- a/packages/analytics-js-plugins/src/iubendaConsentManager/logMessages.ts
+++ b/packages/analytics-js-plugins/src/iubendaConsentManager/logMessages.ts
@@ -1,3 +1,8 @@
+import { LOG_CONTEXT_SEPARATOR } from '@rudderstack/analytics-js-common/constants/logMessages';
+
+const IUBENDA_ACCESS_ERROR = (context: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}Failed to access Iubenda SDK resources. Please ensure that the Iubenda SDK is loaded successfully before RudderStack SDK.`;
+
 const DESTINATION_CONSENT_STATUS_ERROR = `Failed to determine the consent status for the destination. Please check the destination configuration and try again.`;
 
-export { DESTINATION_CONSENT_STATUS_ERROR };
+export { IUBENDA_ACCESS_ERROR, DESTINATION_CONSENT_STATUS_ERROR };

--- a/packages/analytics-js/__mocks__/remotePlugins/IubendaConsentManager.ts
+++ b/packages/analytics-js/__mocks__/remotePlugins/IubendaConsentManager.ts
@@ -1,11 +1,10 @@
 const IubendaConsentManager = () => ({
-    name: 'IubendaConsentManager',
-    consentManager: {
-      init: jest.fn(() => {}),
-      updateConsentsInfo: jest.fn(() => {}),
-      isDestinationConsented: jest.fn(() => {}),
-    },
-  });
-  
-  export default IubendaConsentManager;
-  
+  name: 'IubendaConsentManager',
+  consentManager: {
+    init: jest.fn(() => {}),
+    updateConsentsInfo: jest.fn(() => {}),
+    isDestinationConsented: jest.fn(() => {}),
+  },
+});
+
+export default IubendaConsentManager;

--- a/packages/analytics-js/__mocks__/remotePlugins/IubendaConsentManager.ts
+++ b/packages/analytics-js/__mocks__/remotePlugins/IubendaConsentManager.ts
@@ -1,0 +1,11 @@
+const IubendaConsentManager = () => ({
+    name: 'IubendaConsentManager',
+    consentManager: {
+      init: jest.fn(() => {}),
+      updateConsentsInfo: jest.fn(() => {}),
+      isDestinationConsented: jest.fn(() => {}),
+    },
+  });
+  
+  export default IubendaConsentManager;
+  

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -294,7 +294,7 @@ describe('Config Manager Common Utilities', () => {
 
       expect(state.consents.activeConsentManagerPluginName.value).toBe(undefined);
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'ConfigManager:: The consent manager "randomManager" is not supported. Please choose one of the following supported consent managers: "oneTrust,ketch,custom".',
+        'ConfigManager:: The consent manager "randomManager" is not supported. Please choose one of the following supported consent managers: "iubenda,oneTrust,ketch,custom".',
       );
     });
 

--- a/packages/analytics-js/src/components/configManager/constants.ts
+++ b/packages/analytics-js/src/components/configManager/constants.ts
@@ -5,6 +5,7 @@ const DEFAULT_STORAGE_ENCRYPTION_VERSION = 'v3';
 const DEFAULT_DATA_PLANE_EVENTS_TRANSPORT = 'xhr';
 
 export const ConsentManagersToPluginNameMap: Record<string, PluginName> = {
+  iubenda: 'IubendaConsentManager',
   oneTrust: 'OneTrustConsentManager',
   ketch: 'KetchConsentManager',
   custom: 'CustomConsentManager',

--- a/packages/analytics-js/src/components/pluginsManager/bundledBuildPluginImports.ts
+++ b/packages/analytics-js/src/components/pluginsManager/bundledBuildPluginImports.ts
@@ -6,6 +6,7 @@ import { DeviceModeTransformation } from '@rudderstack/analytics-js-plugins/devi
 import { ErrorReporting } from '@rudderstack/analytics-js-plugins/errorReporting';
 import { ExternalAnonymousId } from '@rudderstack/analytics-js-plugins/externalAnonymousId';
 import { GoogleLinker } from '@rudderstack/analytics-js-plugins/googleLinker';
+import { IubendaConsentManager } from '@rudderstack/analytics-js-plugins/iubendaConsentManager';
 import { KetchConsentManager } from '@rudderstack/analytics-js-plugins/ketchConsentManager';
 import { NativeDestinationQueue } from '@rudderstack/analytics-js-plugins/nativeDestinationQueue';
 import { OneTrustConsentManager } from '@rudderstack/analytics-js-plugins/oneTrustConsentManager';
@@ -27,6 +28,7 @@ const getBundledBuildPluginImports = (): PluginMap => ({
   ErrorReporting,
   ExternalAnonymousId,
   GoogleLinker,
+  IubendaConsentManager,
   KetchConsentManager,
   NativeDestinationQueue,
   OneTrustConsentManager,

--- a/packages/analytics-js/src/components/pluginsManager/defaultPluginsList.ts
+++ b/packages/analytics-js/src/components/pluginsManager/defaultPluginsList.ts
@@ -12,6 +12,7 @@ const defaultOptionalPluginsList: PluginName[] = [
   'ErrorReporting',
   'ExternalAnonymousId',
   'GoogleLinker',
+  'IubendaConsentManager',
   'KetchConsentManager',
   'NativeDestinationQueue',
   'OneTrustConsentManager',

--- a/packages/analytics-js/src/components/pluginsManager/federatedModulesBuildPluginImports.ts
+++ b/packages/analytics-js/src/components/pluginsManager/federatedModulesBuildPluginImports.ts
@@ -28,6 +28,8 @@ const getFederatedModuleImport = (
       return () => import('rudderAnalyticsRemotePlugins/GoogleLinker');
     case 'KetchConsentManager':
       return () => import('rudderAnalyticsRemotePlugins/KetchConsentManager');
+    case 'IubendaConsentManager':
+      return () => import('rudderAnalyticsRemotePlugins/IubendaConsentManager');
     case 'NativeDestinationQueue':
       return () => import('rudderAnalyticsRemotePlugins/NativeDestinationQueue');
     case 'OneTrustConsentManager':

--- a/packages/analytics-js/src/components/pluginsManager/pluginNames.ts
+++ b/packages/analytics-js/src/components/pluginsManager/pluginNames.ts
@@ -17,6 +17,7 @@ const pluginNamesList: PluginName[] = [
   'ErrorReporting',
   'ExternalAnonymousId',
   'GoogleLinker',
+  'IubendaConsentManager',
   'KetchConsentManager',
   'NativeDestinationQueue',
   'OneTrustConsentManager',

--- a/packages/analytics-js/src/types/remote-plugins.d.ts
+++ b/packages/analytics-js/src/types/remote-plugins.d.ts
@@ -6,6 +6,7 @@ declare module 'rudderAnalyticsRemotePlugins/DeviceModeTransformation';
 declare module 'rudderAnalyticsRemotePlugins/ErrorReporting';
 declare module 'rudderAnalyticsRemotePlugins/ExternalAnonymousId';
 declare module 'rudderAnalyticsRemotePlugins/GoogleLinker';
+declare module 'rudderAnalyticsRemotePlugins/IubendaConsentManager';
 declare module 'rudderAnalyticsRemotePlugins/KetchConsentManager';
 declare module 'rudderAnalyticsRemotePlugins/NativeDestinationQueue';
 declare module 'rudderAnalyticsRemotePlugins/OneTrustConsentManager';


### PR DESCRIPTION
## PR Description

This PR integrates iubenda consent manager with rudderstack.
demo:

https://github.com/rudderlabs/rudder-sdk-js/assets/25850856/9ed545eb-f428-48e6-8e19-650f5fc5acf4



## Testing instructions
- create a new iubenda.html file in examples/v3
```
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <meta http-equiv="x-ua-compatible" content="ie=edge" />
    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
    <title>RudderStack JS SDK v3 Example</title>
    <script>
      window._iub = window._iub || [];
          var _iub = _iub || [];
  
          _iub.csConfiguration = {
              lang: 'en',
              cookiePolicyId: 36178045,
              siteId: 3405502,
              logLevel: 'debug',
              enableTcf: true,
              perPurposeConsent: true,
              skipSaveConsent: false,
              banner: {
                position: 'float-center'
              }
          };
    </script>
    <!-- <script async src="http://localhost:3012/cookie_solution/iubenda_cs.js"></script> -->
    <script async src="//cdn.iubenda.com/cs/beta/iubenda_cs.js"></script>
    <script>
      var sdkBaseUrl = 'http://localhost:3001/cdn';
      var sdkName = 'rsa.min.js';
      var asyncScript = true;
      window.rudderAnalyticsBuildType = 'modern';
      window.rudderanalytics = [];
      var methods = [
        'setDefaultInstanceKey',
        'load',
        'ready',
        'page',
        'track',
        'identify',
        'alias',
        'group',
        'reset',
        'getAnonymousId',
        'setAnonymousId',
        'startSession',
        'endSession',
        'getSessionId',
      ];
      for (var i = 0; i < methods.length; i++) {
        var method = methods[i];
        window.rudderanalytics[method] = (function (methodName) {
          return function () {
            window.rudderanalytics.push([methodName].concat(Array.prototype.slice.call(arguments)));
          };
        })(method);
      }
      try {
        new Function('return import("")');
        window.rudderAnalyticsBuildType = 'modern';
      } catch (e) {}
      window.rudderAnalyticsMount = function () {
        if (typeof globalThis === 'undefined') {
          Object.defineProperty(Object.prototype, '__globalThis_magic__', {
            get: function get() {
              return this;
            },
            configurable: true
          });
          __globalThis_magic__.globalThis = __globalThis_magic__;
          delete Object.prototype.__globalThis_magic__;
        }
        var rudderAnalyticsScript = document.createElement('script');
        rudderAnalyticsScript.src = ''
          .concat(sdkBaseUrl, '/')
          .concat(window.rudderAnalyticsBuildType, '/iife/')
          .concat(sdkName);
        rudderAnalyticsScript.async = asyncScript;
        if (document.head) {
          document.head.appendChild(rudderAnalyticsScript);
        } else {
          document.body.appendChild(rudderAnalyticsScript);
        }
      };
      if (typeof Promise === 'undefined' || typeof globalThis === 'undefined') {
        var rudderAnalyticsPromisesScript = document.createElement('script');
        rudderAnalyticsPromisesScript.src =
          'https://polyfill.io/v3/polyfill.min.js?features=Symbol%2CPromise&callback=rudderAnalyticsMount';
        rudderAnalyticsPromisesScript.async = asyncScript;
        if (document.head) {
          document.head.appendChild(rudderAnalyticsPromisesScript);
        } else {
          document.body.appendChild(rudderAnalyticsPromisesScript);
        }
      } else {
        window.rudderAnalyticsMount();
      }
      // New addition to load script ends

      var loadOptions = {
        logLevel: 'DEBUG',
        configUrl: 'https://api.rudderlabs.com',
        destSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
        pluginsSDKBaseURL: 'http://localhost:3002/cdn/' + window.rudderAnalyticsBuildType + '/plugins',
        plugins: [
          'IubendaConsentManager'
        ],
        consentManagement: {
          enabled: true,
          provider: 'iubenda',
        },
      };

      rudderanalytics.load('__WRITE_KEY__', '__DATAPLANE_URL__', loadOptions);
      
      rudderanalytics.identify(
        'customUserID',
        {
          name: 'John Doe',
          title: 'CEO',
          email: 'name.surname@domain.com',
          company: 'Company123',
          phone: '123-456-7890',
          rating: 'Hot',
          city: 'Austin',
          postalCode: '12345',
          country: 'US',
          street: 'Sample Address',
          state: 'TX',
        },
        function (message) {
          console.log('in identify call', message);
        },
      );

      rudderanalytics.page(
        'Home',
        'Cart Viewed',
        {
          path: '',
          referrer: '',
          search: '',
          title: '',
          url: '',
        },
        function (message) {
          console.log('in page call', message);
        },
      );

      rudderanalytics.track(
        'test track event 1',
        {
          revenue: 30,
          currency: 'USD',
          user_actual_id: 12345,
        },
        function (message) {
          console.log('in track call 1', message);
        },
      );

      rudderanalytics.track(
        'test track event 2',
        {
          revenue: 45,
          currency: 'INR',
          user_actual_id: 333,
        },
        function (message) {
          console.log('in track call 2', message);
        },
      );

      rudderanalytics.track(
        'test track event 3',
        {
          revenue: 10003,
          currency: 'EUR',
          user_actual_id: 5678,
        },
        function (message) {
          console.log('in track call 3', message);
        },
      );

      rudderanalytics.ready(function () {
        console.log('All ready!!!');
      });

      // TODO: Call other APIs here
    </script>
  </head>
  <body>
    <h1>Page Loaded</h1>
    <br />

    <button data-testid="page-btn" onclick="page()">Page</button>
    <button data-testid="identify-btn" onclick="identify()">identify</button>
    <button data-testid="track-btn" onclick="track()">Track</button>
    <button data-testid="alias-btn" onclick="alias()">Alias</button>
    <button data-testid="group-btn" onclick="group()">Group</button>

    <p data-testid="action" id="action"></p>
    <p data-testid="payload" id="rudderElement"></p>

    <script>
      function page() {
        rudderanalytics.page(
          'Home',
          'Cart Viewed',
          {
            path: '',
            referrer: '',
            search: '',
            title: '',
            url: '',
          },
          function (rudderElement) {
            console.log('in page call');
            document.getElementById('action').innerHTML = 'Page called';
            document.getElementById('rudderElement').innerHTML = JSON.stringify(rudderElement);
          },
        );
      }

      function identify() {
        rudderanalytics.identify(
          'customUserID',
          {
            name: 'John Doe',
            title: 'CEO',
            email: 'name.surname@domain.com',
            company: 'Company123',
            phone: '123-456-7890',
            rating: 'Hot',
            city: 'Austin',
            postalCode: '12345',
            country: 'US',
            street: 'Sample Address',
            state: 'TX',
          },
          {},
          function (rudderElement) {
            console.log('in identify call');
            document.getElementById('action').innerHTML = 'Identify called';
            document.getElementById('rudderElement').innerHTML = JSON.stringify(rudderElement);
          },
        );
      }

      function track() {
        rudderanalytics.track(
          'test track event 1',
          {
            revenue: 30,
            currency: 'USD',
            user_actual_id: 12345,
          },
          function (rudderElement) {
            console.log('in track call');
            document.getElementById('action').innerHTML = 'Track called';
            document.getElementById('rudderElement').innerHTML = JSON.stringify(rudderElement);
          },
        );
      }

      function alias() {
        rudderanalytics.alias('alias-user-id', function (rudderElement) {
          console.log('alias call');
          document.getElementById('action').innerHTML = 'Alias called';
          document.getElementById('rudderElement').innerHTML = JSON.stringify(rudderElement);
        });
      }

      function group() {
        rudderanalytics.group(
          'sample_group_id',
          {
            name: 'Apple Inc.',
            location: 'USA',
          },
          function (rudderElement) {
            console.log('group call');
            document.getElementById('action').innerHTML = 'Group called';
            document.getElementById('rudderElement').innerHTML = JSON.stringify(rudderElement);
          },
        );
      }
    </script>
  </body>
</html>
```
- replace __WRITE_KEY__, __DATAPLANE_URL__ with proper values
- go to `packages/analytics-js-plugins`
- run: `npm run build:modern`
-  go to root
- `npm run start:modern`
- go to rudderstack dashboard
- navigate to JS Source ( were we got our WRITE_KEY ) 
- open live events
- run iubenda.html on a localserver e.g `python3 -m http.server 6060`
- navigate to the local server in browser
- accept iubenda banner
- refresh page
- after page is refreshed check live event logs and verify consent ids are sent
- clear cookies in browser
- refresh page
- click on `learn more and customize`
- select few purposes and save consent
- refresh page
- check live events logs for proper `allowedConsentIds` & `deniedConsentIds`

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for the Iubenda Consent Manager, including initialization, updating consent information, and checking destination consent status.
  - Added new consent management provider 'iubenda' to the list of supported providers.

- **Enhancements**
  - Updated error messages to include support for 'iubenda'.
  - Expanded consent management configurations to accommodate Iubenda-specific purposes and strategies.

- **Chores**
  - Added mock implementations and test cases for the Iubenda Consent Manager.
  - Updated plugin configurations to include Iubenda Consent Manager in default and optional plugin lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->