### PR TITLE
feat: update itp implementation based on load options

### DIFF
--- a/packages/analytics-js-common/__tests__/utilities/string.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/string.test.ts
@@ -4,6 +4,7 @@ import {
   tryStringify,
   toBase64,
   fromBase64,
+  removeLeadingDot,
 } from '../../src/utilities/string';
 
 describe('Common Utils - String', () => {
@@ -99,6 +100,14 @@ describe('Common Utils - String', () => {
 
     it('should convert base64 with emoji to string', () => {
       expect(fromBase64('8J+Riw==')).toBe('👋');
+    });
+  });
+
+  describe('removeLeadingDot', () => {
+    it('should remove leading dot from the string if any', () => {
+      expect(removeLeadingDot('.sample')).toBe('sample');
+      expect(removeLeadingDot('sample')).toBe('sample');
+      expect(removeLeadingDot('sample.com')).toBe('sample.com');
     });
   });
 });

--- a/packages/analytics-js-common/__tests__/utilities/string.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/string.test.ts
@@ -4,7 +4,7 @@ import {
   tryStringify,
   toBase64,
   fromBase64,
-  removeLeadingDot,
+  removeLeadingPeriod,
 } from '../../src/utilities/string';
 
 describe('Common Utils - String', () => {
@@ -103,11 +103,13 @@ describe('Common Utils - String', () => {
     });
   });
 
-  describe('removeLeadingDot', () => {
+  describe('removeLeadingPeriod', () => {
     it('should remove leading dot from the string if any', () => {
-      expect(removeLeadingDot('.sample')).toBe('sample');
-      expect(removeLeadingDot('sample')).toBe('sample');
-      expect(removeLeadingDot('sample.com')).toBe('sample.com');
+      expect(removeLeadingPeriod('.sample')).toBe('sample');
+      expect(removeLeadingPeriod('sample.')).toBe('sample.');
+      expect(removeLeadingPeriod('..sample')).toBe('sample');
+      expect(removeLeadingPeriod('sample')).toBe('sample');
+      expect(removeLeadingPeriod('sample.com')).toBe('sample.com');
     });
   });
 });

--- a/packages/analytics-js-common/src/utilities/string.ts
+++ b/packages/analytics-js-common/src/utilities/string.ts
@@ -6,7 +6,7 @@ const trim = (value: string): string => value.replace(/^\s+|\s+$/gm, '');
 
 const removeDoubleSpaces = (value: string): string => value.replace(/ {2,}/g, ' ');
 
-const removeLeadingDot = (value: string): string => value.replace(/^\./, '');
+const removeLeadingPeriod = (value: string): string => value.replace(/^\.+/, '');
 
 /**
  * A function to convert values to string
@@ -63,4 +63,4 @@ const toBase64 = (value: string): string => bytesToBase64(new TextEncoder().enco
  */
 const fromBase64 = (value: string): string => new TextDecoder().decode(base64ToBytes(value));
 
-export { trim, removeDoubleSpaces, tryStringify, toBase64, fromBase64, removeLeadingDot };
+export { trim, removeDoubleSpaces, tryStringify, toBase64, fromBase64, removeLeadingPeriod };

--- a/packages/analytics-js-common/src/utilities/string.ts
+++ b/packages/analytics-js-common/src/utilities/string.ts
@@ -6,6 +6,8 @@ const trim = (value: string): string => value.replace(/^\s+|\s+$/gm, '');
 
 const removeDoubleSpaces = (value: string): string => value.replace(/ {2,}/g, ' ');
 
+const removeLeadingDot = (value: string): string => value.replace(/^\./, '');
+
 /**
  * A function to convert values to string
  * @param val input value
@@ -61,4 +63,4 @@ const toBase64 = (value: string): string => bytesToBase64(new TextEncoder().enco
  */
 const fromBase64 = (value: string): string => new TextDecoder().decode(base64ToBytes(value));
 
-export { trim, removeDoubleSpaces, tryStringify, toBase64, fromBase64 };
+export { trim, removeDoubleSpaces, tryStringify, toBase64, fromBase64, removeLeadingDot };

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../src/components/configManager/util/commonUtil';
 import {
   getDataServiceUrl,
-  isTopLevelDomain,
+  isWebpageTopLevelDomain,
 } from '../../../src/components/configManager/util/validate';
 import { state, resetState } from '../../../src/state';
 
@@ -37,16 +37,16 @@ describe('Config Manager Common Utilities', () => {
   } as unknown as ILogger;
 
   let originalGetDataServiceUrl: (endpoint: string, useExactDomain: boolean) => string;
-  let originalIsTopLevelDomain: (domain: string) => boolean;
+  let isWebpageTopLevelDomainOriginal: (domain: string) => boolean;
 
   beforeAll(() => {
     // Save the original implementation
     originalGetDataServiceUrl = jest.requireActual(
       '../../../src/components/configManager/util/validate',
     ).getDataServiceUrl;
-    originalIsTopLevelDomain = jest.requireActual(
+    isWebpageTopLevelDomainOriginal = jest.requireActual(
       '../../../src/components/configManager/util/validate',
-    ).isTopLevelDomain;
+    ).isWebpageTopLevelDomain;
   });
 
   beforeEach(() => {
@@ -314,7 +314,7 @@ describe('Config Manager Common Utilities', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.setCookieDomain = 'test-host.com';
 
-      (isTopLevelDomain as jest.Mock).mockImplementation(originalIsTopLevelDomain);
+      (isWebpageTopLevelDomain as jest.Mock).mockImplementation(isWebpageTopLevelDomainOriginal);
       (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
       updateStorageStateFromLoadOptions(mockLogger);
 
@@ -326,7 +326,7 @@ describe('Config Manager Common Utilities', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.setCookieDomain = 'random-host.com';
 
-      (isTopLevelDomain as jest.Mock).mockImplementation(originalIsTopLevelDomain);
+      (isWebpageTopLevelDomain as jest.Mock).mockImplementation(isWebpageTopLevelDomainOriginal);
       (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
       updateStorageStateFromLoadOptions(mockLogger);
 

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -9,7 +9,10 @@ import {
   updateDataPlaneEventsStateFromLoadOptions,
   getSourceConfigURL,
 } from '../../../src/components/configManager/util/commonUtil';
+import { getDataServiceUrl } from '../../../src/components/configManager/util/validate';
 import { state, resetState } from '../../../src/state';
+
+jest.mock('../../../src/components/configManager/util/validate');
 
 const createScriptElement = (url: string) => {
   const script = document.createElement('script');
@@ -30,8 +33,18 @@ describe('Config Manager Common Utilities', () => {
     error: jest.fn(),
   } as unknown as ILogger;
 
+  let originalGetDataServiceUrl: (endpoint: string, useExactDomain: boolean) => string;
+
+  beforeAll(() => {
+    // Save the original implementation
+    originalGetDataServiceUrl = jest.requireActual(
+      '../../../src/components/configManager/util/validate',
+    ).getDataServiceUrl;
+  });
+
   beforeEach(() => {
     resetState();
+    (getDataServiceUrl as jest.Mock).mockRestore();
   });
 
   describe('getSDKUrl', () => {
@@ -233,6 +246,65 @@ describe('Config Manager Common Utilities', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'ConfigManager:: The storage data migration has been disabled because the configured storage encryption version (legacy) is not the latest (v3). To enable storage data migration, please update the storage encryption version to the latest version.',
       );
+    });
+    it('should not change the value of isEnabledServerSideCookies if the useServerSideCookies is set to false', () => {
+      state.loadOptions.value.useServerSideCookies = false;
+      state.loadOptions.value.storage = {
+        cookie: {
+          samesite: 'secure',
+        },
+      };
+
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+      expect(state.storage.cookie.value).toEqual({
+        samesite: 'secure',
+      });
+    });
+    it('should set the value of isEnabledServerSideCookies to false if the useServerSideCookies is set to true but the dataServiceUrl is not valid url', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      (getDataServiceUrl as jest.Mock).mockImplementation(() => 'invalid-url');
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+    });
+    it('should set the value of isEnabledServerSideCookies to true if the useServerSideCookies is set to true and the dataServiceUrl is a valid url', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      (getDataServiceUrl as jest.Mock).mockImplementation(() => 'https://www.dummy.url');
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
+      expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.dummy.url');
+    });
+    it('should determine the dataServiceUrl from the exact domain if sameDomainCookiesOnly load option is set to true', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.sameDomainCookiesOnly = true;
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
+      expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.test-host.com/rsaRequest');
+    });
+    it('should determine the dataServiceUrl from the exact domain if setCookieDomain load option is provided', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.setCookieDomain = 'www.test-host.com';
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
+      expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.test-host.com/rsaRequest');
+    });
+    it('should set isEnabledServerSideCookies to false if provided setCookieDomain load option is different from current domain', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.setCookieDomain = 'test-host.com';
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
     });
   });
 

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -247,6 +247,7 @@ describe('Config Manager Common Utilities', () => {
         'ConfigManager:: The storage data migration has been disabled because the configured storage encryption version (legacy) is not the latest (v3). To enable storage data migration, please update the storage encryption version to the latest version.',
       );
     });
+
     it('should not change the value of isEnabledServerSideCookies if the useServerSideCookies is set to false', () => {
       state.loadOptions.value.useServerSideCookies = false;
       state.loadOptions.value.storage = {
@@ -262,6 +263,7 @@ describe('Config Manager Common Utilities', () => {
         samesite: 'secure',
       });
     });
+
     it('should set the value of isEnabledServerSideCookies to false if the useServerSideCookies is set to true but the dataServiceUrl is not valid url', () => {
       state.loadOptions.value.useServerSideCookies = true;
       (getDataServiceUrl as jest.Mock).mockImplementation(() => 'invalid-url');
@@ -269,6 +271,7 @@ describe('Config Manager Common Utilities', () => {
 
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
     });
+
     it('should set the value of isEnabledServerSideCookies to true if the useServerSideCookies is set to true and the dataServiceUrl is a valid url', () => {
       state.loadOptions.value.useServerSideCookies = true;
       (getDataServiceUrl as jest.Mock).mockImplementation(() => 'https://www.dummy.url');
@@ -277,6 +280,7 @@ describe('Config Manager Common Utilities', () => {
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
       expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.dummy.url');
     });
+
     it('should determine the dataServiceUrl from the exact domain if sameDomainCookiesOnly load option is set to true', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.sameDomainCookiesOnly = true;
@@ -287,6 +291,7 @@ describe('Config Manager Common Utilities', () => {
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
       expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.test-host.com/rsaRequest');
     });
+
     it('should determine the dataServiceUrl from the exact domain if setCookieDomain load option is provided', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.setCookieDomain = 'www.test-host.com';
@@ -297,7 +302,8 @@ describe('Config Manager Common Utilities', () => {
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
       expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.test-host.com/rsaRequest');
     });
-    it('should set isEnabledServerSideCookies to false if provided setCookieDomain load option is different from current domain', () => {
+
+    it('should set isEnabledServerSideCookies to false if provided setCookieDomain load option is different from current domain and sameDomainCookiesOnly option is not set', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.setCookieDomain = 'test-host.com';
 
@@ -305,6 +311,19 @@ describe('Config Manager Common Utilities', () => {
       updateStorageStateFromLoadOptions(mockLogger);
 
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'ConfigManager:: The server side cookie setting feature has been disabled because provided cookie domain (test-host.com) is not matching with current domain (www.test-host.com).',
+      );
+    });
+    it('should set isEnabledServerSideCookies to true if provided setCookieDomain load option is different from current domain and sameDomainCookiesOnly option is set', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.setCookieDomain = 'test-host.com';
+      state.loadOptions.value.sameDomainCookiesOnly = true;
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
     });
   });
 

--- a/packages/analytics-js/__tests__/components/configManager/validate.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/validate.test.ts
@@ -2,6 +2,7 @@ import {
   validateLoadArgs,
   getTopDomainUrl,
   getDataServiceUrl,
+  isTopLevelDomain,
 } from '../../../src/components/configManager/util/validate';
 
 describe('Config manager util - validate load arguments', () => {
@@ -56,6 +57,17 @@ describe('Config manager util - validate load arguments', () => {
     it('should return dataServiceUrl with exact domain', () => {
       const dataServiceUrl = getDataServiceUrl('endpoint', true);
       expect(dataServiceUrl).toBe('https://www.test-host.com/endpoint');
+    });
+  });
+
+  describe('isTopLevelDomain', () => {
+    it('should return true for top level domain', () => {
+      const isTopLevel = isTopLevelDomain('test-host.com');
+      expect(isTopLevel).toBe(true);
+    });
+    it('should return false for subdomain', () => {
+      const isTopLevel = isTopLevelDomain('sub.test-host.com');
+      expect(isTopLevel).toBe(false);
     });
   });
 });

--- a/packages/analytics-js/__tests__/components/configManager/validate.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/validate.test.ts
@@ -2,7 +2,7 @@ import {
   validateLoadArgs,
   getTopDomainUrl,
   getDataServiceUrl,
-  isTopLevelDomain,
+  isWebpageTopLevelDomain,
 } from '../../../src/components/configManager/util/validate';
 
 describe('Config manager util - validate load arguments', () => {
@@ -60,13 +60,13 @@ describe('Config manager util - validate load arguments', () => {
     });
   });
 
-  describe('isTopLevelDomain', () => {
+  describe('isWebpageTopLevelDomain', () => {
     it('should return true for top level domain', () => {
-      const isTopLevel = isTopLevelDomain('test-host.com');
+      const isTopLevel = isWebpageTopLevelDomain('test-host.com');
       expect(isTopLevel).toBe(true);
     });
     it('should return false for subdomain', () => {
-      const isTopLevel = isTopLevelDomain('sub.test-host.com');
+      const isTopLevel = isWebpageTopLevelDomain('sub.test-host.com');
       expect(isTopLevel).toBe(false);
     });
   });

--- a/packages/analytics-js/__tests__/components/configManager/validate.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/validate.test.ts
@@ -46,12 +46,16 @@ describe('Config manager util - validate load arguments', () => {
   });
   describe('getDataServiceUrl', () => {
     it('should return dataServiceUrl', () => {
-      const dataServiceUrl = getDataServiceUrl('endpoint');
+      const dataServiceUrl = getDataServiceUrl('endpoint', false);
       expect(dataServiceUrl).toBe('https://test-host.com/endpoint');
     });
     it('should prepare the dataServiceUrl with endpoint without leading slash', () => {
-      const dataServiceUrl = getDataServiceUrl('/endpoint');
+      const dataServiceUrl = getDataServiceUrl('/endpoint', false);
       expect(dataServiceUrl).toBe('https://test-host.com/endpoint');
+    });
+    it('should return dataServiceUrl with exact domain', () => {
+      const dataServiceUrl = getDataServiceUrl('endpoint', true);
+      expect(dataServiceUrl).toBe('https://www.test-host.com/endpoint');
     });
   });
 });

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -49,7 +49,7 @@ import {
   ErrorReportingProvidersToPluginNameMap,
   StorageEncryptionVersionsToPluginNameMap,
 } from '../constants';
-import { getDataServiceUrl, isValidStorageType, isTopLevelDomain } from './validate';
+import { getDataServiceUrl, isValidStorageType, isWebpageTopLevelDomain } from './validate';
 import { getConsentManagementData } from '../../utilities/consent';
 
 /**
@@ -172,7 +172,7 @@ const updateStorageStateFromLoadOptions = (logger?: ILogger): void => {
        */
       const useExactDomain =
         (isDefined(providedCookieDomain) &&
-          !isTopLevelDomain(removeLeadingPeriod(providedCookieDomain as string))) ||
+          !isWebpageTopLevelDomain(removeLeadingPeriod(providedCookieDomain as string))) ||
         sameDomainCookiesOnly;
 
       const dataServiceUrl = getDataServiceUrl(

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -191,8 +191,6 @@ const updateStorageStateFromLoadOptions = (logger?: ILogger): void => {
             secure: true,
           };
         }
-        console.log('dataServiceHost', dataServiceHost);
-        console.log('setCookieDomain', setCookieDomain);
         if (
           isDefined(setCookieDomain) &&
           dataServiceHost !== removeLeadingDot(setCookieDomain as string)

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -164,7 +164,7 @@ const updateStorageStateFromLoadOptions = (logger?: ILogger): void => {
     if (useServerSideCookies) {
       state.serverCookies.isEnabledServerSideCookies.value = useServerSideCookies;
       let dataServiceUrl;
-      if (isDefined(setCookieDomain || sameDomainCookiesOnly)) {
+      if (isDefined(setCookieDomain) || sameDomainCookiesOnly) {
         dataServiceUrl = getDataServiceUrl(
           dataServiceEndpoint ?? DEFAULT_DATA_SERVICE_ENDPOINT,
           true,

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -37,7 +37,7 @@ const isValidSourceConfig = (res: any): boolean =>
 const isValidStorageType = (storageType?: StorageType): boolean =>
   typeof storageType === 'string' && SUPPORTED_STORAGE_TYPES.includes(storageType);
 
-const getTopDomainUrl = (url: string) => {
+const getTopDomain = (url: string) => {
   // Create a URL object
   const urlObj = new URL(url);
 
@@ -55,6 +55,11 @@ const getTopDomainUrl = (url: string) => {
     // If only two parts or less, return as it is
     topDomain = host;
   }
+  return { topDomain, protocol };
+};
+
+const getTopDomainUrl = (url: string) => {
+  const { topDomain, protocol } = getTopDomain(url);
   return `${protocol}//${topDomain}`;
 };
 
@@ -62,6 +67,11 @@ const getDataServiceUrl = (endpoint: string, useExactDomain: boolean) => {
   const url = useExactDomain ? window.location.origin : getTopDomainUrl(window.location.href);
   const formattedEndpoint = endpoint.startsWith('/') ? endpoint.substring(1) : endpoint;
   return `${url}/${formattedEndpoint}`;
+};
+
+const isTopLevelDomain = (providedDomain: string): boolean => {
+  const { topDomain } = getTopDomain(window.location.href);
+  return topDomain === providedDomain;
 };
 
 export {
@@ -72,4 +82,5 @@ export {
   validateDataPlaneUrl,
   getTopDomainUrl,
   getDataServiceUrl,
+  isTopLevelDomain,
 };

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -69,7 +69,7 @@ const getDataServiceUrl = (endpoint: string, useExactDomain: boolean) => {
   return `${url}/${formattedEndpoint}`;
 };
 
-const isTopLevelDomain = (providedDomain: string): boolean => {
+const isWebpageTopLevelDomain = (providedDomain: string): boolean => {
   const { topDomain } = getTopDomain(window.location.href);
   return topDomain === providedDomain;
 };
@@ -82,5 +82,5 @@ export {
   validateDataPlaneUrl,
   getTopDomainUrl,
   getDataServiceUrl,
-  isTopLevelDomain,
+  isWebpageTopLevelDomain,
 };

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -58,8 +58,8 @@ const getTopDomainUrl = (url: string) => {
   return `${protocol}//${topDomain}`;
 };
 
-const getDataServiceUrl = (endpoint: string) => {
-  const url = getTopDomainUrl(window.location.href);
+const getDataServiceUrl = (endpoint: string, useExactDomain: boolean) => {
+  const url = useExactDomain ? window.location.origin : getTopDomainUrl(window.location.href);
   const formattedEndpoint = endpoint.startsWith('/') ? endpoint.substring(1) : endpoint;
   return `${url}/${formattedEndpoint}`;
 };

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -142,7 +142,7 @@ const SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING = (
   providedCookieDomain: string | undefined,
   currentCookieDomain: string,
 ): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}The server side cookie setting feature has been disabled because provided cookie domain (${providedCookieDomain}) is not matching with current domain (${currentCookieDomain}).`;
+  `${context}${LOG_CONTEXT_SEPARATOR}The provided cookie domain (${providedCookieDomain}) does not match the current webpage's domain (${currentCookieDomain}). Hence, the cookies will be set client-side.`;
 
 const RESERVED_KEYWORD_WARNING = (
   context: string,

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -137,6 +137,13 @@ const STORAGE_DATA_MIGRATION_OVERRIDE_WARNING = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The storage data migration has been disabled because the configured storage encryption version (${storageEncryptionVersion}) is not the latest (${defaultVersion}). To enable storage data migration, please update the storage encryption version to the latest version.`;
 
+const SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING = (
+  context: string,
+  providedCookieDomain: string | undefined,
+  currentCookieDomain: string,
+): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The server side cookie setting feature has been disabled because provided cookie domain (${providedCookieDomain}) is not matching with current domain (${currentCookieDomain}).`;
+
 const RESERVED_KEYWORD_WARNING = (
   context: string,
   property: string,
@@ -308,4 +315,5 @@ export {
   INVALID_POLYFILL_URL_WARNING,
   SOURCE_DISABLED_ERROR,
   COMPONENT_BASE_URL_ERROR,
+  SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
 };


### PR DESCRIPTION
## PR Description

- If the `setCookieDomain` load option is provided, SDK will use the exact domain for making requests to the server. 
  - If the provided domain differs from the current domain, setting cookies from the server side feature will be disabled.
- if the `sameDomainCookiesOnly` load option is provided, SDK will use the exact domain for making requests to the server. No domain value will be sent in the request.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-2076/update-itp-request-url-and-cookie-options-based-on-load-options)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new function to handle removal of leading periods from strings.
	- Introduced new validation and utility functions for improved domain handling.

- **Bug Fixes**
	- Enhanced server-side cookie handling with additional domain validation and warnings.

- **Tests**
	- Added comprehensive test cases for new utility and validation functions.
	- Updated existing tests to reflect changes in function parameters and logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->