### PR TITLE
fix: explicitly set XHR to async mode

### DIFF
--- a/packages/analytics-js/src/services/HttpClient/xhr/xhrRequestHandler.ts
+++ b/packages/analytics-js/src/services/HttpClient/xhr/xhrRequestHandler.ts
@@ -115,7 +115,7 @@ const xhrRequest = (
       }
     };
 
-    xhr.open(options.method, options.url);
+    xhr.open(options.method, options.url, true);
     if (options.withCredentials === true) {
       xhr.withCredentials = true;
     }


### PR DESCRIPTION

## PR Description

Some sites (Shopify) monkey patch a default synchronous XHR which causes RudderStack SDK to crash because it's providing a `timeout` expecting XHR to default to async mode.

![](https://c.r8x.net/a24a3f50a66b6f4a.png)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced application responsiveness by implementing asynchronous HTTP requests, preventing UI freezing during data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->