### PR TITLE
fix: abort initialization if source is disabled

### DIFF
--- a/packages/analytics-js/src/components/configManager/ConfigManager.ts
+++ b/packages/analytics-js/src/components/configManager/ConfigManager.ts
@@ -15,6 +15,7 @@ import {
   SOURCE_CONFIG_FETCH_ERROR,
   SOURCE_CONFIG_OPTION_ERROR,
   SOURCE_CONFIG_RESOLUTION_ERROR,
+  SOURCE_DISABLED_ERROR,
 } from '../../constants/logMessages';
 import { getSourceConfigURL } from '../utilities/loadOptions';
 import { filterEnabledDestination } from '../utilities/destinations';
@@ -156,6 +157,12 @@ class ConfigManager implements IConfigManager {
       return;
     }
 
+    // Log error and abort if source is disabled
+    if (res.source.enabled === false) {
+      this.logger?.error(SOURCE_DISABLED_ERROR);
+      return;
+    }
+
     // set the values in state for reporting slice
     updateReportingState(res, this.logger);
 
@@ -209,7 +216,7 @@ class ConfigManager implements IConfigManager {
       if (!isFunction(sourceConfigFunc)) {
         throw new Error(SOURCE_CONFIG_OPTION_ERROR);
       }
-      // fetch source config from the function
+      // Fetch source config from the function
       const res = sourceConfigFunc();
 
       if (res instanceof Promise) {
@@ -222,7 +229,7 @@ class ConfigManager implements IConfigManager {
         this.processConfig(res as SourceConfigResponse);
       }
     } else {
-      // fetch source config from config url API
+      // Fetch source configuration from the configured URL
       this.httpClient.getAsyncData({
         url: state.lifecycle.sourceConfigUrl.value as string,
         options: {

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -15,6 +15,7 @@ const INTG_CDN_BASE_URL_ERROR = `Failed to load the SDK as the CDN base URL for 
 const PLUGINS_CDN_BASE_URL_ERROR = `Failed to load the SDK as the CDN base URL for plugins is not valid.`;
 const DATA_PLANE_URL_ERROR = `Failed to load the SDK as the data plane URL could not be determined. Please check that the data plane URL is set correctly and try again.`;
 const SOURCE_CONFIG_RESOLUTION_ERROR = `Unable to process/parse source configuration response.`;
+const SOURCE_DISABLED_ERROR = `The source is disabled. Please enable the source in the dashboard to send events.`;
 const XHR_PAYLOAD_PREP_ERROR = `Failed to prepare data for the request.`;
 const EVENT_OBJECT_GENERATION_ERROR = `Failed to generate the event object.`;
 const PLUGIN_EXT_POINT_MISSING_ERROR = `Failed to invoke plugin because the extension point name is missing.`;
@@ -318,4 +319,5 @@ export {
   FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
   FAILED_TO_REMOVE_COOKIE_FROM_SERVER_ERROR,
   MISCONFIGURED_PLUGINS_WARNING,
+  SOURCE_DISABLED_ERROR,
 };


### PR DESCRIPTION
## PR Description

SDK doesn't proceed with initialization if the source is disabled.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1834/js-sdk-does-not-stop-initializing-even-if-the-source-is-disabled

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added error logging and abort functionality when a data source is disabled.
  - Introduced a new error message to inform users about disabled data sources and the need to enable them in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->