### PR TITLE
fix: handle cross domain server-side cookie requests

### DIFF
--- a/packages/analytics-js-common/src/types/HttpClient.ts
+++ b/packages/analytics-js-common/src/types/HttpClient.ts
@@ -29,6 +29,7 @@ export interface IXHRRequestOptions {
   headers: Record<string, string | undefined>;
   data?: XMLHttpRequestBodyInit;
   sendRawData?: boolean;
+  withCredentials?: boolean;
 }
 
 export type HTTPClientMethod =

--- a/packages/analytics-js/.size-limit.js
+++ b/packages/analytics-js/.size-limit.js
@@ -21,11 +21,11 @@ module.exports = [
   {
     name: 'Core Legacy - CDN',
     path: 'dist/cdn/legacy/iife/rsa.min.js',
-    limit: '44.5 KiB',
+    limit: '45 KiB',
   },
   {
     name: 'Core - CDN',
     path: 'dist/cdn/modern/iife/rsa.min.js',
-    limit: '24 KiB',
+    limit: '24.5 KiB',
   },
 ];

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1712,6 +1712,7 @@ describe('User session manager', () => {
               },
             }),
             sendRawData: true,
+            withCredentials: true,
           },
           isRawResponse: true,
           callback: expect.any(Function),

--- a/packages/analytics-js/src/components/configManager/ConfigManager.ts
+++ b/packages/analytics-js/src/components/configManager/ConfigManager.ts
@@ -9,8 +9,7 @@ import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/Error
 import type { Destination } from '@rudderstack/analytics-js-common/types/Destination';
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import { CONFIG_MANAGER } from '@rudderstack/analytics-js-common/constants/loggerContexts';
-import { isValidURL } from '@rudderstack/analytics-js-common/utilities/url';
-import { getDataServiceUrl, isValidSourceConfig, validateLoadArgs } from './util/validate';
+import { isValidSourceConfig, validateLoadArgs } from './util/validate';
 import {
   DATA_PLANE_URL_ERROR,
   SOURCE_CONFIG_FETCH_ERROR,
@@ -33,7 +32,6 @@ import {
   updateReportingState,
   updateStorageStateFromLoadOptions,
 } from './util/commonUtil';
-import { DEFAULT_DATA_SERVICE_ENDPOINT } from './constants';
 
 class ConfigManager implements IConfigManager {
   httpClient: IHttpClient;
@@ -81,8 +79,7 @@ class ConfigManager implements IConfigManager {
     updateConsentsStateFromLoadOptions(this.logger);
     updateDataPlaneEventsStateFromLoadOptions(this.logger);
 
-    const { useServerSideCookies, dataServiceEndpoint, logLevel, configUrl } =
-      state.loadOptions.value;
+    const { logLevel, configUrl } = state.loadOptions.value;
 
     // set application lifecycle state in global state
     batch(() => {
@@ -99,20 +96,6 @@ class ConfigManager implements IConfigManager {
         lockIntegrationsVersion,
         this.logger,
       );
-
-      if (useServerSideCookies) {
-        state.serverCookies.isEnabledServerSideCookies.value = useServerSideCookies;
-        const dataServiceUrl = getDataServiceUrl(
-          dataServiceEndpoint ?? DEFAULT_DATA_SERVICE_ENDPOINT,
-        );
-        if (isValidURL(dataServiceUrl)) {
-          state.serverCookies.dataServiceUrl.value = removeTrailingSlashes(
-            dataServiceUrl,
-          ) as string;
-        } else {
-          state.serverCookies.isEnabledServerSideCookies.value = false;
-        }
-      }
     });
 
     this.getConfig();

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -41,11 +41,11 @@ const getTopDomainUrl = (url: string) => {
   // Create a URL object
   const urlObj = new URL(url);
 
-  // Extract the hostname and protocol
-  const { hostname, protocol } = urlObj;
+  // Extract the host and protocol
+  const { host, protocol } = urlObj;
 
-  // Split the hostname into parts
-  const parts = hostname.split('.');
+  // Split the host into parts
+  const parts = host.split('.');
   let topDomain;
   // Handle different cases, especially for co.uk or similar TLDs
   if (parts.length > 2) {
@@ -53,7 +53,7 @@ const getTopDomainUrl = (url: string) => {
     topDomain = `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
   } else {
     // If only two parts or less, return as it is
-    topDomain = hostname;
+    topDomain = host;
   }
   return `${protocol}//${topDomain}`;
 };

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -45,7 +45,7 @@ const getTopDomainUrl = (url: string) => {
   const { host, protocol } = urlObj;
 
   // Split the host into parts
-  const parts = host.split('.');
+  const parts: string[] = host.split('.');
   let topDomain;
   // Handle different cases, especially for co.uk or similar TLDs
   if (parts.length > 2) {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -337,6 +337,7 @@ class UserSessionManager implements IUserSessionManager {
           },
         }) as string,
         sendRawData: true,
+        withCredentials: true,
       },
       isRawResponse: true,
       callback,

--- a/packages/analytics-js/src/components/utilities/url.ts
+++ b/packages/analytics-js/src/components/utilities/url.ts
@@ -9,21 +9,21 @@ import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 const removeTrailingSlashes = (url: Nullable<string> | undefined): Nullable<string> | undefined =>
   url?.endsWith('/') ? removeTrailingSlashes(url.substring(0, url.length - 1)) : url;
 
+const getDomain = (url: string): Nullable<string> => {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.host;
+  } catch (error) {
+    return null;
+  }
+};
+
 /**
  * Get the referring domain from the referrer URL
  * @param referrer Page referrer
  * @returns Page referring domain
  */
-const getReferringDomain = (referrer: string): string => {
-  let referringDomain = '';
-  try {
-    const url = new URL(referrer);
-    referringDomain = url.host;
-  } catch (error) {
-    // Do nothing
-  }
-  return referringDomain;
-};
+const getReferringDomain = (referrer: string): string => getDomain(referrer) ?? '';
 
 /**
  * Extracts UTM parameters from the URL
@@ -67,4 +67,10 @@ const getUrlWithoutHash = (url: string): string => {
   return urlWithoutHash;
 };
 
-export { removeTrailingSlashes, getReferringDomain, extractUTMParameters, getUrlWithoutHash };
+export {
+  removeTrailingSlashes,
+  getReferringDomain,
+  extractUTMParameters,
+  getUrlWithoutHash,
+  getDomain,
+};

--- a/packages/analytics-js/src/services/HttpClient/xhr/xhrRequestHandler.ts
+++ b/packages/analytics-js/src/services/HttpClient/xhr/xhrRequestHandler.ts
@@ -116,6 +116,9 @@ const xhrRequest = (
     };
 
     xhr.open(options.method, options.url);
+    if (options.withCredentials === true) {
+      xhr.withCredentials = true;
+    }
     // The timeout property may be set only in the time interval between a call to the open method
     // and the first call to the send method in legacy browsers
     xhr.timeout = timeout;


### PR DESCRIPTION
## PR Description

To handle server-side cookies for cross-domain (sub-domain) sites, additional cookie attributes need to be set.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1942/set-correct-cookie-options-for-cross-domain-cookie-requests

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `withCredentials` option for enhanced security in data requests.
  - Added new utility functions for better URL management and domain extraction.

- **Improvements**
  - Increased size limits for specific modules to accommodate new features.
  - Refactored code for improved modularity and reusability.
  - Enhanced state management based on configuration options.

- **Bug Fixes**
  - Corrected terminology in comments for better clarity in URL validation logic.

- **Tests**
  - Updated tests to include `withCredentials` option validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->