### PR TITLE
fix: add state metadata even for unhandled errors

### DIFF
--- a/packages/analytics-js-plugins/__tests__/bugsnag/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/bugsnag/index.test.ts
@@ -93,31 +93,9 @@ describe('Plugin - Bugsnag', () => {
 
     const mockError = new Error('Test Error');
 
-    Bugsnag().errorReportingProvider.notify(bsClient, mockError, state);
+    Bugsnag().errorReportingProvider.notify(bsClient, mockError);
 
-    expect(bsClient.notify).toHaveBeenCalledWith(mockError, {
-      metaData: {
-        state: {
-          plugins: {
-            loadedPlugins: [],
-          },
-          source: {
-            id: 'test-source-id',
-          },
-          lifecycle: {
-            writeKey: 'dummy-write-key',
-          },
-          context: {
-            app: {
-              name: 'test-app',
-              namespace: 'test-namespace',
-              version: '1.0.0',
-              installType: 'npm',
-            },
-          },
-        },
-      },
-    });
+    expect(bsClient.notify).toHaveBeenCalledWith(mockError);
   });
 
   it('should leave a breadcrumb', () => {

--- a/packages/analytics-js-plugins/src/bugsnag/index.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/index.ts
@@ -8,7 +8,7 @@ import type { PluginName } from '@rudderstack/analytics-js-common/types/PluginsM
 import type { BugsnagLib } from '../types/plugins';
 import { BUGSNAG_API_KEY_VALIDATION_ERROR, BUGSNAG_SDK_URL_ERROR } from './logMessages';
 import { API_KEY } from './constants';
-import { initBugsnagClient, loadBugsnagSDK, isApiKeyValid, getAppStateForMetadata } from './utils';
+import { initBugsnagClient, loadBugsnagSDK, isApiKeyValid } from './utils';
 
 const pluginName: PluginName = 'Bugsnag';
 
@@ -48,7 +48,7 @@ const Bugsnag = (): ExtensionPlugin => ({
       state: ApplicationState,
       logger?: ILogger,
     ): void => {
-      client?.notify(error);
+      client.notify(error);
     },
     breadcrumb: (client: BugsnagLib.Client, message: string, logger?: ILogger): void => {
       client?.leaveBreadcrumb(message);

--- a/packages/analytics-js-plugins/src/bugsnag/index.ts
+++ b/packages/analytics-js-plugins/src/bugsnag/index.ts
@@ -48,11 +48,7 @@ const Bugsnag = (): ExtensionPlugin => ({
       state: ApplicationState,
       logger?: ILogger,
     ): void => {
-      client?.notify(error, {
-        metaData: {
-          state: getAppStateForMetadata(state),
-        },
-      });
+      client?.notify(error);
     },
     breadcrumb: (client: BugsnagLib.Client, message: string, logger?: ILogger): void => {
       client?.leaveBreadcrumb(message);

--- a/packages/analytics-js/__tests__/services/ErrorHandler/ErrorHandler.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/ErrorHandler.test.ts
@@ -39,6 +39,8 @@ jest.mock('../../../src/services/ErrorHandler/processError', () => {
   };
 });
 
+const extSrcLoader = {} as IExternalSrcLoader;
+
 describe('ErrorHandler', () => {
   let errorHandlerInstance: ErrorHandler;
 
@@ -58,13 +60,23 @@ describe('ErrorHandler', () => {
     );
   });
 
-  it('should notifyError if plugin engine is provided', () => {
+  it('should not notify error if error reporting client is not defined', () => {
+    // since we're not initializing the error handler instance,
+    // the error reporting client will not be defined
+    errorHandlerInstance.notifyError(new Error('notify'));
+    expect(defaultPluginEngine.invokeSingle).toHaveBeenCalledTimes(0);
+  });
+
+  it('should notify error if plugin engine is provided', () => {
+    // Hard code the presence of the error reporting client
+    errorHandlerInstance.errReportingClient = {};
+
     errorHandlerInstance.notifyError(new Error('notify'));
     expect(defaultPluginEngine.invokeSingle).toHaveBeenCalledTimes(1);
     expect(defaultPluginEngine.invokeSingle).toHaveBeenCalledWith(
       'errorReporting.notify',
       defaultPluginEngine,
-      undefined,
+      {},
       expect.any(Error),
       state,
       expect.any(Object),
@@ -72,13 +84,16 @@ describe('ErrorHandler', () => {
   });
 
   it('should log error for Errors with context and custom message if logger exists', () => {
+    // Hard code the presence of the error reporting client
+    errorHandlerInstance.errReportingClient = {};
+
     errorHandlerInstance.onError(new Error('dummy error'), 'Unit test', 'dummy  custom  message');
 
     expect(defaultPluginEngine.invokeSingle).toHaveBeenCalledTimes(1);
     expect(defaultPluginEngine.invokeSingle).toHaveBeenCalledWith(
       'errorReporting.notify',
       defaultPluginEngine,
-      undefined,
+      {},
       expect.any(Error),
       state,
       expect.any(Object),
@@ -91,13 +106,16 @@ describe('ErrorHandler', () => {
   });
 
   it('should log error for messages with context and custom message if logger exists', () => {
+    // Hard code the presence of the error reporting client
+    errorHandlerInstance.errReportingClient = {};
+
     errorHandlerInstance.onError('dummy error', 'Unit test', 'dummy custom message');
 
     expect(defaultPluginEngine.invokeSingle).toHaveBeenCalledTimes(1);
     expect(defaultPluginEngine.invokeSingle).toHaveBeenCalledWith(
       'errorReporting.notify',
       defaultPluginEngine,
-      undefined,
+      {},
       expect.any(Error),
       state,
       expect.any(Object),
@@ -110,6 +128,9 @@ describe('ErrorHandler', () => {
   });
 
   it('should log and throw for messages with context and custom message if logger exists and shouldAlwaysThrow', () => {
+    // Hard code the presence of the error reporting client
+    errorHandlerInstance.errReportingClient = {};
+
     try {
       errorHandlerInstance.onError('dummy error', 'Unit test', 'dummy custom message', true);
     } catch (err) {
@@ -117,7 +138,7 @@ describe('ErrorHandler', () => {
       expect(defaultPluginEngine.invokeSingle).toHaveBeenCalledWith(
         'errorReporting.notify',
         defaultPluginEngine,
-        undefined,
+        {},
         expect.any(Error),
         state,
         expect.any(Object),
@@ -161,6 +182,9 @@ describe('ErrorHandler', () => {
   });
 
   it('should log error on notifyError if invoking plugin results in an exception', () => {
+    // Hard code the presence of the error reporting client
+    errorHandlerInstance.errReportingClient = {};
+
     defaultPluginEngine.invokeSingle = jest.fn(() => {
       throw new Error('dummy error');
     });
@@ -192,8 +216,6 @@ describe('ErrorHandler', () => {
   });
 
   describe('init', () => {
-    const extSrcLoader = {} as IExternalSrcLoader;
-
     it('reporting client should not be defined if the plugin engine is not supplied', () => {
       errorHandlerInstance = new ErrorHandler(defaultLogger);
       errorHandlerInstance.init(extSrcLoader);

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -181,9 +181,9 @@ class ErrorHandler implements IErrorHandler {
    * @param {Error} error Error instance from handled error
    */
   notifyError(error: Error) {
-    if (this.pluginEngine && isAllowedToBeNotified(error)) {
+    if (this.errReportingClient && isAllowedToBeNotified(error)) {
       try {
-        this.pluginEngine.invokeSingle(
+        this.pluginEngine?.invokeSingle(
           'errorReporting.notify',
           this.pluginEngine,
           this.errReportingClient,


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified the error notification process in the Bugsnag plugin, enhancing its efficiency.
  - Improved error handling logic in the ErrorHandler component to ensure proper error notifications and logging.

- **Refactor**
  - Updated test setup to include state object for better context management during error handling tests.
  - Adjusted method signatures and control flow within error handling processes to improve clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->