### PR TITLE
feat: add install type to context

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -51,6 +51,14 @@ jobs:
           echo "CURRENT_VERSION_SW_VALUE=$current_version_sw" >> $GITHUB_ENV
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
 
+      - name: Get versions in NPM
+        run: |
+          current_npm_version=$(npm show @rudderstack/analytics-js version 2>/dev/null || echo "not found")
+          echo "CURRENT_NPM_VERSION=$current_npm_version" >> $GITHUB_ENV
+
+          current_npm_version_sw=$(npm show @rudderstack/analytics-js-service-worker version 2>/dev/null || echo "not found")
+          echo "CURRENT_NPM_VERSION_SW=$current_npm_version_sw" >> $GITHUB_ENV
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -82,7 +90,16 @@ jobs:
           git reset --hard
           git clean -fd
 
+      - name: Get versions in NPM after publish
+        run: |
+          new_npm_version=$(npm show @rudderstack/analytics-js version 2>/dev/null || echo "not found")
+          echo "NEW_NPM_VERSION=$new_npm_version" >> $GITHUB_ENV
+
+          new_npm_version_sw=$(npm show @rudderstack/analytics-js-service-worker version 2>/dev/null || echo "not found")
+          echo "NEW_NPM_VERSION_SW=$new_npm_version_sw" >> $GITHUB_ENV
+
       - name: Send message to Slack channel
+        if: ${{ env.CURRENT_NPM_VERSION != env.NEW_NPM_VERSION && env.NEW_NPM_VERSION != 'not found'}}
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         env:
@@ -131,6 +148,7 @@ jobs:
             }
 
       - name: Send message to Slack channel for Service Worker
+        if: ${{ env.CURRENT_NPM_VERSION_SW != env.NEW_NPM_VERSION_SW && env.NEW_NPM_VERSION_SW != 'not found'}}
         id: slackSw
         uses: slackapi/slack-github-action@v1.26.0
         env:

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -145,12 +145,12 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'Sanity suite - ${{ inputs.environment }}'
           CDN_URL: 'https://cdn.rudderlabs.com/sanity-suite${{ env.SUITE_CDN_PATH }}v3/cdn/index.html'
-          LINK_TEXT: ${{ (inputs.environment == 'staging' && format('{0} - Staging', env.CURRENT_VERSION_VALUE) || env.CURRENT_VERSION_VALUE) }}
+          LINK_TEXT: ${{ ((inputs.environment == 'staging' && format('v{0} - Staging', env.CURRENT_VERSION_VALUE)) || format('v{0}', env.CURRENT_VERSION_VALUE)) }}
           with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": "*New Deployment: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|Deployment>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
+              "text": "*New Deployment: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
               "blocks": [
                 {
                   "type": "header",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,12 +177,12 @@ jobs:
           PROJECT_NAME: 'JS SDK Browser Package${{ inputs.action_type }} - ${{ inputs.environment }}'
           CDN_URL: 'https://cdn.rudderlabs.com/${{ inputs.s3_dir_path }}/modern/rsa.min.js'
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js@'
-          LINK_TEXT: ${{ inputs.environment == 'development' && 'Development' || (inputs.environment == 'staging' && format('{0} - Staging', env.CURRENT_VERSION_VALUE) || env.CURRENT_VERSION_VALUE) }}
+          LINK_TEXT: ${{ inputs.environment == 'development' && 'Development' || ((inputs.environment == 'staging' && format('v{0} - Staging', env.CURRENT_VERSION_VALUE)) || format('v{0}', env.CURRENT_VERSION_VALUE)) }}
         with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
+              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>",
               "blocks": [
                 {
                   "type": "header",
@@ -198,7 +198,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*<${{ env.CDN_URL }}|v${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
+                    "text": "*<${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D>"
                   },
                   "accessory": {
                     "type": "image",

--- a/packages/analytics-js-common/__tests__/utilities/url.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/url.test.ts
@@ -25,6 +25,10 @@ describe('utilities - url', () => {
       [true, 'https://example.com?query=string&another=value'],
       [true, 'https://example.com#fragment'],
       [false, undefined],
+      [
+        true,
+        'https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=URL%2CPromise%2CNumber.isNaN%2CNumber.isInteger%2CArray.from%2CArray.prototype.find%2CArray.prototype.includes%2CString.prototype.endsWith%2CString.prototype.startsWith%2CString.prototype.includes%2CString.prototype.replaceAll%2CString.fromCodePoint%2CObject.entries%2CObject.values%2CObject.assign%2CObject.fromEntries%2CElement.prototype.dataset%2CTextEncoder%2CrequestAnimationFrame%2CCustomEvent%2Cnavigator.sendBeacon%2CArrayBuffer%2CSet',
+      ],
     ];
 
     it.each(testCases)('should return %p if URL is %p', (expected, url) => {

--- a/packages/analytics-js-common/src/types/EventContext.ts
+++ b/packages/analytics-js-common/src/types/EventContext.ts
@@ -2,6 +2,7 @@ export type AppInfo = {
   readonly name: string;
   readonly version: string;
   readonly namespace: string;
+  readonly installType: string;
 };
 
 export type LibraryInfo = {

--- a/packages/analytics-js-common/src/utilities/url.ts
+++ b/packages/analytics-js-common/src/utilities/url.ts
@@ -1,5 +1,5 @@
 import { URL_PATTERN } from '../constants/urls';
-import { isString } from './checks';
+import { isFunction, isString } from './checks';
 
 const removeDuplicateSlashes = (str: string): string => str.replace(/\/{2,}/g, '/');
 
@@ -9,15 +9,19 @@ const removeDuplicateSlashes = (str: string): string => str.replace(/\/{2,}/g, '
  * @returns true if `url` is valid and false otherwise
  */
 const isValidURL = (url: string | undefined): url is string => {
+  if (!isString(url)) {
+    return false;
+  }
+
   try {
-    if (!isString(url)) {
-      return false;
+    // If URL is supported by the browser, we can use it to validate the URL
+    // Otherwise, we can at least check if the URL matches the pattern
+    if (isFunction(globalThis.URL)) {
+      // eslint-disable-next-line no-new
+      new URL(url);
     }
-    // eslint-disable-next-line no-new
-    new URL(url);
     return URL_PATTERN.test(url);
   } catch (e) {
-    console.log(e);
     return false;
   }
 };

--- a/packages/analytics-js-plugins/__tests__/bugsnag/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/bugsnag/index.test.ts
@@ -14,6 +14,14 @@ describe('Plugin - Bugsnag', () => {
     source: signal({
       id: 'test-source-id',
     }),
+    context: {
+      app: signal({
+        name: 'test-app',
+        namespace: 'test-namespace',
+        version: '1.0.0',
+        installType: 'npm',
+      }),
+    },
   };
 
   let state: any;
@@ -98,6 +106,14 @@ describe('Plugin - Bugsnag', () => {
           },
           lifecycle: {
             writeKey: 'dummy-write-key',
+          },
+          context: {
+            app: {
+              name: 'test-app',
+              namespace: 'test-namespace',
+              version: '1.0.0',
+              installType: 'npm',
+            },
           },
         },
       },

--- a/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
@@ -19,6 +19,14 @@ import {
 } from '../../src/bugsnag/utils';
 import { server } from '../../__fixtures__/msw.server';
 
+beforeEach(() => {
+  window.RudderSnippetVersion = '3.0.0';
+});
+
+afterEach(() => {
+  delete window.RudderSnippetVersion;
+});
+
 describe('Bugsnag utilities', () => {
   describe('isApiKeyValid', () => {
     it('should return true for a valid API key', () => {
@@ -166,11 +174,11 @@ describe('Bugsnag utilities', () => {
         errorMessage: 'test error message',
       };
 
-      enhanceErrorEventMutator(event, 'dummyMetadataVal');
+      enhanceErrorEventMutator(event);
 
       expect(event.metadata).toEqual({
         source: {
-          metadataSource: 'dummyMetadataVal',
+          snippetVersion: '3.0.0',
         },
       });
 
@@ -196,7 +204,7 @@ describe('Bugsnag utilities', () => {
 
       expect(event.metadata).toEqual({
         source: {
-          metadataSource: 'dummyMetadataVal',
+          snippetVersion: '3.0.0',
         },
       });
 
@@ -376,7 +384,7 @@ describe('Bugsnag utilities', () => {
     };
 
     it('should return a function', () => {
-      expect(typeof onError(state)).toBe('function');
+      expect(typeof onError()).toBe('function');
     });
 
     it('should return a function that returns false if the error is not from RudderStack SDK', () => {
@@ -388,7 +396,7 @@ describe('Bugsnag utilities', () => {
         ],
       };
 
-      const onErrorFn = onError(state);
+      const onErrorFn = onError();
 
       expect(onErrorFn(error)).toBe(false);
     });
@@ -404,11 +412,11 @@ describe('Bugsnag utilities', () => {
         updateMetaData: jest.fn(),
       } as any;
 
-      const onErrorFn = onError(state);
+      const onErrorFn = onError();
 
       expect(onErrorFn(error)).toBe(true);
       expect(error.updateMetaData).toHaveBeenCalledWith('source', {
-        metadataSource: 'dummy-source-id',
+        snippetVersion: '3.0.0',
       });
       expect(error.severity).toBe('error');
       expect(error.context).toBe('Script load failures');
@@ -425,7 +433,7 @@ describe('Bugsnag utilities', () => {
         errorMessage: 'error in script loading "https://invalid-domain.com/rsa.min.js"',
       } as any;
 
-      const onErrorFn = onError(state);
+      const onErrorFn = onError();
 
       expect(onErrorFn(error)).toBe(false);
     });

--- a/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
@@ -4,6 +4,7 @@ import { ExternalSrcLoader } from '@rudderstack/analytics-js-common/services/Ext
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/ErrorHandler';
 import * as timeouts from '@rudderstack/analytics-js-common/src/constants/timeouts';
+import type { ApplicationState } from '@rudderstack/analytics-js-common/types/ApplicationState';
 import * as bugsnagConstants from '../../src/bugsnag/constants';
 import {
   isApiKeyValid,
@@ -18,8 +19,7 @@ import {
   getAppStateForMetadata,
 } from '../../src/bugsnag/utils';
 import { server } from '../../__fixtures__/msw.server';
-import { BugsnagLib } from '../../src/types/plugins';
-import { authToken } from '../../__fixtures__/fixtures';
+import type { BugsnagLib } from '../../src/types/plugins';
 
 beforeEach(() => {
   window.RudderSnippetVersion = '3.0.0';
@@ -216,7 +216,7 @@ describe('Bugsnag utilities', () => {
   });
 
   describe('initBugsnagClient', () => {
-    let state;
+    let state: ApplicationState;
 
     beforeEach(() => {
       state = {

--- a/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
@@ -207,6 +207,14 @@ describe('Bugsnag utilities', () => {
 
   describe('initBugsnagClient', () => {
     const state = {
+      context: {
+        app: signal({
+          name: 'test-app',
+          namespace: 'test-namespace',
+          version: '1.0.0',
+          installType: 'npm',
+        }),
+      },
       source: signal({
         id: 'dummy-source-id',
       }),

--- a/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/bugsnag/utils.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete window.RudderSnippetVersion;
+  window.RudderSnippetVersion = undefined;
 });
 
 describe('Bugsnag utilities', () => {

--- a/packages/analytics-js-plugins/src/bugsnag/logMessages.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/logMessages.ts
@@ -11,9 +11,13 @@ const BUGSNAG_SDK_LOAD_ERROR = (context: string): string =>
 
 const BUGSNAG_SDK_URL_ERROR = 'The Bugsnag SDK URL is invalid. Failed to load the Bugsnag SDK.';
 
+const FAILED_TO_FILTER_ERROR = (context: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}Failed to filter the error.`;
+
 export {
   BUGSNAG_API_KEY_VALIDATION_ERROR,
   BUGSNAG_SDK_LOAD_TIMEOUT_ERROR,
   BUGSNAG_SDK_LOAD_ERROR,
   BUGSNAG_SDK_URL_ERROR,
+  FAILED_TO_FILTER_ERROR,
 };

--- a/packages/analytics-js-plugins/src/bugsnag/utils.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/utils.ts
@@ -109,7 +109,7 @@ const getNewClient = (state: ApplicationState, logger?: ILogger): BugsnagLib.Cli
 
   const clientConfig: BugsnagLib.IConfig = {
     apiKey: API_KEY,
-    appVersion: '__PACKAGE_VERSION__', // Set SDK version as the app version from build config
+    appVersion: state.context.app.value.version,
     metaData: {
       SDK: {
         name: 'JS',
@@ -124,7 +124,7 @@ const getNewClient = (state: ApplicationState, logger?: ILogger): BugsnagLib.Cli
     maxBreadcrumbs: 40,
     releaseStage: getReleaseStage(),
     user: {
-      id: state.lifecycle.writeKey.value,
+      id: state.source.value?.id || state.lifecycle.writeKey.value,
     },
     logger,
     networkBreadcrumbsEnabled: false,

--- a/packages/analytics-js-plugins/src/bugsnag/utils.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/utils.ts
@@ -165,7 +165,7 @@ const loadBugsnagSDK = (externalSrcLoader: IExternalSrcLoader, logger?: ILogger)
 const initBugsnagClient = (
   state: ApplicationState,
   promiseResolve: (value: BugsnagLib.Client) => void,
-  promiseReject: (reason?: any) => void,
+  promiseReject: (reason?: Error) => void,
   logger?: ILogger,
   time = 0,
 ): void => {

--- a/packages/analytics-js-plugins/src/bugsnag/utils.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/utils.ts
@@ -41,7 +41,7 @@ const isValidVersion = (globalLibInstance: any) => {
   return version && version.charAt(0) === BUGSNAG_VALID_MAJOR_VERSION;
 };
 
-const isRudderSDKError = (event: any) => {
+const isRudderSDKError = (event: BugsnagLib.Report) => {
   const errorOrigin = event.stacktrace?.[0]?.file;
 
   if (!errorOrigin || typeof errorOrigin !== 'string') {
@@ -60,7 +60,7 @@ const isRudderSDKError = (event: any) => {
   );
 };
 
-const enhanceErrorEventMutator = (event: any) => {
+const enhanceErrorEventMutator = (event: BugsnagLib.Report) => {
   event.updateMetaData('source', {
     snippetVersion: (globalThis as typeof window).RudderSnippetVersion,
   });
@@ -80,7 +80,7 @@ const enhanceErrorEventMutator = (event: any) => {
   event.severity = 'error';
 };
 
-const onError = () => (event: any) => {
+const onError = (event: BugsnagLib.Report): boolean => {
   try {
     // Discard the event if it's not originated at the SDK
     if (!isRudderSDKError(event)) {
@@ -116,7 +116,7 @@ const getNewClient = (state: ApplicationState, logger?: ILogger): BugsnagLib.Cli
         installType: state.context.app.value.installType,
       },
     },
-    beforeSend: onError(),
+    beforeSend: onError,
     autoCaptureSessions: false, // auto capture sessions is disabled
     collectUserIp: false, // collecting user's IP is disabled
     // enabledBreadcrumbTypes: ['error', 'log', 'user'], // for v7 and above

--- a/packages/analytics-js-plugins/src/bugsnag/utils.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/utils.ts
@@ -118,7 +118,7 @@ const getNewClient = (state: ApplicationState, logger?: ILogger): BugsnagLib.Cli
     metaData: {
       SDK: {
         name: 'JS',
-        installType: '__MODULE_TYPE__',
+        installType: state.context.app.value.installType,
       },
     },
     beforeSend: onError(state),

--- a/packages/analytics-js-plugins/src/types/plugins.ts
+++ b/packages/analytics-js-plugins/src/types/plugins.ts
@@ -66,4 +66,4 @@ export interface IQueue<T = any> {
   stop(): void;
   enqueue(item: QueueItem<T>): void;
   addItem(item: T): void;
-}
+};

--- a/packages/analytics-js/src/state/slices/context.ts
+++ b/packages/analytics-js/src/state/slices/context.ts
@@ -1,12 +1,13 @@
 import { signal } from '@preact/signals-core';
 import type { ContextState } from '@rudderstack/analytics-js-common/types/ApplicationState';
-import { APP_NAME, APP_NAMESPACE, APP_VERSION } from '../../constants/app';
+import { APP_NAME, APP_NAMESPACE, APP_VERSION, MODULE_TYPE } from '../../constants/app';
 
 const contextState: ContextState = {
   app: signal({
     name: APP_NAME,
     namespace: APP_NAMESPACE,
     version: APP_VERSION,
+    installType: MODULE_TYPE,
   }),
   traits: signal(null),
   library: signal({

--- a/packages/sanity-suite/__fixtures__/alias1.json
+++ b/packages/sanity-suite/__fixtures__/alias1.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/alias2.json
+++ b/packages/sanity-suite/__fixtures__/alias2.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/alias3.json
+++ b/packages/sanity-suite/__fixtures__/alias3.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/alias4.json
+++ b/packages/sanity-suite/__fixtures__/alias4.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/alias5.json
+++ b/packages/sanity-suite/__fixtures__/alias5.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/alias6.json
+++ b/packages/sanity-suite/__fixtures__/alias6.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/eventFiltering1.json
+++ b/packages/sanity-suite/__fixtures__/eventFiltering1.json
@@ -15,6 +15,7 @@
         "resolutionStrategy": "and"
       },
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "3.0.0-beta.15"

--- a/packages/sanity-suite/__fixtures__/eventFiltering2.json
+++ b/packages/sanity-suite/__fixtures__/eventFiltering2.json
@@ -15,6 +15,7 @@
         "resolutionStrategy": "and"
       },
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "3.0.0-beta.15"

--- a/packages/sanity-suite/__fixtures__/eventFiltering3.json
+++ b/packages/sanity-suite/__fixtures__/eventFiltering3.json
@@ -15,6 +15,7 @@
         "resolutionStrategy": "and"
       },
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "3.0.0-beta.15"

--- a/packages/sanity-suite/__fixtures__/group1.json
+++ b/packages/sanity-suite/__fixtures__/group1.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/group2.json
+++ b/packages/sanity-suite/__fixtures__/group2.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/group3.json
+++ b/packages/sanity-suite/__fixtures__/group3.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/group4.json
+++ b/packages/sanity-suite/__fixtures__/group4.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/group5.json
+++ b/packages/sanity-suite/__fixtures__/group5.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/group6.json
+++ b/packages/sanity-suite/__fixtures__/group6.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/identify1.json
+++ b/packages/sanity-suite/__fixtures__/identify1.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/identify2.json
+++ b/packages/sanity-suite/__fixtures__/identify2.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/identify3.json
+++ b/packages/sanity-suite/__fixtures__/identify3.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/identify4.json
+++ b/packages/sanity-suite/__fixtures__/identify4.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/identify5.json
+++ b/packages/sanity-suite/__fixtures__/identify5.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/identify6.json
+++ b/packages/sanity-suite/__fixtures__/identify6.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/identify7.json
+++ b/packages/sanity-suite/__fixtures__/identify7.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/identify8.json
+++ b/packages/sanity-suite/__fixtures__/identify8.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/page1.json
+++ b/packages/sanity-suite/__fixtures__/page1.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/page2.json
+++ b/packages/sanity-suite/__fixtures__/page2.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/page3.json
+++ b/packages/sanity-suite/__fixtures__/page3.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/page4.json
+++ b/packages/sanity-suite/__fixtures__/page4.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/page5.json
+++ b/packages/sanity-suite/__fixtures__/page5.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/page6.json
+++ b/packages/sanity-suite/__fixtures__/page6.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/page7.json
+++ b/packages/sanity-suite/__fixtures__/page7.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/page8.json
+++ b/packages/sanity-suite/__fixtures__/page8.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/sourceConfig1.json
+++ b/packages/sanity-suite/__fixtures__/sourceConfig1.json
@@ -292,7 +292,7 @@
           ],
           "useNativeSDKToSend": false,
           "eventFilteringOption": "disable",
-          "extendPageViewParams": false,
+          "extendPageViewParams": true,
           "piiPropertiesToIgnore": [
             {
               "piiProperty": ""

--- a/packages/sanity-suite/__fixtures__/track1.json
+++ b/packages/sanity-suite/__fixtures__/track1.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/track2.json
+++ b/packages/sanity-suite/__fixtures__/track2.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/track3.json
+++ b/packages/sanity-suite/__fixtures__/track3.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/track4.json
+++ b/packages/sanity-suite/__fixtures__/track4.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/track5.json
+++ b/packages/sanity-suite/__fixtures__/track5.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/track6.json
+++ b/packages/sanity-suite/__fixtures__/track6.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/__fixtures__/track7.json
+++ b/packages/sanity-suite/__fixtures__/track7.json
@@ -3,6 +3,7 @@
     "channel": "web",
     "context": {
       "app": {
+        "installType": "cdn",
         "name": "RudderLabs JavaScript SDK",
         "namespace": "com.rudderlabs.javascript",
         "version": "2.22.2"

--- a/packages/sanity-suite/package.json
+++ b/packages/sanity-suite/package.json
@@ -30,6 +30,7 @@
     "package": "exit 0",
     "release": "exit 0",
     "start:integrations": "npm run clean && mkdir dist && mkdir dist/local && npm run build:v1.1 && npm run build:integrations && rsync -r ../analytics-js-integrations/dist/cdn/legacy/js-integrations dist/local && npm run start:local",
+    "build:start:local:v3": "npm run build:v3 && npm run start:local:v3",
     "start:local": "DEV_SERVER=true npm run build -- --watch",
     "start:local:v3": "DEV_SERVER=true npm run build:local:v3 -- --watch",
     "start:cdn": "DEV_SERVER=true npm run build:cdn -- --watch",
@@ -44,6 +45,7 @@
     "build:cdn:v1": "rollup -c --environment DISTRIBUTION_TYPE:cdn,SDK_VERSION:v1",
     "build:cdn:v3": "rollup -c --environment DISTRIBUTION_TYPE:cdn,SDK_VERSION:v3",
     "build:local:v1.1": "rollup -c --environment DISTRIBUTION_TYPE:local,SDK_VERSION:v1.1",
+    "build:local:v3": "rollup -c --environment DISTRIBUTION_TYPE:local,SDK_VERSION:v3",
     "build:npm:v1.1": "SDK_VERSION=v1.1 npm run build:npm",
     "build:npm:v3": "SDK_VERSION=v3 npm run build:npm",
     "build:all": "npm run build:cdn:v1.1 && npm run build:cdn:v3 && npm run build:npm:v1.1 && npm run build:npm:v3 && rimraf -rf ./dist/dts"


### PR DESCRIPTION
## PR Description

We're now sending a new context field `installType` in `context.app` object which indicates whether the installation type is CDN or NPM.
Based on this, the fixtures in sanity suite have been modified accordingly.

Other minor updates:
- Slack notifications for NPM publishes are sent only when a package is actually published.
- Hyperlink text in Slack notifications tailed for different environment deployments.
- Fixed the installation type value sent to Bugsnag.
- Fixed the app version sent to Bugsnag.
- For user ID in Bugsnag payload, we prefer source ID over write key.
- Fixed an issue in the URL validation to cover the scenario where the 'URL' object is not available in the browsers (legacy).

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1477/send-the-installation-type-in-the-event-context-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `installType` field to the `AppInfo` type for better context in analytics.

- **Bug Fixes**
  - Enhanced error handling and context information in Bugsnag utilities.

- **Chores**
  - Updated deployment workflows to include version information based on the environment.
  - Improved NPM version retrieval and Slack notifications in deployment workflows.

- **Tests**
  - Added new test cases for URL validation and Bugsnag utilities, including setting and deleting global variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->