### PR TITLE
fix: remove pollyfill url from command bar destination

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/CommandBar/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/CommandBar/nativeSdkLoader.js
@@ -73,13 +73,7 @@ function loadNativeSdk(orgId) {
         r(''.concat(f, '/latest/').concat(o, '?').concat(s.join('&')), !0);
     }
   }
-  void 0 === Object.assign || 'undefined' == typeof Symbol || void 0 === Symbol.for
-    ? ((a.__CommandBarBootstrap__ = t),
-      r(
-        'https://polyfill.io/v3/polyfill.min.js?version=3.101.0&callback=__CommandBarBootstrap__&features=' +
-          n,
-      ))
-    : t();
+  t();
 }
 
 export { loadNativeSdk };


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
