### PR TITLE
chore: fix github publish action

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -11,23 +11,17 @@ env:
   NODE_OPTIONS: "--no-warnings"
 
 jobs:
-  deploy:
-    name: Deploy BETA/BugBash Feature
+  get-deploy-inputs:
+    name: Get Deploy Inputs
+    if: startsWith(github.ref, 'refs/heads/beta/') || startsWith(github.ref, 'refs/tags/bugbash/')
     runs-on: [self-hosted, Linux, X64]
-    if: startsWith(github.ref, 'refs/heads/beta/') || startsWith(github.ref, 'refs/tags/bugbash')
+    outputs:
+      release_type: ${{ steps.deploy-inputs.outputs.release_type }}
+      feature_name: ${{ steps.deploy-inputs.outputs.feature_name }}
 
     steps:
-      - name: Install AWS cli
-        uses: unfor19/install-aws-cli-action@master
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_PROD_ACCOUNT_ID }}:role/${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
-          aws-region: us-east-1
-
-      - name: Extract feature name from branch
-        id: extract_branch
+      - name: Extract deploy inputs
+        id: deploy-inputs
         shell: bash
         run: |
           source_branch_name=${GITHUB_REF##*/}
@@ -38,57 +32,26 @@ jobs:
           FEATURE_NAME=${FEATURE_NAME#refs/heads/}
           FEATURE_NAME=${FEATURE_NAME#refs/tags/}
 
-          echo "branch_name=$FEATURE_NAME" >> $GITHUB_OUTPUT
-          echo "branch_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+          echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+          echo "feature_name=$FEATURE_NAME" >> $GITHUB_OUTPUT
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install dependencies
-        env:
-          HUSKY: 0
-          REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/modern/plugins'
-          BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
-          BUGSNAG_RELEASE_STAGE: '${{ steps.extract_branch.outputs.branch_type }}'
-        run: |
-          npm run setup:ci
-
-      - name: Build release artifacts
-        env:
-          REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/modern/plugins'
-          BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
-          BUGSNAG_RELEASE_STAGE: '${{ steps.extract_branch.outputs.branch_type }}'
-        run: |
-          npm run build:browser
-          npm run build:browser:modern
-
-      - name: Sync files to S3 beta directory
-        run: |
-          aws s3 cp packages/analytics-js/dist/cdn/legacy/iife/ s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/legacy/ --recursive --cache-control max-age=3600
-          aws s3 cp packages/analytics-js/dist/cdn/modern/iife/ s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/modern/ --recursive --cache-control max-age=3600
-          aws s3 cp packages/analytics-js-plugins/dist/cdn/modern/plugins/ s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/modern/plugins/ --recursive --cache-control max-age=3600
-          aws s3 cp packages/analytics-js-integrations/dist/cdn/legacy/js-integrations/ s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/legacy/js-integrations/ --recursive --cache-control max-age=3600
-          aws s3 cp packages/analytics-js-integrations/dist/cdn/modern/js-integrations/ s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/modern/js-integrations/ --recursive --cache-control max-age=3600
-
-      - name: Create Cloudfront invalidation
-        run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/*"
-
-
-      # Below steps are for v1.1 SDK (legacy)
-      - name: Sync files to S3 beta directory (v1.1)
-        run: |
-          aws s3 cp packages/analytics-v1.1/dist/cdn/legacy/rudder-analytics.min.js s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/rudder-analytics.min.js --cache-control max-age=3600
-          aws s3 cp packages/analytics-v1.1/dist/cdn/legacy/rudder-analytics.min.js.map s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/rudder-analytics.min.js.map --cache-control max-age=3600
-          aws s3 cp packages/analytics-js-integrations/dist/cdn/legacy/js-integrations/ s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/js-integrations/ --recursive --cache-control max-age=3600
-      
-      - name: Create Cloudfront invalidation
-        run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ steps.extract_branch.outputs.branch_type }}/${{ steps.extract_branch.outputs.branch_name }}/*"
+  deploy:
+    name: Deploy BETA/BugBash Feature
+    if: startsWith(github.ref, 'refs/heads/beta/') || startsWith(github.ref, 'refs/tags/bugbash')
+    uses: ./.github/workflows/deploy.yml
+    needs: get-deploy-inputs
+    with:
+      environment: ${{ needs.get-deploy-inputs.outputs.release_type }}
+      bugsnag_release_stage: ${{ needs.get-deploy-inputs.outputs.release_type }}
+      s3_dir_path: ${{ needs.get-deploy-inputs.outputs.release_type }}/${{ needs.get-deploy-inputs.outputs.feature_name }}
+      s3_dir_path_legacy: ${{ needs.get-deploy-inputs.outputs.release_type }}/${{ needs.get-deploy-inputs.outputs.feature_name }}/v1.1
+      action_type: ''
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_PROD_ACCOUNT_ID }}
+      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_PROD_S3_BUCKET_NAME }}
+      AWS_S3_SYNC_ROLE: ${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
+      AWS_CF_DISTRIBUTION_ID: ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}
+      BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         env:
           HUSKY: 0
-          REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/${{ env.CURRENT_VERSION_VALUE }}/modern/plugins'
+          REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/v3/modern/plugins'
           BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
           BUGSNAG_RELEASE_STAGE: 'production'
         run: |
@@ -77,19 +77,20 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          PROJECT_NAME: 'JS SDK v3 NPM Package'
+          PROJECT_NAME: 'JS SDK NPM Package'
           NPM_PACKAGE_URL: 'https://www.npmjs.com/package/@rudderstack/analytics-js'
+          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js@'
         with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": "*Release: <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_SW_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
+              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "New release: ${{ env.PROJECT_NAME }}"
+                    "text": "New Release: ${{ env.PROJECT_NAME }}"
                   }
                 },
                 {
@@ -99,8 +100,22 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Release: <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                    "text": "*<${{ env.NPM_PACKAGE_URL }}|v${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://img.icons8.com/color/452/npm.png",
+                    "alt_text": "NPM Icon"
                   }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "For more details, check the full release notes <${{env.RELEASES_URL}}${{ env.CURRENT_VERSION_VALUE }}|here>."
+                    }
+                  ]
                 }
               ]
             }
@@ -112,17 +127,18 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'JS SDK Service Worker NPM Package'
           NPM_PACKAGE_URL: 'https://www.npmjs.com/package/@rudderstack/analytics-js-service-worker'
+          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js-service-worker@'
         with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": "*Release: <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_SW_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
+              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_SW_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "New release: ${{ env.PROJECT_NAME }}"
+                    "text": "New Release: ${{ env.PROJECT_NAME }}"
                   }
                 },
                 {
@@ -132,41 +148,22 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Release: <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_SW_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
-                  }
-                }
-              ]
-            }
-
-      - name: Send message to Slack channel for v1.1
-        id: slackv1
-        uses: slackapi/slack-github-action@v1.26.0
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          PROJECT_NAME: 'JS SDK v1.1 NPM Package'
-          NPM_PACKAGE_URL: 'https://www.npmjs.com/package/rudder-sdk-js'
-        with:
-          channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "*Release: <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_V1_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "New release: ${{ env.PROJECT_NAME }}"
+                    "text": "*<${{ env.NPM_PACKAGE_URL }}|v${{ env.CURRENT_VERSION_SW_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://img.icons8.com/color/452/npm.png",
+                    "alt_text": "NPM Icon"
                   }
                 },
                 {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Release: <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_V1_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
-                  }
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "For more details, check the full release notes <${{ env.RELEASES_URL }}${{ env.CURRENT_VERSION_SW_VALUE }}|here>."
+                    }
+                  ]
                 }
               ]
             }

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -149,13 +149,13 @@ jobs:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": "*<${{ env.CDN_URL }}|Deployment>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
+              "text": "*New Deployment: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|Deployment>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "New deployment: ${{ env.PROJECT_NAME }}"
+                    "text": "New Deployment: ${{ env.PROJECT_NAME }}"
                   }
                 },
                 {
@@ -166,6 +166,12 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "*<${{ env.CDN_URL }}|Deployment>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://cdn.jsdelivr.net/npm/programming-languages-logos/src/javascript/javascript.png
+                    ",
+                    "alt_text": "JavaScript Icon"
                   }
                 }
               ]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Install dependencies
         env:
           HUSKY: 0
+          REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/${{ inputs.s3_dir_path }}/modern/plugins'
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
           BUGSNAG_RELEASE_STAGE: ${{ inputs.bugsnag_release_stage }}
         run: |
@@ -173,13 +174,14 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          PROJECT_NAME: 'JS SDK v3 Browser Package${{ inputs.action_type }} - ${{ inputs.environment }}'
+          PROJECT_NAME: 'JS SDK Browser Package${{ inputs.action_type }} - ${{ inputs.environment }}'
           CDN_URL: 'https://cdn.rudderlabs.com/${{ inputs.s3_dir_path }}/modern/rsa.min.js'
+          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js@'
         with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": "*Release: <${{ env.CDN_URL }}|${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
+              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
               "blocks": [
                 {
                   "type": "header",
@@ -195,8 +197,23 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Release: <${{ env.CDN_URL }}|${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                    "text": "*<${{ env.CDN_URL }}|v${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://cdn.jsdelivr.net/npm/programming-languages-logos/src/javascript/javascript.png
+                    ",
+                    "alt_text": "JavaScript Icon"
                   }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "For more details, check the full release notes <${{ env.RELEASES_URL }}${{ env.CURRENT_VERSION_VALUE }}|here>."
+                    }
+                  ]
                 }
               ]
             }
@@ -258,36 +275,3 @@ jobs:
         if: ${{ inputs.environment == 'production' }}
         run: |
           AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/latest*"
-
-      - name: Send message to Slack channel
-        id: slackv1
-        uses: slackapi/slack-github-action@v1.26.0
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          PROJECT_NAME: 'JS SDK v1.1 Browser Package${{ inputs.action_type }} - ${{ inputs.environment }}'
-          CDN_URL: 'https://cdn.rudderlabs.com/${{ inputs.s3_dir_path_legacy }}/rudder-analytics.min.js'
-        with:
-          channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "*Release: <${{ env.CDN_URL }}|${{ env.CURRENT_VERSION_V1_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "New release: ${{ env.PROJECT_NAME }}"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Release: <${{ env.CDN_URL }}|${{ env.CURRENT_VERSION_V1_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
-                  }
-                }
-              ]
-            }

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -98,6 +98,6 @@ jobs:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'main'
           github_token: ${{ secrets.PAT }}
-          pr_title: 'chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into main'
+          pr_title: 'chore(release): pull ${{ steps.create-release.outputs.branch_name }} into main'
           pr_body: ':crown: *An automated PR*'
           pr_reviewer: 'MoumitaM,saikumarrs'

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -121,19 +121,20 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          PROJECT_NAME: 'JS SDK (v3) monorepo'
-          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/compare/'
+          PROJECT_NAME: 'JS SDK Monorepo'
+          TAG_COMPARE_URL: 'https://github.com/rudderlabs/rudder-sdk-js/compare/'
+          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/'
         with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": "*Release: <${{env.RELEASES_URL}}${{ env.last_monorepo_version }}...v${{ steps.extract-version.outputs.release_version }}|v${{ steps.extract-version.outputs.release_version }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
+              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{env.TAG_COMPARE_URL}}${{ env.last_monorepo_version }}...v${{ steps.extract-version.outputs.release_version }}|v${{ steps.extract-version.outputs.release_version }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "New release: ${{ env.PROJECT_NAME }}"
+                    "text": "New Release: ${{ env.PROJECT_NAME }}"
                   }
                 },
                 {
@@ -143,8 +144,22 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Release: <${{env.RELEASES_URL}}${{ env.last_monorepo_version }}...v${{ steps.extract-version.outputs.release_version }}|v${{ steps.extract-version.outputs.release_version }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                    "text": "*<${{env.TAG_COMPARE_URL}}${{ env.last_monorepo_version }}...v${{ steps.extract-version.outputs.release_version }}|v${{ steps.extract-version.outputs.release_version }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                    "alt_text": "GitHub Icon"
                   }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "For more details, check the full release notes <${{env.RELEASES_URL}}v${{ steps.extract-version.outputs.release_version }}|here>."
+                    }
+                  ]
                 }
               ]
             }

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -78,7 +78,17 @@ jobs:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # The default behavior of Nx is to consider changes to package-lock.json
+          # as impacting all the packages.
+          # Here is a work around to ignore package-lock.json and package.json
+          # files before publishing the releases.
+          # Ref: https://github.com/nrwl/nx/issues/15116#issuecomment-1535260119
+          echo package-lock.json >> .nxignore
+          echo package.json >> .nxignore
           npm run release:github -- --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }}
+
+          # Restore working copy
+          git checkout -- .nxignore
 
       - name: Create pull request into develop
         uses: repo-sync/pull-request@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "@lukeed/uuid": "2.0.1",
-        "@preact/signals-core": "1.6.0",
-        "get-value": "3.0.1",
-        "ramda": "0.30.0",
-        "storejs": "2.1.0"
-      },
       "devDependencies": {
         "@babel/core": "7.24.5",
         "@babel/eslint-parser": "7.24.5",
@@ -4240,6 +4233,7 @@
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4247,6 +4241,7 @@
     },
     "node_modules/@lukeed/uuid": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lukeed/csprng": "^1.1.0"
@@ -4288,6 +4283,7 @@
     },
     "node_modules/@ndhoule/defaults": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ndhoule/drop": "^2.0.0",
@@ -4296,10 +4292,12 @@
     },
     "node_modules/@ndhoule/drop": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ndhoule/each": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ndhoule/keys": "^2.0.0"
@@ -4307,14 +4305,17 @@
     },
     "node_modules/@ndhoule/extend": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ndhoule/keys": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ndhoule/rest": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -5572,6 +5573,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.6.0.tgz",
       "integrity": "sha512-O/XGxwP85h1F7+ouqTMOIZ3+V1whfaV9ToIVcuyGriD4JkSD00cQo54BKdqjvBJxbenvp7ynfqRHEwI6e+NIhw==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6096,6 +6098,7 @@
     },
     "node_modules/@segment/localstorage-retry": {
       "version": "1.3.0",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
@@ -6107,6 +6110,7 @@
     },
     "node_modules/@segment/localstorage-retry/node_modules/component-emitter": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6114,6 +6118,7 @@
     },
     "node_modules/@segment/top-domain": {
       "version": "3.0.1",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "component-cookie": "^1.1.5",
@@ -6937,6 +6942,7 @@
     },
     "node_modules/@vespaiach/axios-fetch-adapter": {
       "version": "0.3.1",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "axios": ">=0.26.0"
@@ -7579,6 +7585,7 @@
     },
     "node_modules/assert": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7632,6 +7639,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -7644,6 +7652,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -7666,6 +7675,7 @@
     },
     "node_modules/axios": {
       "version": "1.6.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",
@@ -7677,6 +7687,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.2.0.tgz",
       "integrity": "sha512-zcVGX7NrRe+nadNFsSlf+KUT8ZFWRd8lf5f2QDqZCvWX6n3KTfPWErpTRxD7Nd7pPzQlnpvoEUq1ZrkhCwj/cA==",
+      "dev": true,
       "dependencies": {
         "is-retry-allowed": "^2.2.0"
       },
@@ -8471,6 +8482,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -8635,6 +8647,7 @@
     },
     "node_modules/charenc": {
       "version": "0.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -8945,6 +8958,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -9147,6 +9161,7 @@
     },
     "node_modules/component-cookie": {
       "version": "1.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^2.6.9"
@@ -9154,6 +9169,7 @@
     },
     "node_modules/component-each": {
       "version": "0.2.6",
+      "dev": true,
       "dependencies": {
         "component-type": "1.0.0",
         "to-function": "2.0.6"
@@ -9161,6 +9177,7 @@
     },
     "node_modules/component-emitter": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9170,10 +9187,12 @@
       }
     },
     "node_modules/component-props": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "node_modules/component-type": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9183,7 +9202,8 @@
       }
     },
     "node_modules/component-url": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "dev": true
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -9673,6 +9693,7 @@
     },
     "node_modules/crypt": {
       "version": "0.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -9681,10 +9702,12 @@
     "node_modules/crypto-es": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/crypto-es/-/crypto-es-2.1.0.tgz",
-      "integrity": "sha512-C5Dbuv4QTPGuloy5c5Vv/FZHtmK+lobLAypFfuRaBbwCsk3qbCWWESCH3MUcBsrgXloRNMrzwUAiPg4U6+IaKA=="
+      "integrity": "sha512-C5Dbuv4QTPGuloy5c5Vv/FZHtmK+lobLAypFfuRaBbwCsk3qbCWWESCH3MUcBsrgXloRNMrzwUAiPg4U6+IaKA==",
+      "dev": true
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cssom": {
@@ -9760,6 +9783,7 @@
     },
     "node_modules/debug": {
       "version": "4.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -9775,6 +9799,7 @@
     },
     "node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/decimal.js": {
@@ -9825,6 +9850,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -9848,6 +9874,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -9899,6 +9926,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -10488,6 +10516,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4"
@@ -10498,6 +10527,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12065,6 +12095,7 @@
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -12082,6 +12113,7 @@
     },
     "node_modules/for-each": {
       "version": "0.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
@@ -12115,6 +12147,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -12181,6 +12214,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12271,6 +12305,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12340,6 +12375,7 @@
     },
     "node_modules/get-value": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -12621,6 +12657,7 @@
     },
     "node_modules/gopd": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
@@ -12710,6 +12747,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -12720,6 +12758,7 @@
     },
     "node_modules/has-proto": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12730,6 +12769,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12740,6 +12780,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -12758,6 +12799,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -13132,6 +13174,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -13295,6 +13338,7 @@
     },
     "node_modules/is": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -13302,6 +13346,7 @@
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -13388,6 +13433,7 @@
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-builtin-module": {
@@ -13406,6 +13452,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13514,6 +13561,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.0.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -13565,6 +13613,7 @@
     },
     "node_modules/is-nan": {
       "version": "1.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -13711,6 +13760,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13793,6 +13843,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.14"
@@ -13907,6 +13958,7 @@
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15904,6 +15956,7 @@
     },
     "node_modules/join-component": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-stringify": {
@@ -16617,6 +16670,7 @@
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -16627,14 +16681,17 @@
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
@@ -16644,10 +16701,12 @@
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isundefined": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.kebabcase": {
@@ -16679,6 +16738,7 @@
     },
     "node_modules/lodash.pickby": {
       "version": "4.6.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
@@ -16695,6 +16755,7 @@
     },
     "node_modules/lodash.tostring": {
       "version": "4.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -17406,6 +17467,7 @@
     },
     "node_modules/md5": {
       "version": "2.3.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "charenc": "0.0.2",
@@ -17467,6 +17529,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -17474,6 +17537,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -17777,6 +17841,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/msw": {
@@ -18650,6 +18715,7 @@
     },
     "node_modules/obj-case": {
       "version": "0.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -18670,6 +18736,7 @@
     },
     "node_modules/object-is": {
       "version": "1.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -18684,6 +18751,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -18698,6 +18766,7 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -18784,6 +18853,7 @@
     },
     "node_modules/on-body": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "component-each": "*"
@@ -19542,6 +19612,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -19775,6 +19846,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/psl": {
@@ -19971,6 +20043,7 @@
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.0.tgz",
       "integrity": "sha512-13Y0iMhIQuAm/wNGBL/9HEqIfRGmNmjKnTPlKWfA9f7dnDkr8d45wQ+S7+ZLh/Pq9PdcGxkqKUEA7ySu1QSd9Q==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -21075,6 +21148,7 @@
     },
     "node_modules/rudder-component-cookie": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.2.0"
@@ -21516,6 +21590,7 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.2",
@@ -21975,6 +22050,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/storejs/-/storejs-2.1.0.tgz",
       "integrity": "sha512-0AZJCucZVGYGAEmkK44xf7rkUEhsPuocSHwTcAU3HEyGWl/VYRsc9FURznqxPWVdeIfCrleWalRcwskppxeDYA==",
+      "dev": true,
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
@@ -22556,6 +22632,7 @@
     },
     "node_modules/to-function": {
       "version": "2.0.6",
+      "dev": true,
       "dependencies": {
         "component-props": "*"
       }
@@ -23205,6 +23282,7 @@
     },
     "node_modules/util": {
       "version": "0.12.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -23512,6 +23590,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.14",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.6",
@@ -23791,34 +23870,42 @@
       "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
+        "@preact/signals-core": "1.6.0",
         "@rudderstack/analytics-js-common": "*",
-        "@rudderstack/analytics-js-plugins": "*"
+        "@rudderstack/analytics-js-plugins": "*",
+        "ramda": "0.30.0",
+        "storejs": "2.1.0"
       }
     },
     "packages/analytics-js-common": {
       "name": "@rudderstack/analytics-js-common",
       "version": "3.2.0",
       "license": "MIT",
-      "dependencies": {
-        "@ndhoule/defaults": "2.0.1",
-        "@segment/top-domain": "3.0.1",
-        "crypto-js": "4.2.0",
-        "rudder-component-cookie": "0.0.1"
-      },
       "devDependencies": {
-        "@types/crypto-js": "4.2.2"
+        "@lukeed/uuid": "2.0.1",
+        "@ndhoule/defaults": "2.0.1",
+        "@preact/signals-core": "1.6.0",
+        "@segment/top-domain": "3.0.1",
+        "@types/crypto-js": "4.2.2",
+        "crypto-js": "4.2.0",
+        "get-value": "3.0.1",
+        "ramda": "0.30.0",
+        "rudder-component-cookie": "0.0.1",
+        "storejs": "2.1.0"
       }
     },
     "packages/analytics-js-integrations": {
       "name": "@rudderstack/analytics-js-integrations",
       "version": "3.2.0",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@lukeed/uuid": "2.0.1",
         "@ndhoule/each": "2.0.1",
         "@ndhoule/extend": "2.0.0",
         "@rudderstack/analytics-js-common": "*",
         "component-each": "0.2.6",
         "crypto-js": "4.2.0",
+        "get-value": "3.0.1",
         "is": "3.3.0",
         "lodash.get": "4.4.2",
         "lodash.isempty": "4.4.0",
@@ -23828,43 +23915,41 @@
         "lodash.tostring": "4.1.4",
         "md5": "2.3.0",
         "obj-case": "0.2.1",
-        "on-body": "0.0.1"
-      },
-      "devDependencies": {}
+        "on-body": "0.0.1",
+        "ramda": "0.30.0"
+      }
     },
     "packages/analytics-js-plugins": {
       "name": "@rudderstack/analytics-js-plugins",
       "version": "3.0.5",
       "license": "MIT",
-      "dependencies": {
-        "@rudderstack/analytics-js-common": "*",
-        "crypto-es": "2.1.0"
-      },
       "devDependencies": {
-        "@bugsnag/js": "6.5.2"
+        "@bugsnag/js": "6.5.2",
+        "@rudderstack/analytics-js-common": "*",
+        "crypto-es": "2.1.0",
+        "ramda": "0.30.0"
       }
     },
     "packages/analytics-js-service-worker": {
       "name": "@rudderstack/analytics-js-service-worker",
       "version": "3.0.6",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@lukeed/uuid": "2.0.1",
+        "@types/lodash.clonedeep": "4.5.9",
+        "@types/lodash.isstring": "4.0.9",
+        "@types/ms": "0.7.34",
+        "@types/node": "20.12.12",
         "@vespaiach/axios-fetch-adapter": "0.3.1",
         "assert": "2.1.0",
         "axios": "1.6.8",
         "axios-retry": "4.2.0",
         "component-type": "2.0.0",
+        "jest-date-mock": "1.0.10",
         "join-component": "1.1.0",
         "lodash.clonedeep": "4.5.0",
         "lodash.isstring": "4.0.1",
         "ms": "2.1.3"
-      },
-      "devDependencies": {
-        "@types/lodash.clonedeep": "4.5.9",
-        "@types/lodash.isstring": "4.0.9",
-        "@types/ms": "0.7.34",
-        "@types/node": "20.12.12",
-        "jest-date-mock": "1.0.10"
       },
       "engines": {
         "node": ">=v12"
@@ -23874,6 +23959,7 @@
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
       "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -23884,12 +23970,13 @@
       "name": "rudder-sdk-js",
       "version": "2.48.7",
       "license": "MIT",
-      "dependencies": {
-        "@segment/localstorage-retry": "1.3.0",
-        "component-emitter": "2.0.0"
-      },
       "devDependencies": {
-        "@rudderstack/analytics-js-common": "*"
+        "@lukeed/uuid": "2.0.1",
+        "@rudderstack/analytics-js-common": "*",
+        "@segment/localstorage-retry": "1.3.0",
+        "component-emitter": "2.0.0",
+        "get-value": "3.0.1",
+        "ramda": "0.30.0"
       }
     },
     "packages/loading-scripts": {

--- a/package.json
+++ b/package.json
@@ -60,13 +60,7 @@
     "type": "git",
     "url": "https://github.com/rudderlabs/rudder-sdk-js.git"
   },
-  "dependencies": {
-    "@lukeed/uuid": "2.0.1",
-    "@preact/signals-core": "1.6.0",
-    "get-value": "3.0.1",
-    "ramda": "0.30.0",
-    "storejs": "2.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "7.24.5",
     "@babel/eslint-parser": "7.24.5",

--- a/packages/analytics-js-common/package.json
+++ b/packages/analytics-js-common/package.json
@@ -54,14 +54,18 @@
     "package": "npm pack",
     "release": "npm publish"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "@preact/signals-core": "1.6.0",
+    "@types/crypto-js": "4.2.2",
     "@ndhoule/defaults": "2.0.1",
     "rudder-component-cookie": "0.0.1",
     "@segment/top-domain": "3.0.1",
-    "crypto-js": "4.2.0"
-  },
-  "devDependencies": {
-    "@types/crypto-js": "4.2.2"
+    "crypto-js": "4.2.0",
+    "@lukeed/uuid": "2.0.1",
+    "get-value": "3.0.1",
+    "ramda": "0.30.0",
+    "storejs": "2.1.0"
   },
   "overrides": {},
   "browserslist": {

--- a/packages/analytics-js-integrations/package.json
+++ b/packages/analytics-js-integrations/package.json
@@ -84,7 +84,8 @@
     "build:integration:all:bundle-size": "VISUALIZER=true npm run build:integration:all",
     "build:integration:all:bundle-size:modern": "VISUALIZER=true npm run build:integration:all:modern"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "@rudderstack/analytics-js-common": "*",
     "@ndhoule/each": "2.0.1",
     "lodash.get": "4.4.2",
@@ -99,9 +100,11 @@
     "lodash.isundefined": "3.0.1",
     "lodash.isempty": "4.4.0",
     "lodash.pickby": "4.6.0",
-    "lodash.tostring": "4.1.4"
+    "lodash.tostring": "4.1.4",
+    "@lukeed/uuid": "2.0.1",
+    "get-value": "3.0.1",
+    "ramda": "0.30.0"
   },
-  "devDependencies": {},
   "overrides": {},
   "browserslist": {
     "production": [

--- a/packages/analytics-js-plugins/package.json
+++ b/packages/analytics-js-plugins/package.json
@@ -73,12 +73,12 @@
     "package": "npm pack",
     "release": "npm publish"
   },
-  "dependencies": {
-    "crypto-es": "2.1.0",
-    "@rudderstack/analytics-js-common": "*"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "@bugsnag/js": "6.5.2"
+    "@bugsnag/js": "6.5.2",
+    "crypto-es": "2.1.0",
+    "@rudderstack/analytics-js-common": "*",
+    "ramda": "0.30.0"
   },
   "overrides": {},
   "browserslist": {

--- a/packages/analytics-js-service-worker/package.json
+++ b/packages/analytics-js-service-worker/package.json
@@ -68,7 +68,13 @@
   "engines": {
     "node": ">=v12"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "@types/ms": "0.7.34",
+    "@types/lodash.clonedeep": "4.5.9",
+    "@types/lodash.isstring": "4.0.9",
+    "@types/node": "20.12.12",
+    "jest-date-mock": "1.0.10",
     "@vespaiach/axios-fetch-adapter": "0.3.1",
     "assert": "2.1.0",
     "axios": "1.6.8",
@@ -77,14 +83,8 @@
     "join-component": "1.1.0",
     "lodash.clonedeep": "4.5.0",
     "lodash.isstring": "4.0.1",
-    "ms": "2.1.3"
-  },
-  "devDependencies": {
-    "@types/ms": "0.7.34",
-    "@types/lodash.clonedeep": "4.5.9",
-    "@types/lodash.isstring": "4.0.9",
-    "@types/node": "20.12.12",
-    "jest-date-mock": "1.0.10"
+    "ms": "2.1.3",
+    "@lukeed/uuid": "2.0.1"
   },
   "overrides": {},
   "browserslist": {

--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -90,7 +90,10 @@
   },
   "devDependencies": {
     "@rudderstack/analytics-js-common": "*",
-    "@rudderstack/analytics-js-plugins": "*"
+    "@rudderstack/analytics-js-plugins": "*",
+    "@preact/signals-core": "1.6.0",
+    "ramda": "0.30.0",
+    "storejs": "2.1.0"
   },
   "browserslist": {
     "production": [

--- a/packages/analytics-v1.1/package.json
+++ b/packages/analytics-v1.1/package.json
@@ -76,12 +76,14 @@
     "url": "https://github.com/rudderlabs/rudder-sdk-js.git",
     "directory": "packages/analytics-v1.1"
   },
-  "dependencies": {
-    "component-emitter": "2.0.0",
-    "@segment/localstorage-retry": "1.3.0"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "@rudderstack/analytics-js-common": "*"
+    "@rudderstack/analytics-js-common": "*",
+    "component-emitter": "2.0.0",
+    "@segment/localstorage-retry": "1.3.0",
+    "@lukeed/uuid": "2.0.1",
+    "get-value": "3.0.1",
+    "ramda": "0.30.0"
   },
   "overrides": {},
   "browserslist": {


### PR DESCRIPTION
## PR Description

To avoid Nx considering all the projects affected for creating GitHub releases, as they usually involve changes to package.json and package-lock.json, we're explicitly ignoring them from Nx.

Also, all the project-specific dependencies have been moved to the corresponding package.json files. This was done to ensure any real dependency changes would result in releasing the package as it is a file within the project's scope.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1489/fix-the-publish-to-github-workflow-to-not-fail-when-a-package-does-not

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Updated GitHub workflow titles for better clarity in release pull requests.
  - Implemented a workaround to ignore `package-lock.json` and `package.json` files before publishing releases.
  - Restructured workflow steps in deployment to enhance deployment job referencing and parameter setting.
  - Updated URLs and project names for NPM packages in Slack notifications for better consistency and clarity.
  - Enhanced Slack message template for deployment notifications to include project name and JavaScript icon.
  - Added `REMOTE_MODULES_BASE_PATH` environment variable and modified project details in Slack notification for improved deployment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->