### PR TITLE
feat: handle remove cookie from client side

### DIFF
--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1483,12 +1483,10 @@ describe('User session manager', () => {
         state.serverCookies.isEnabledServerSideCookies.value = true;
         state.storage.entries.value = entriesWithOnlyCookieStorage;
         userSessionManager.setServerSideCookie = jest.fn();
+        clientDataStoreCookie.remove = jest.fn();
         userSessionManager.syncValueToStorage('anonymousId', cookieValue);
-        expect(userSessionManager.setServerSideCookie).toHaveBeenCalledWith(
-          [{ name: 'rl_anonymous_id', value: '' }],
-          undefined,
-          expect.any(Object),
-        );
+        expect(userSessionManager.setServerSideCookie).not.toHaveBeenCalled();
+        expect(clientDataStoreCookie.remove).toHaveBeenCalled();
       });
     });
   });
@@ -1596,28 +1594,6 @@ describe('User session manager', () => {
           done();
         }, 1000);
       });
-      it('should log error if not successfully removed from the server', done => {
-        state.source.value = { workspaceId: 'sample_workspaceId' };
-        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
-        state.storage.cookie.value = {
-          maxage: 10 * 60 * 1000, // 10 min
-          path: '/',
-          domain: 'example.com',
-          samesite: 'Lax',
-        };
-        userSessionManager.setServerSideCookie(
-          [{ name: 'key', value: '' }],
-          undefined,
-          mockCookieStore,
-        );
-        setTimeout(() => {
-          expect(mockCookieStore.get).toHaveBeenCalledWith('key');
-          expect(defaultLogger.error).toHaveBeenCalledWith(
-            'The server failed to remove the key cookie.',
-          );
-          done();
-        }, 1000);
-      });
     });
 
     it('should set cookie from client side if data service is down', done => {
@@ -1695,14 +1671,6 @@ describe('User session manager', () => {
         expect(encryptedData).toStrictEqual([
           { name: 'key', value: 'encrypted_sample_cookie_value_1234' },
         ]);
-      });
-      it('cookie value do not exists', () => {
-        const encryptedData = userSessionManager.getEncryptedCookieData(
-          [{ name: 'key', value: '' }],
-          mockCookieStore,
-        );
-        expect(mockCookieStore.encrypt).not.toHaveBeenCalled();
-        expect(encryptedData).toStrictEqual([{ name: 'key', value: '' }]);
       });
     });
     describe('makeRequestToSetCookie', () => {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -47,7 +47,6 @@ import {
   DATA_SERVER_REQUEST_FAIL_ERROR,
   FAILED_SETTING_COOKIE_FROM_SERVER_ERROR,
   FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
-  FAILED_TO_REMOVE_COOKIE_FROM_SERVER_ERROR,
   TIMEOUT_NOT_NUMBER_WARNING,
   TIMEOUT_NOT_RECOMMENDED_WARNING,
   TIMEOUT_ZERO_WARNING,
@@ -296,10 +295,9 @@ class UserSessionManager implements IUserSessionManager {
   getEncryptedCookieData(cookieData: CookieData[], store?: IStore): EncryptedCookieData[] {
     const encryptedCookieData: EncryptedCookieData[] = [];
     cookieData.forEach(e => {
-      const encryptedValue =
-        e.value === ''
-          ? e.value
-          : store?.encrypt(stringifyWithoutCircular(e.value, false, [], this.logger));
+      const encryptedValue = store?.encrypt(
+        stringifyWithoutCircular(e.value, false, [], this.logger),
+      );
       if (isDefinedAndNotNull(encryptedValue)) {
         encryptedCookieData.push({
           name: e.name,
@@ -360,17 +358,13 @@ class UserSessionManager implements IUserSessionManager {
           if (details?.xhr?.status === 200) {
             cookieData.forEach(each => {
               const cookieValue = store?.get(each.name);
-              if (each.value) {
-                const before = stringifyWithoutCircular(each.value, false, []);
-                const after = stringifyWithoutCircular(cookieValue, false, []);
-                if (after !== before) {
-                  this.logger?.error(FAILED_SETTING_COOKIE_FROM_SERVER_ERROR(each.name));
-                  if (cb) {
-                    cb(each.name, each.value);
-                  }
+              const before = stringifyWithoutCircular(each.value, false, []);
+              const after = stringifyWithoutCircular(cookieValue, false, []);
+              if (after !== before) {
+                this.logger?.error(FAILED_SETTING_COOKIE_FROM_SERVER_ERROR(each.name));
+                if (cb) {
+                  cb(each.name, each.value);
                 }
-              } else if (cookieValue) {
-                this.logger?.error(FAILED_TO_REMOVE_COOKIE_FROM_SERVER_ERROR(each.name));
               }
             });
           } else {
@@ -426,14 +420,6 @@ class UserSessionManager implements IUserSessionManager {
         } else {
           curStore?.set(key, value);
         }
-      } else if (
-        state.serverCookies.isEnabledServerSideCookies.value &&
-        storageType === COOKIE_STORAGE
-      ) {
-        // remove cookie that is set from server side
-        // TODO: Test cookies set from server side can be cleared from client side
-        // and make appropriate changes.
-        this.setServerSideCookie([{ name: key, value: '' }], undefined, curStore);
       } else {
         curStore?.remove(key);
       }

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -99,8 +99,6 @@ const DATA_SERVER_REQUEST_FAIL_ERROR = (status?: number) =>
   `The server responded with status ${status} while setting the cookies. As a fallback, the cookies will be set client side.`;
 const FAILED_SETTING_COOKIE_FROM_SERVER_ERROR = (key: string) =>
   `The server failed to set the ${key} cookie. As a fallback, the cookies will be set client side.`;
-const FAILED_TO_REMOVE_COOKIE_FROM_SERVER_ERROR = (key: string) =>
-  `The server failed to remove the ${key} cookie.`;
 const FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR = `Failed to set/remove cookies via server. As a fallback, the cookies will be managed client side.`;
 
 // WARNING
@@ -318,7 +316,6 @@ export {
   DATA_SERVER_REQUEST_FAIL_ERROR,
   FAILED_SETTING_COOKIE_FROM_SERVER_ERROR,
   FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
-  FAILED_TO_REMOVE_COOKIE_FROM_SERVER_ERROR,
   generateMisconfiguredPluginsWarning,
   INVALID_POLYFILL_URL_WARNING,
   SOURCE_DISABLED_ERROR,


### PR DESCRIPTION
## PR Description

Remove the cookies(that are set from the server side) from client side only.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-1941/handle-remove-cookies-from-client-side)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved cookie handling logic in user sessions for better performance and reliability.

- **Tests**
  - Updated tests to reflect changes in cookie management, ensuring robust validation.

- **Chores**
  - Cleaned up obsolete error handling code and constants related to server-side cookie removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->