### PR TITLE
fix: upgrade axios to a safe version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@segment/top-domain": "3.0.1",
         "@vespaiach/axios-fetch-adapter": "0.3.1",
         "assert": "2.1.0",
-        "axios": "1.7.2",
+        "axios": "1.7.4",
         "axios-retry": "4.4.0",
         "component-each": "0.2.6",
         "component-emitter": "2.0.0",
@@ -7535,9 +7535,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -24306,7 +24306,7 @@
         "@rudderstack/analytics-js-common": "*",
         "@vespaiach/axios-fetch-adapter": "0.3.1",
         "assert": "2.1.0",
-        "axios": "1.7.2",
+        "axios": "1.7.4",
         "axios-retry": "4.4.0",
         "component-type": "2.0.0",
         "join-component": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@segment/top-domain": "3.0.1",
     "@vespaiach/axios-fetch-adapter": "0.3.1",
     "assert": "2.1.0",
-    "axios": "1.7.2",
+    "axios": "1.7.4",
     "axios-retry": "4.4.0",
     "component-each": "0.2.6",
     "component-emitter": "2.0.0",

--- a/packages/analytics-js-service-worker/package.json
+++ b/packages/analytics-js-service-worker/package.json
@@ -93,7 +93,7 @@
     "@rudderstack/analytics-js-common": "*",
     "@vespaiach/axios-fetch-adapter": "0.3.1",
     "assert": "2.1.0",
-    "axios": "1.7.2",
+    "axios": "1.7.4",
     "axios-retry": "4.4.0",
     "component-type": "2.0.0",
     "join-component": "1.1.0",


### PR DESCRIPTION
## PR Description

Upgrade axios to `1.7.4` which is free from vulnerabilities.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-2251/upgrade-axios-package-to-safe-version-service-worker-sdk)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
