### PR TITLE
fix: sdk base url deduction

### DIFF
--- a/packages/analytics-js/.size-limit.js
+++ b/packages/analytics-js/.size-limit.js
@@ -11,17 +11,17 @@ module.exports = [
   {
     name: 'Core CJS - NPM',
     path: 'dist/npm/modern/cjs/index.js',
-    limit: '23.7 KiB',
+    limit: '24 KiB',
   },
   {
     name: 'Core - NPM',
     path: 'dist/npm/modern/umd/index.js',
-    limit: '23.7 KiB',
+    limit: '24 KiB',
   },
   {
     name: 'Core Legacy - CDN',
     path: 'dist/cdn/legacy/iife/rsa.min.js',
-    limit: '44.2 KiB',
+    limit: '44.5 KiB',
   },
   {
     name: 'Core - CDN',

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -38,48 +38,34 @@ describe('Config Manager Common Utilities', () => {
       removeScriptElement();
     });
 
-    it('should return SDK url that is being used', () => {
-      const dummySdkURL = 'https://www.dummy.url/fromScript/v3/rsa.min.js';
-      createScriptElement(dummySdkURL);
+    const testCases = [
+      // expected, input
+      [
+        'https://www.dummy.url/fromScript/v3/rsa.min.js',
+        'https://www.dummy.url/fromScript/v3/rsa.min.js',
+      ],
+      [undefined, 'https://www.dummy.url/fromScript/v3/other.min.js'],
+      ['https://www.dummy.url/fromScript/v3/rsa.js', 'https://www.dummy.url/fromScript/v3/rsa.js'],
+      [undefined, 'https://www.dummy.url/fromScript/v3/rudder.min.js'],
+      [undefined, 'https://www.dummy.url/fromScript/v3/analytics.min.js'],
+      [undefined, 'https://www.dummy.url/fromScript/v3/rsa.min'],
+      ['https://www.dummy.url/fromScript/v3/rsa.js', 'https://www.dummy.url/fromScript/v3/rsa.js'],
+      [undefined, 'https://www.dummy.url/fromScript/v3/rsa'],
+      [undefined, 'https://www.dummy.url/fromScript/v3rsa.min.js'],
+      ['/rsa.min.js', '/rsa.min.js'],
+      ['/rsa.js', '/rsa.js'],
+      [undefined, 'https://www.dummy.url/fromScript/v3/rs.min.js'],
+      [undefined, 'https://www.dummy.url/fromScript/v3/rsamin.js'],
+      ['rsa.min.js', 'rsa.min.js'],
+      ['rsa.js', 'rsa.js'],
+      [undefined, 'https://www.dummy.url/fromScript/v3/rsa.min.jsx'],
+    ];
+
+    test.each(testCases)('should return %s when the script src is %s', (expected, input) => {
+      createScriptElement(input as string);
 
       const sdkURL = getSDKUrl();
-      expect(sdkURL).toBe(dummySdkURL);
-    });
-
-    it('should return sdkURL as undefined when rudder SDK is not used', () => {
-      const dummySdkURL = 'https://www.dummy.url/fromScript/v3/other.min.js';
-      createScriptElement(dummySdkURL);
-
-      const sdkURL = getSDKUrl();
-      expect(sdkURL).toBe(undefined);
-    });
-    it('should return sdkURL when development rudder SDK is used', () => {
-      const dummySdkURL = 'https://www.dummy.url/fromScript/v3/rsa.js';
-      createScriptElement(dummySdkURL);
-
-      const sdkURL = getSDKUrl();
-      expect(sdkURL).toBe(dummySdkURL);
-    });
-    it('should return sdkURL as undefined when different SDK is used with similar name', () => {
-      const dummySdkURL = 'https://www.dummy.url/fromScript/v3/rudder.min.js';
-      createScriptElement(dummySdkURL);
-
-      const sdkURL = getSDKUrl();
-      expect(sdkURL).toBe(undefined);
-    });
-    it('should return sdkURL as undefined when different SDK is used with the name analytics', () => {
-      const dummySdkURL = 'https://www.dummy.url/fromScript/v3/analytics.min.js';
-      createScriptElement(dummySdkURL);
-
-      const sdkURL = getSDKUrl();
-      expect(sdkURL).toBe(undefined);
-    });
-    it('should return sdkURL as undefined when rudder SDK is used with incomplete name', () => {
-      const dummySdkURL = 'https://www.dummy.url/fromScript/v3/rsa.min';
-      createScriptElement(dummySdkURL);
-
-      const sdkURL = getSDKUrl();
-      expect(sdkURL).toBe(undefined);
+      expect(sdkURL).toBe(expected);
     });
   });
 

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -59,6 +59,7 @@ describe('Config Manager Common Utilities', () => {
       ['rsa.min.js', 'rsa.min.js'],
       ['rsa.js', 'rsa.js'],
       [undefined, 'https://www.dummy.url/fromScript/v3/rsa.min.jsx'],
+      [undefined, null],
     ];
 
     test.each(testCases)('should return %s when the script src is %s', (expected, input) => {

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -51,22 +51,17 @@ import { getConsentManagementData } from '../../utilities/consent';
  */
 const getSDKUrl = (): string | undefined => {
   const scripts = document.getElementsByTagName('script');
-  let sdkURL: string | undefined;
-  const scriptList = Array.prototype.slice.call(scripts);
+  const sdkFileNameRegex = /(?:^|\/)rsa(\.min)?\.js$/;
 
-  scriptList.some(script => {
-    const curScriptSrc = removeTrailingSlashes(script.getAttribute('src'));
-    if (curScriptSrc) {
-      const urlMatches = curScriptSrc.match(/^.*rsa?(\.min)?\.js$/);
-      if (urlMatches) {
-        sdkURL = curScriptSrc;
-        return true;
-      }
+  // eslint-disable-next-line no-restricted-syntax
+  for (const script of scripts) {
+    const src = script.getAttribute('src');
+    if (src && sdkFileNameRegex.test(src)) {
+      return src;
     }
-    return false;
-  });
+  }
 
-  return sdkURL;
+  return undefined;
 };
 
 /**


### PR DESCRIPTION
## PR Description

I've fixed the logic to deduce the SDK base URL from the script tags. The regex previously used had a problem.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1921/update-sdk-base-url-regex

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
