### PR TITLE
feat: introduce a new config for if hashing is required

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/BingAds/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/BingAds/browser.test.js
@@ -61,9 +61,9 @@ describe('BingAds Track event', () => {
     bingAds.init();
     window.bing12567839.push = jest.fn((_, y, z) => output.push({ event: y, ...z }));
   });
-  test('Test for custom properties with enhanced conversions using email only', () => {
+  test('Test for custom properties with enhanced conversions using email only with hashing disabled', () => {
     bingAds = new BingAds(
-      { tagID: '12567839', enableEnhancedConversions: true },
+      { tagID: '12567839', enableEnhancedConversions: true, isHashRequired: false },
       { loglevel: 'DEBUG' },
     );
     bingAds.init();
@@ -72,7 +72,7 @@ describe('BingAds Track event', () => {
       message: {
         type: 'track',
         context: {
-          traits: { email: 'abc+!@xyz.com' },
+          traits: { email: 'hashed_email' },
         },
         event,
         properties: {
@@ -92,10 +92,11 @@ describe('BingAds Track event', () => {
       ecomm_pagetype: 'other',
       pid: {
         '': '',
-        em: 'ee278943de84e5d6243578ee1a1057bcce0e50daad9755f45dfa64b60b13bc5d',
+        em: 'hashed_email',
       },
     });
   });
+
   test('Test for all properties not null', () => {
     bingAds.track({
       message: {
@@ -251,6 +252,41 @@ describe('BingAds Track event', () => {
       ecomm_totalvalue: 18.9,
       pid: {
         phn: '422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8',
+        em: 'ee278943de84e5d6243578ee1a1057bcce0e50daad9755f45dfa64b60b13bc5d',
+      },
+    });
+  });
+  test('Test for custom properties with enhanced conversions using email only with hashing set as true', () => {
+    bingAds = new BingAds(
+      { tagID: '12567839', enableEnhancedConversions: true, isHashRequired: true },
+      { loglevel: 'DEBUG' },
+    );
+    bingAds.init();
+    window.bing12567839.push = jest.fn((_, y, z) => output.push({ event: y, ...z }));
+    bingAds.track({
+      message: {
+        type: 'track',
+        context: {
+          traits: { email: 'abc+!@xyz.com' },
+        },
+        event,
+        properties: {
+          event_action: 'button_click',
+          category: 'Food',
+          currency: 'INR',
+          customProp: 'custom',
+        },
+      },
+    });
+    expect(output[5]).toEqual({
+      event: 'button_click',
+      event_label: event,
+      event_category: 'Food',
+      currency: 'INR',
+      customProp: 'custom',
+      ecomm_pagetype: 'other',
+      pid: {
+        '': '',
         em: 'ee278943de84e5d6243578ee1a1057bcce0e50daad9755f45dfa64b60b13bc5d',
       },
     });

--- a/packages/analytics-js-integrations/__tests__/integrations/BingAds/utils.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/BingAds/utils.test.js
@@ -144,7 +144,7 @@ describe('Construct PID payload for enahcned conversions', () => {
     const message = {};
 
     // Act
-    const result = constructPidPayload(message);
+    const result = constructPidPayload(message, true);
 
     // Assert
     expect(result).toEqual(undefined);
@@ -162,7 +162,7 @@ describe('Construct PID payload for enahcned conversions', () => {
     };
 
     // Act
-    const result = constructPidPayload(message);
+    const result = constructPidPayload(message, true);
 
     // Assert
     expect(result).toBeUndefined();
@@ -180,7 +180,7 @@ describe('Construct PID payload for enahcned conversions', () => {
     };
 
     // Act
-    const result = constructPidPayload(message);
+    const result = constructPidPayload(message, true);
 
     // Assert
     expect(result).toEqual({
@@ -199,7 +199,7 @@ describe('Construct PID payload for enahcned conversions', () => {
     };
 
     // Act
-    const result = constructPidPayload(message);
+    const result = constructPidPayload(message, true);
 
     // Assert
     expect(result).toEqual({
@@ -214,21 +214,21 @@ describe('Construct PID payload for enahcned conversions', () => {
     const message = {
       context: {
         traits: {
-          email: 'test@example.com',
+          email: 'hashed_email',
         },
       },
       traits: {
-        phone: '1234567890',
+        phone: 'hashed_phone',
       },
     };
 
     // Act
-    const result = constructPidPayload(message);
+    const result = constructPidPayload(message, false);
 
     // Assert
     expect(result).toEqual({
-      em: '973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b',
-      ph: '422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8',
+      em: 'hashed_email',
+      ph: 'hashed_phone',
     });
   });
 });

--- a/packages/analytics-js-integrations/src/integrations/BingAds/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/BingAds/browser.js
@@ -30,6 +30,7 @@ class BingAds {
     } = destinationInfo ?? {});
     this.uniqueId = `bing${this.tagID}`;
     this.enableEnhancedConversions = config.enableEnhancedConversions;
+    this.isHashRequired = config.isHashRequired;
   }
 
   init() {
@@ -75,7 +76,7 @@ class BingAds {
 
     payload = { ...payload, ...customProperties };
     if (this.enableEnhancedConversions === true) {
-      payload.pid = context?.traits?.pid || constructPidPayload(context);
+      payload.pid = context?.traits?.pid || constructPidPayload(context, this.isHashRequired);
     }
     payload = removeUndefinedAndNullValues(payload);
     window[this.uniqueId].push('event', eventToSend, payload);

--- a/packages/analytics-js-integrations/src/integrations/BingAds/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/BingAds/utils.js
@@ -163,15 +163,15 @@ function formatAndHashPhoneNumber(phoneNumber) {
  * Constructing Pid Payload
  * @param {*} context
  */
-const constructPidPayload = message => {
+const constructPidPayload = (message, hashRequired) => {
   const email = get(message, 'context.traits.email') || get(message, 'traits.email');
   const phone = get(message, 'context.traits.phone') || get(message, 'traits.phone');
   const pid = {};
   if (isDefinedAndNotNull(email)) {
-    pid.em = formatAndHashEmailAddress(email);
+    pid.em = hashRequired ? formatAndHashEmailAddress(email) : email;
   }
   if (isDefinedAndNotNull(phone)) {
-    pid.ph = formatAndHashPhoneNumber(phone);
+    pid.ph = hashRequired ? formatAndHashPhoneNumber(phone) : phone;
   }
   /* Docs: https://help.ads.microsoft.com/apex/index/3/en/60178
   Bing ads says if anyone one of the properties is not available 


### PR DESCRIPTION
## PR Description
Introducing a new config option to check if hashing is required or not for email and phone used for enhanced conversions

Please include a summary of the change along with the relevant motivation and context.

## Linear task (optional)
Resolved INT-2077

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced BingAds integration to support custom properties with conditional email hashing for improved conversions.

- **Bug Fixes**
  - Fixed issues with payload construction in BingAds integration to correctly handle hashed and non-hashed email values.

- **Tests**
  - Added new test cases for BingAds integration to verify functionality with and without email hashing.
  
- **Improvements**
  - Updated payload construction logic to conditionally hash email and phone numbers based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->