### PR TITLE
fix: sync issues between state and storage for session info

### DIFF
--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -635,9 +635,11 @@ class UserSessionManager implements IUserSessionManager {
     // Always write to state (in-turn to storage) to keep the session info up to date.
     state.session.sessionInfo.value = sessionInfo;
 
-    // Force update the storage as the 'effect' blocks are not getting triggered
-    // when processing preload buffered requests
-    this.syncValueToStorage('sessionInfo', sessionInfo);
+    if (state.lifecycle.status.value !== 'readyExecuted') {
+      // Force update the storage as the 'effect' blocks are not getting triggered
+      // when processing preload buffered requests
+      this.syncValueToStorage('sessionInfo', sessionInfo);
+    }
   }
 
   /**

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -634,6 +634,10 @@ class UserSessionManager implements IUserSessionManager {
 
     // Always write to state (in-turn to storage) to keep the session info up to date.
     state.session.sessionInfo.value = sessionInfo;
+
+    // Force update the storage as the 'effect' blocks are not getting triggered
+    // when processing preload buffered requests
+    this.syncValueToStorage('sessionInfo', sessionInfo);
   }
 
   /**

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -620,17 +620,20 @@ class UserSessionManager implements IUserSessionManager {
       //   Mark it as sessionStart.
       // 2. If sessionStart is true, then need to flip it for the future events.
       if (sessionInfo.sessionStart === undefined) {
-        state.session.sessionInfo.value = {
+        sessionInfo = {
           ...sessionInfo,
           sessionStart: true,
         };
       } else if (sessionInfo.sessionStart) {
-        state.session.sessionInfo.value = {
+        sessionInfo = {
           ...sessionInfo,
           sessionStart: false,
         };
       }
     }
+
+    // Always write to state (in-turn to storage) to keep the session info up to date.
+    state.session.sessionInfo.value = sessionInfo;
   }
 
   /**


### PR DESCRIPTION
## PR Description

It was observed that signal effects were not getting triggered while processing the buffered events, which would require session info to be updated in the storage.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1943/session-info-sync-up-issues-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
