### PR TITLE
fix: gracefully handle cross sdk version cookies and warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "check:support": "NODE_ENV=production npx browserslist --mobile-to-desktop",
     "check:support:modern": "NODE_ENV=modern npx browserslist --mobile-to-desktop",
     "check:duplicates": "nx run-many -t check:duplicates --verbose",
-    "check:security": "npm audit --recursive --audit-level=high",
+    "check:security": "npm audit --recursive --audit-level=high --omit=dev",
     "check:pub": "nx run-many -t check:pub --verbose",
     "check:pub:ci": "nx affected -t check:pub --verbose --base=$BASE_REF",
     "format": "prettier --write .",

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -7,7 +7,7 @@ export default [
     name: 'Core - Legacy - NPM (ESM)',
     path: 'dist/npm/legacy/esm/index.mjs',
     import: '*',
-    limit: '47.5 KiB',
+    limit: '48 KiB',
   },
   {
     name: 'Core - Legacy - NPM (CJS)',
@@ -19,7 +19,7 @@ export default [
     name: 'Core - Legacy - NPM (UMD)',
     path: 'dist/npm/legacy/umd/index.js',
     import: '*',
-    limit: '47.5 KiB',
+    limit: '48 KiB',
   },
   {
     name: 'Core - Legacy - CDN',
@@ -53,7 +53,7 @@ export default [
     name: 'Core (Bundled) - Legacy - NPM (ESM)',
     path: 'dist/npm/legacy/bundled/esm/index.mjs',
     import: '*',
-    limit: '47.5 KiB',
+    limit: '48 KiB',
   },
   {
     name: 'Core (Bundled) - Legacy - NPM (CJS)',
@@ -65,7 +65,7 @@ export default [
     name: 'Core (Bundled) - Legacy - NPM (UMD)',
     path: 'dist/npm/legacy/bundled/umd/index.js',
     import: '*',
-    limit: '47.5 KiB',
+    limit: '48 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (ESM)',
@@ -89,7 +89,7 @@ export default [
     name: 'Core (Content Script) - Legacy - NPM (ESM)',
     path: 'dist/npm/legacy/content-script/esm/index.mjs',
     import: '*',
-    limit: '47 KiB',
+    limit: '48 KiB',
   },
   {
     name: 'Core (Content Script) - Legacy - NPM (CJS)',
@@ -101,7 +101,7 @@ export default [
     name: 'Core (Content Script) - Legacy - NPM (UMD)',
     path: 'dist/npm/legacy/content-script/umd/index.js',
     import: '*',
-    limit: '47 KiB',
+    limit: '47.5 KiB',
   },
   {
     name: 'Core (Content Script) - Modern - NPM (ESM)',

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -254,7 +254,8 @@ const INVALID_POLYFILL_URL_WARNING = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The provided polyfill URL "${customPolyfillUrl}" is invalid. The default polyfill URL will be used instead.`;
 
-// DEBUG
+const BAD_COOKIES_WARNING = (key: string) =>
+  `The cookie data for ${key} seems to be encrypted using SDK versions < v3. The data is dropped. This can potentially stem from using SDK versions < v3 on other sites or web pages that can share cookies with this webpage. We recommend using the same SDK (v3) version everywhere or avoid disabling the storage data migration.`;
 
 export {
   UNSUPPORTED_CONSENT_MANAGER_ERROR,
@@ -319,4 +320,5 @@ export {
   SOURCE_DISABLED_ERROR,
   COMPONENT_BASE_URL_ERROR,
   SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
+  BAD_COOKIES_WARNING,
 };

--- a/packages/analytics-js/src/services/StoreManager/Store.ts
+++ b/packages/analytics-js/src/services/StoreManager/Store.ts
@@ -1,5 +1,5 @@
 import { trim } from '@rudderstack/analytics-js-common/utilities/string';
-import { isNullOrUndefined } from '@rudderstack/analytics-js-common/utilities/checks';
+import { isNullOrUndefined, isString } from '@rudderstack/analytics-js-common/utilities/checks';
 import { stringifyWithoutCircular } from '@rudderstack/analytics-js-common/utilities/json';
 import type { IStorage, IStore, IStoreConfig } from '@rudderstack/analytics-js-common/types/Store';
 import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/ErrorHandler';
@@ -12,6 +12,7 @@ import { defaultLogger } from '../Logger';
 import { defaultErrorHandler } from '../ErrorHandler';
 import { isStorageQuotaExceeded } from '../../components/capabilitiesManager/detection';
 import {
+  BAD_COOKIES_WARNING,
   STORAGE_QUOTA_EXCEEDED_WARNING,
   STORE_DATA_FETCH_ERROR,
   STORE_DATA_SAVE_ERROR,
@@ -128,22 +129,29 @@ class Store implements IStore {
    */
   get<T = any>(key: string): Nullable<T> {
     const validKey = this.createValidKey(key);
+    let decryptedValue;
 
     try {
       if (!validKey) {
         return null;
       }
 
-      const str = this.decrypt(this.engine.getItem(validKey));
+      decryptedValue = this.decrypt(this.engine.getItem(validKey));
 
-      if (isNullOrUndefined(str)) {
+      if (isNullOrUndefined(decryptedValue)) {
         return null;
       }
 
       // storejs that is used in localstorage engine already deserializes json strings but swallows errors
-      return JSON.parse(str as string);
+      return JSON.parse(decryptedValue as string);
     } catch (err) {
       this.onError(new Error(`${STORE_DATA_FETCH_ERROR(key)}: ${(err as Error).message}`));
+
+      // A hack for warning the users of potential partial SDK version migrations
+      if (isString(decryptedValue) && decryptedValue.startsWith('RudderEncrypt:')) {
+        this.logger?.warn(BAD_COOKIES_WARNING(key));
+      }
+
       return null;
     }
   }

--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -123,13 +123,33 @@ class Analytics {
     this.userId = this.storage.getUserId() || '';
     this.storage.setUserId(this.userId);
 
-    this.userTraits = this.storage.getUserTraits() || {};
+    this.userTraits = {};
+    const storedUserTraits = this.storage.getUserTraits();
+    // Ensure that stored user traits is an object indeed
+    if (
+      storedUserTraits !== null &&
+      typeof storedUserTraits === 'object' &&
+      !Array.isArray(storedUserTraits)
+    ) {
+      this.userTraits = storedUserTraits;
+    }
+
     this.storage.setUserTraits(this.userTraits);
 
     this.groupId = this.storage.getGroupId() || '';
     this.storage.setGroupId(this.groupId);
 
-    this.groupTraits = this.storage.getGroupTraits() || {};
+    this.groupTraits = {};
+    const storedGroupTraits = this.storage.getGroupTraits();
+    // Ensure that stored group traits is an object indeed
+    if (
+      storedGroupTraits !== null &&
+      typeof storedGroupTraits === 'object' &&
+      !Array.isArray(storedGroupTraits)
+    ) {
+      this.groupTraits = storedGroupTraits;
+    }
+
     this.storage.setGroupTraits(this.groupTraits);
 
     this.anonymousId = this.getAnonymousId(anonymousIdOptions);


### PR DESCRIPTION
## PR Description

v3:
- Warned users of potential instrumentation of SDK version < v3 in other sites or web pages that share the cookies. This can happen when users explicitly disable migration via the `load` API option or skip the `StorageMigrator` plugin or both. Storage data migration is already enabled by default.

v1.1:
- Attempted to even decrypt v3 SDK encrypted cookies.
- Attempted to even decrypt cookies again if the underlying value is an "SDK v3 encrypted cookie value" which was again encrypted by the v1.1 SDK.
  - Also, warned the users of potential instrumentation issues.
- Warned the users in case cookie values could not be decrypted and parsed. Calls for complete SDK migration.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2357/drop-undecrypted-cookie-values-in-v11-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
