### PR TITLE
chore: fix correct changelog generation for dependencies

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -78,6 +78,7 @@ jobs:
         id: finish-release
         env:
           HUSKY: 0
+          BASE_BRANCH: ${{ steps.create-release.outputs.branch_name }}
         run: |
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build:v1.1": "nx run-many -t build --projects=rudder-sdk-js",
     "build:sanity": "rm -rf packages/sanity-suite/dist && nx run-many --targets=build:all --projects=@rudderstack/analytics-js-sanity-suite",
     "bump-version:monorepo": "npm version minor --git-tag-version false",
-    "release": "nx affected --base=origin/main --target=version --parallel=1 --skipCommitTypes=docs,ci,chore,test",
+    "release": "nx affected --base=origin/main --target=version --parallel=1 --skipCommitTypes=docs,ci,chore,test --baseBranch=$BASE_BRANCH",
     "release:nx": "nx release --skip-publish --verbose --dry-run",
     "release:github": "nx affected --target=github --parallel=1 --skipCommitTypes=docs,ci,chore,test",
     "deploy:npm": "nx affected --target=deploy --parallel=1 --skipCommitTypes=docs,ci,chore,test"

--- a/packages/analytics-js-common/project.json
+++ b/packages/analytics-js-common/project.json
@@ -43,11 +43,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     },
     "github": {

--- a/packages/analytics-js-cookies/project.json
+++ b/packages/analytics-js-cookies/project.json
@@ -43,11 +43,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     },
     "github": {

--- a/packages/analytics-js-integrations/project.json
+++ b/packages/analytics-js-integrations/project.json
@@ -43,11 +43,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     },
     "github": {

--- a/packages/analytics-js-plugins/project.json
+++ b/packages/analytics-js-plugins/project.json
@@ -43,11 +43,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     },
     "github": {

--- a/packages/analytics-js-service-worker/project.json
+++ b/packages/analytics-js-service-worker/project.json
@@ -43,11 +43,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     },
     "github": {

--- a/packages/analytics-js/project.json
+++ b/packages/analytics-js/project.json
@@ -51,11 +51,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     },
     "github": {

--- a/packages/analytics-v1.1/project.json
+++ b/packages/analytics-v1.1/project.json
@@ -51,11 +51,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     },
     "github": {

--- a/packages/loading-scripts/project.json
+++ b/packages/loading-scripts/project.json
@@ -43,11 +43,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     },
     "github": {

--- a/packages/sanity-suite/project.json
+++ b/packages/sanity-suite/project.json
@@ -43,11 +43,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "baseBranch": "main",
         "preset": "conventionalcommits",
         "tagPrefix": "{projectName}@",
-        "trackDeps": true,
-        "push": true
+        "trackDeps": true
       }
     }
   }

--- a/patches/@jscutlery+semver+5.2.2.patch
+++ b/patches/@jscutlery+semver+5.2.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@jscutlery/semver/src/executors/version/utils/try-bump.js b/node_modules/@jscutlery/semver/src/executors/version/utils/try-bump.js
+index 13c94d0..f616b64 100644
+--- a/node_modules/@jscutlery/semver/src/executors/version/utils/try-bump.js
++++ b/node_modules/@jscutlery/semver/src/executors/version/utils/try-bump.js
+@@ -167,7 +167,7 @@ function _getDependencyVersions({ commitParserOptions, preset, dependencyRoots,
+     return (0, rxjs_1.forkJoin)(dependencyRoots.map(({ path: projectRoot, name: dependencyName }) => {
+         /* Get dependency version changes since last project version */
+         const tagPrefix = (0, tag_1.formatTagPrefix)({
+-            versionTagPrefix,
++            versionTagPrefix: `{projectName}@`,
+             projectName: dependencyName,
+             syncVersions,
+         });


### PR DESCRIPTION
## PR Description

I patched `@jscutlery/semver` package to correctly generate the changelog for dependencies. There is no need for the `push` option as the target can pick up the locally generated tags.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2227/fix-changelog-generation-during-release

## Cross Browser Tests

N/A

## Sanity Suite

N/A

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable for better handling of release branches in the workflow.
	- Enhanced version tagging with project name inclusion for improved clarity and specificity.

- **Bug Fixes**
	- Resolved inconsistencies in version tag formatting to ensure accurate version representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->