### PR TITLE
fix: cookie domain determination

### DIFF
--- a/packages/analytics-js/__tests__/services/StoreManager/storages/defaultOptions.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/storages/defaultOptions.test.ts
@@ -1,0 +1,29 @@
+import { domain } from '../../../../src/services/StoreManager/top-domain';
+import { getDefaultCookieOptions } from '../../../../src/services/StoreManager/storages/defaultOptions';
+
+jest.mock('../../../../src/services/StoreManager/top-domain', () => ({
+  domain: jest.fn().mockReturnValue('example.com'),
+}));
+describe('getDefaultCookieOptions', () => {
+  it('should return default cookie options with a valid top domain', () => {
+    const result = getDefaultCookieOptions();
+    expect(result).toEqual({
+      maxage: 31536000000,
+      path: '/',
+      domain: '.example.com',
+      samesite: 'Lax',
+      enabled: true,
+    });
+  });
+  it('should return default cookie options with undefined domain', () => {
+    (domain as jest.Mock).mockReturnValueOnce('');
+    const result = getDefaultCookieOptions();
+    expect(result).toEqual({
+      maxage: 31536000000,
+      path: '/',
+      domain: undefined,
+      samesite: 'Lax',
+      enabled: true,
+    });
+  });
+});

--- a/packages/analytics-js/src/services/StoreManager/storages/defaultOptions.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/defaultOptions.ts
@@ -8,7 +8,7 @@ import { DEFAULT_COOKIE_MAX_AGE_MS } from '../../../constants/timeouts';
 import { domain } from '../top-domain';
 
 const getDefaultCookieOptions = (): ICookieStorageOptions => {
-  const topDomain = domain(globalThis.location.href);
+  const topDomain = `.${domain(globalThis.location.href)}`;
 
   return {
     maxage: DEFAULT_COOKIE_MAX_AGE_MS,


### PR DESCRIPTION
## PR Description

A leading dot was added after determining the top-level domain.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-1929/fix-cookie-domain-determination)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved domain handling in cookie options to ensure better cross-domain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->