### PR TITLE
fix: loading snippet to unmangle reserved variables

### DIFF
--- a/packages/loading-scripts/rollup.config.mjs
+++ b/packages/loading-scripts/rollup.config.mjs
@@ -57,34 +57,41 @@ export function getDefaultConfig(distName) {
       }),
       terser({
         safari10: true,
-        ecma: 2015,
+        ecma: 5,
         keep_fnames: true,
         format: {
-          beautify: !shouldUglify,
           comments: false,
           braces: true,
-          indent_level: 2,
           max_line_len: 120,
+          width: 100,
+          ecma: 5,
+          safari10: true,
+          webkit: true,
         },
         compress: shouldUglify ? {
           evaluate: false,
           join_vars: false,
           toplevel: true,
+          dead_code: false,
+          unused: false,
           top_retain: [
             'sdkBaseUrl',
             'sdkName',
-            'asyncScript',
-            'loadOptions'
+            'loadOptions',
+            'scriptLoadingMode',
+            'rudderanalytics'
           ],
           booleans: false
         } : false,
         mangle: shouldUglify ? {
           eval: false,
+          keep_fnames: true,
           reserved: [
             'sdkBaseUrl',
             'sdkName',
-            'asyncScript',
-            'loadOptions'
+            'loadOptions',
+            'scriptLoadingMode',
+            'rudderanalytics'
           ],
           toplevel: true,
           safari10: true,

--- a/packages/loading-scripts/rollup.config.mjs
+++ b/packages/loading-scripts/rollup.config.mjs
@@ -60,10 +60,11 @@ export function getDefaultConfig(distName) {
         ecma: 5,
         keep_fnames: true,
         format: {
+          beautify: !shouldUglify,
           comments: false,
           braces: true,
+          indent_level: 2,
           max_line_len: 120,
-          width: 100,
           ecma: 5,
           safari10: true,
           webkit: true,


### PR DESCRIPTION
## PR Description

Update the loading script's rollup config to unmangle some reserved variables.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-2072/update-sdk-loading-snippets-to-unmangle-some-reserved-variables)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated terser configuration to improve compatibility and optimize performance. This includes changes to ECMAScript version, formatting, and compression settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->