### PR TITLE
chore: fix globalThis polyfill in loading snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,37 +49,7 @@ The JavaScript SDK lets you track customer event data from your website and send
 
 ### Using CDN
 
-To integrate the JavaScript SDK with your website, place the following code snippet in the `<head>` section of your website.
-
-```javascript
-<script type="text/javascript">
-  !function(){"use strict";window.RudderSnippetVersion="3.0.10";var e="rudderanalytics";window[e]||(window[e]=[])
-  ;var t=window[e];if(Array.isArray(t)){if(true===t.snippetExecuted&&window.console&&console.error){
-  console.error("RudderStack JavaScript SDK snippet included more than once.")}else{t.snippetExecuted=true,
-  window.rudderAnalyticsBuildType="legacy";var sdkBaseUrl="https://cdn.rudderlabs.com/v3";var sdkName="rsa.min.js"
-  ;var r="async"
-  ;var n=["setDefaultInstanceKey","load","ready","page","track","identify","alias","group","reset","setAnonymousId","startSession","endSession","consent"]
-  ;for(var i=0;i<n.length;i++){var d=n[i];t[d]=function(r){return function(){var n
-  ;Array.isArray(window[e])?t.push([r].concat(Array.prototype.slice.call(arguments))):null===(n=window[e][r])||void 0===n||n.apply(window[e],arguments)
-  }}(d)}try{new Function('return import("")'),window.rudderAnalyticsBuildType="modern"}catch(c){}
-  var o=document.head||document.getElementsByTagName("head")[0]
-  ;var a=document.body||document.getElementsByTagName("body")[0];window.rudderAnalyticsAddScript=function(e,t,n){
-  var i=document.createElement("script");i.src=e,i.setAttribute("data-loader","RS_JS_SDK"),t&&n&&i.setAttribute(t,n),
-  "async"===r?i.async=true:"defer"===r&&(i.defer=true),o?o.insertBefore(i,o.firstChild):a.insertBefore(i,a.firstChild)},
-  window.rudderAnalyticsMount=function(){
-  "undefined"==typeof globalThis&&(Object.defineProperty(Object.prototype,"__globalThis_magic__",{get:function get(){
-  return this},configurable:true}),__globalThis_magic__.globalThis=__globalThis_magic__,
-  delete Object.prototype.__globalThis_magic__),
-  window.rudderAnalyticsAddScript("".concat(sdkBaseUrl,"/").concat(window.rudderAnalyticsBuildType,"/").concat(sdkName),"data-rsa-write-key",<WRITE_KEY>)
-  },
-  "undefined"==typeof Promise||"undefined"==typeof globalThis?window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount"):window.rudderAnalyticsMount()
-  ;t.load(<WRITE_KEY>,<DATA_PLANE_URL>,{})}}}();
-</script>
-```
-
-<br>
-
-> The above snippet lets you integrate the SDK with your website and load it asynchronously to avoid impacting the performance of your webpages.
+See [CDN installation](https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/quickstart/#using-cdn) for detailed steps.
 
 To load SDK script on to your page synchronously, see the [**JavaScript SDK documentation**](https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/installation/#synchronous-loading).
 

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -59,16 +59,28 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function() {
+                    if (typeof self !== "undefined") { 
+                      return self; 
+                    }
+                    if (typeof window !== "undefined") { 
+                      return window; 
+                    }
+                    return null;
+                  };
+                  
+                  var global = getGlobal();
+                  
+                  if (global) {
+                    Object.defineProperty(global, 'globalThis', {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
 
               // Commented out SDK script addition
               // as the build process automatically adds the script

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -61,7 +61,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
+                  let getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -71,7 +71,7 @@
                     return null;
                   };
                   
-                  var global = getGlobal();
+                  let global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/loading-scripts/src/index.ts
+++ b/packages/loading-scripts/src/index.ts
@@ -101,7 +101,7 @@ if (Array.isArray(rudderanalytics)) {
       // globalThis polyfill as polyfill-fastly.io one does not work in legacy safari
       (function () {
         if (typeof globalThis === 'undefined') {
-          var getGlobal = function () {
+          let getGlobal = function () {
             if (typeof self !== 'undefined') {
               return self;
             }
@@ -111,7 +111,7 @@ if (Array.isArray(rudderanalytics)) {
             return null;
           };
 
-          var global = getGlobal();
+          let global = getGlobal();
 
           if (global) {
             Object.defineProperty(global, 'globalThis', {

--- a/packages/loading-scripts/src/index.ts
+++ b/packages/loading-scripts/src/index.ts
@@ -99,18 +99,28 @@ if (Array.isArray(rudderanalytics)) {
     window.rudderAnalyticsMount = () => {
       /* eslint-disable */
       // globalThis polyfill as polyfill-fastly.io one does not work in legacy safari
-      if (typeof globalThis === 'undefined') {
-        Object.defineProperty(Object.prototype, '__globalThis_magic__', {
-          get: function get() {
-            return this;
-          },
-          configurable: true,
-        });
-        // @ts-ignore
-        __globalThis_magic__.globalThis = __globalThis_magic__;
-        // @ts-ignore
-        delete Object.prototype.__globalThis_magic__;
-      }
+      (function () {
+        if (typeof globalThis === 'undefined') {
+          var getGlobal = function () {
+            if (typeof self !== 'undefined') {
+              return self;
+            }
+            if (typeof window !== 'undefined') {
+              return window;
+            }
+            return null;
+          };
+
+          var global = getGlobal();
+
+          if (global) {
+            Object.defineProperty(global, 'globalThis', {
+              value: global,
+              configurable: true,
+            });
+          }
+        }
+      })();
       /* eslint-enable */
 
       window.rudderAnalyticsAddScript(

--- a/packages/sanity-suite/public/v3/index-cdn.html
+++ b/packages/sanity-suite/public/v3/index-cdn.html
@@ -81,16 +81,28 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function() {
+                    if (typeof self !== "undefined") { 
+                      return self; 
+                    }
+                    if (typeof window !== "undefined") { 
+                      return window; 
+                    }
+                    return null;
+                  };
+                  
+                  var global = getGlobal();
+                  
+                  if (global) {
+                    Object.defineProperty(global, 'globalThis', {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/packages/sanity-suite/public/v3/index-cdn.html
+++ b/packages/sanity-suite/public/v3/index-cdn.html
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
+                  let getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  var global = getGlobal();
+                  let global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/index-local.html
+++ b/packages/sanity-suite/public/v3/index-local.html
@@ -81,16 +81,28 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function() {
+                    if (typeof self !== "undefined") { 
+                      return self; 
+                    }
+                    if (typeof window !== "undefined") { 
+                      return window; 
+                    }
+                    return null;
+                  };
+                  
+                  var global = getGlobal();
+                  
+                  if (global) {
+                    Object.defineProperty(global, 'globalThis', {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/packages/sanity-suite/public/v3/index-local.html
+++ b/packages/sanity-suite/public/v3/index-local.html
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
+                  let getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  var global = getGlobal();
+                  let global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/index-npm-bundled.html
@@ -95,16 +95,28 @@
       src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise%2CglobalThis"
     ></script>
     <script>
-      if (typeof globalThis === 'undefined') {
-        Object.defineProperty(Object.prototype, '__globalThis_magic__', {
-          get: function get() {
-            return this;
-          },
-          configurable: true
-        });
-        __globalThis_magic__.globalThis = __globalThis_magic__;
-        delete Object.prototype.__globalThis_magic__;
-      }
+      (function() {
+        if (typeof globalThis === "undefined") {
+          var getGlobal = function() {
+            if (typeof self !== "undefined") { 
+              return self; 
+            }
+            if (typeof window !== "undefined") { 
+              return window; 
+            }
+            return null;
+          };
+          
+          var global = getGlobal();
+          
+          if (global) {
+            Object.defineProperty(global, 'globalThis', {
+              value: global,
+              configurable: true
+            });
+          }
+        }
+      })();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/index-npm-bundled.html
@@ -97,7 +97,7 @@
     <script>
       (function() {
         if (typeof globalThis === "undefined") {
-          var getGlobal = function() {
+          let getGlobal = function() {
             if (typeof self !== "undefined") { 
               return self; 
             }
@@ -107,7 +107,7 @@
             return null;
           };
           
-          var global = getGlobal();
+          let global = getGlobal();
           
           if (global) {
             Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/index-npm.html
+++ b/packages/sanity-suite/public/v3/index-npm.html
@@ -95,16 +95,28 @@
       src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise%2CglobalThis"
     ></script>
     <script>
-      if (typeof globalThis === 'undefined') {
-        Object.defineProperty(Object.prototype, '__globalThis_magic__', {
-          get: function get() {
-            return this;
-          },
-          configurable: true
-        });
-        __globalThis_magic__.globalThis = __globalThis_magic__;
-        delete Object.prototype.__globalThis_magic__;
-      }
+      (function() {
+        if (typeof globalThis === "undefined") {
+          var getGlobal = function() {
+            if (typeof self !== "undefined") { 
+              return self; 
+            }
+            if (typeof window !== "undefined") { 
+              return window; 
+            }
+            return null;
+          };
+          
+          var global = getGlobal();
+          
+          if (global) {
+            Object.defineProperty(global, 'globalThis', {
+              value: global,
+              configurable: true
+            });
+          }
+        }
+      })();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/index-npm.html
+++ b/packages/sanity-suite/public/v3/index-npm.html
@@ -97,7 +97,7 @@
     <script>
       (function() {
         if (typeof globalThis === "undefined") {
-          var getGlobal = function() {
+          let getGlobal = function() {
             if (typeof self !== "undefined") { 
               return self; 
             }
@@ -107,7 +107,7 @@
             return null;
           };
           
-          var global = getGlobal();
+          let global = getGlobal();
           
           if (global) {
             Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v3/integrations/index-cdn.html
@@ -81,16 +81,28 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function() {
+                    if (typeof self !== "undefined") { 
+                      return self; 
+                    }
+                    if (typeof window !== "undefined") { 
+                      return window; 
+                    }
+                    return null;
+                  };
+                  
+                  var global = getGlobal();
+                  
+                  if (global) {
+                    Object.defineProperty(global, 'globalThis', {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/packages/sanity-suite/public/v3/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v3/integrations/index-cdn.html
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
+                  let getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  var global = getGlobal();
+                  let global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/integrations/index-local.html
+++ b/packages/sanity-suite/public/v3/integrations/index-local.html
@@ -81,16 +81,28 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function() {
+                    if (typeof self !== "undefined") { 
+                      return self; 
+                    }
+                    if (typeof window !== "undefined") { 
+                      return window; 
+                    }
+                    return null;
+                  };
+                  
+                  var global = getGlobal();
+                  
+                  if (global) {
+                    Object.defineProperty(global, 'globalThis', {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/packages/sanity-suite/public/v3/integrations/index-local.html
+++ b/packages/sanity-suite/public/v3/integrations/index-local.html
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
+                  let getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  var global = getGlobal();
+                  let global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
@@ -83,7 +83,7 @@
     <script>
       (function() {
         if (typeof globalThis === "undefined") {
-          var getGlobal = function() {
+          let getGlobal = function() {
             if (typeof self !== "undefined") { 
               return self; 
             }
@@ -93,7 +93,7 @@
             return null;
           };
           
-          var global = getGlobal();
+          let global = getGlobal();
           
           if (global) {
             Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
@@ -81,16 +81,28 @@
       src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise%2CglobalThis"
     ></script>
     <script>
-      if (typeof globalThis === 'undefined') {
-        Object.defineProperty(Object.prototype, '__globalThis_magic__', {
-          get: function get() {
-            return this;
-          },
-          configurable: true
-        });
-        __globalThis_magic__.globalThis = __globalThis_magic__;
-        delete Object.prototype.__globalThis_magic__;
-      }
+      (function() {
+        if (typeof globalThis === "undefined") {
+          var getGlobal = function() {
+            if (typeof self !== "undefined") { 
+              return self; 
+            }
+            if (typeof window !== "undefined") { 
+              return window; 
+            }
+            return null;
+          };
+          
+          var global = getGlobal();
+          
+          if (global) {
+            Object.defineProperty(global, 'globalThis', {
+              value: global,
+              configurable: true
+            });
+          }
+        }
+      })();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm.html
@@ -83,7 +83,7 @@
     <script>
       (function() {
         if (typeof globalThis === "undefined") {
-          var getGlobal = function() {
+          let getGlobal = function() {
             if (typeof self !== "undefined") { 
               return self; 
             }
@@ -93,7 +93,7 @@
             return null;
           };
           
-          var global = getGlobal();
+          let global = getGlobal();
           
           if (global) {
             Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm.html
@@ -81,16 +81,28 @@
       src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise%2CglobalThis"
     ></script>
     <script>
-      if (typeof globalThis === 'undefined') {
-        Object.defineProperty(Object.prototype, '__globalThis_magic__', {
-          get: function get() {
-            return this;
-          },
-          configurable: true
-        });
-        __globalThis_magic__.globalThis = __globalThis_magic__;
-        delete Object.prototype.__globalThis_magic__;
-      }
+      (function() {
+        if (typeof globalThis === "undefined") {
+          var getGlobal = function() {
+            if (typeof self !== "undefined") { 
+              return self; 
+            }
+            if (typeof window !== "undefined") { 
+              return window; 
+            }
+            return null;
+          };
+          
+          var global = getGlobal();
+          
+          if (global) {
+            Object.defineProperty(global, 'globalThis', {
+              value: global,
+              configurable: true
+            });
+          }
+        }
+      })();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -81,16 +81,28 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function() {
+                    if (typeof self !== "undefined") { 
+                      return self; 
+                    }
+                    if (typeof window !== "undefined") { 
+                      return window; 
+                    }
+                    return null;
+                  };
+                  
+                  var global = getGlobal();
+                  
+                  if (global) {
+                    Object.defineProperty(global, 'globalThis', {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
+                  let getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  var global = getGlobal();
+                  let global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
@@ -81,16 +81,28 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function() {
+                    if (typeof self !== "undefined") { 
+                      return self; 
+                    }
+                    if (typeof window !== "undefined") { 
+                      return window; 
+                    }
+                    return null;
+                  };
+                  
+                  var global = getGlobal();
+                  
+                  if (global) {
+                    Object.defineProperty(global, 'globalThis', {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
+                  let getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  var global = getGlobal();
+                  let global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
@@ -83,7 +83,7 @@
     <script>
       (function() {
         if (typeof globalThis === "undefined") {
-          var getGlobal = function() {
+          let getGlobal = function() {
             if (typeof self !== "undefined") { 
               return self; 
             }
@@ -93,7 +93,7 @@
             return null;
           };
           
-          var global = getGlobal();
+          let global = getGlobal();
           
           if (global) {
             Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
@@ -81,16 +81,28 @@
       src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise%2CglobalThis"
     ></script>
     <script>
-      if (typeof globalThis === 'undefined') {
-        Object.defineProperty(Object.prototype, '__globalThis_magic__', {
-          get: function get() {
-            return this;
-          },
-          configurable: true
-        });
-        __globalThis_magic__.globalThis = __globalThis_magic__;
-        delete Object.prototype.__globalThis_magic__;
-      }
+      (function() {
+        if (typeof globalThis === "undefined") {
+          var getGlobal = function() {
+            if (typeof self !== "undefined") { 
+              return self; 
+            }
+            if (typeof window !== "undefined") { 
+              return window; 
+            }
+            return null;
+          };
+          
+          var global = getGlobal();
+          
+          if (global) {
+            Object.defineProperty(global, 'globalThis', {
+              value: global,
+              configurable: true
+            });
+          }
+        }
+      })();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
@@ -83,7 +83,7 @@
     <script>
       (function() {
         if (typeof globalThis === "undefined") {
-          var getGlobal = function() {
+          let getGlobal = function() {
             if (typeof self !== "undefined") { 
               return self; 
             }
@@ -93,7 +93,7 @@
             return null;
           };
           
-          var global = getGlobal();
+          let global = getGlobal();
           
           if (global) {
             Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
@@ -81,16 +81,28 @@
       src="https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise%2CglobalThis"
     ></script>
     <script>
-      if (typeof globalThis === 'undefined') {
-        Object.defineProperty(Object.prototype, '__globalThis_magic__', {
-          get: function get() {
-            return this;
-          },
-          configurable: true
-        });
-        __globalThis_magic__.globalThis = __globalThis_magic__;
-        delete Object.prototype.__globalThis_magic__;
-      }
+      (function() {
+        if (typeof globalThis === "undefined") {
+          var getGlobal = function() {
+            if (typeof self !== "undefined") { 
+              return self; 
+            }
+            if (typeof window !== "undefined") { 
+              return window; 
+            }
+            return null;
+          };
+          
+          var global = getGlobal();
+          
+          if (global) {
+            Object.defineProperty(global, 'globalThis', {
+              value: global,
+              configurable: true
+            });
+          }
+        }
+      })();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
     <style>


### PR DESCRIPTION
## PR Description

Fixed the custom `globalThis` polyfill in the loading snippet.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2239/update-globalthis-polyfill-for-safari-browsers

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Safari
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Streamlined integration instructions in the README by removing lengthy code snippets and providing a concise reference to the official documentation for the JavaScript SDK.

- **New Features**
  - Enhanced the logic for defining `globalThis` across various JavaScript files, ensuring safer, more robust global context assignments without modifying `Object.prototype`. This improves compatibility and reduces potential side effects.

These changes collectively enhance user experience by providing clearer documentation and a more reliable integration method for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->