### PR TITLE
fix: sdk loading snippet and sanity suite

### DIFF
--- a/examples/angular/sample-app/src/index.html
+++ b/examples/angular/sample-app/src/index.html
@@ -9,7 +9,7 @@
   <script>
     (function() {
       "use strict";
-      window.RudderSnippetVersion = "3.0.10";
+      window.RudderSnippetVersion = "3.0.29";
       var identifier = "rudderanalytics";
       if (!window[identifier]) {
         window[identifier] = [];

--- a/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/public/index.html
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/public/index.html
@@ -26,24 +26,26 @@
     -->
     <title>React App</title>
     <script type="text/javascript">
-      !function(){"use strict";window.RudderSnippetVersion="3.0.10";var e="rudderanalytics";window[e]||(window[e]=[])
-      ;var t=window[e];if(Array.isArray(t)){if(true===t.snippetExecuted&&window.console&&console.error){
-      console.error("RudderStack JavaScript SDK snippet included more than once.")}else{t.snippetExecuted=true,
+      !function(){"use strict";window.RudderSnippetVersion="3.0.29";var e="rudderanalytics";window[e]||(window[e]=[])
+      ;var rudderanalytics=window[e];if(Array.isArray(rudderanalytics)){
+      if(true===rudderanalytics.snippetExecuted&&window.console&&console.error){
+      console.error("RudderStack JavaScript SDK snippet included more than once.")}else{rudderanalytics.snippetExecuted=true,
       window.rudderAnalyticsBuildType="legacy";var sdkBaseUrl="https://cdn.rudderlabs.com/v3";var sdkName="rsa.min.js"
-      ;var r="async"
-      ;var n=["setDefaultInstanceKey","load","ready","page","track","identify","alias","group","reset","setAnonymousId","startSession","endSession","consent"]
-      ;for(var i=0;i<n.length;i++){var d=n[i];t[d]=function(r){return function(){var n
-      ;Array.isArray(window[e])?t.push([r].concat(Array.prototype.slice.call(arguments))):null===(n=window[e][r])||void 0===n||n.apply(window[e],arguments)
-      }}(d)}try{new Function('return import("")'),window.rudderAnalyticsBuildType="modern"}catch(c){}
-      var o=document.head||document.getElementsByTagName("head")[0]
-      ;var a=document.body||document.getElementsByTagName("body")[0];window.rudderAnalyticsAddScript=function(e,t,n){
-      var i=document.createElement("script");i.src=e,i.setAttribute("data-loader","RS_JS_SDK"),t&&n&&i.setAttribute(t,n),
-      "async"===r?i.async=true:"defer"===r&&(i.defer=true),o?o.insertBefore(i,o.firstChild):a.insertBefore(i,a.firstChild)},
-      window.rudderAnalyticsMount=function(){
-      "undefined"==typeof globalThis&&(Object.defineProperty(Object.prototype,"__globalThis_magic__",{get:function get(){
-      return this},configurable:true}),__globalThis_magic__.globalThis=__globalThis_magic__,
-      delete Object.prototype.__globalThis_magic__),
-      window.rudderAnalyticsAddScript("".concat(sdkBaseUrl,"/").concat(window.rudderAnalyticsBuildType,"/").concat(sdkName),"data-rsa-write-key","dummyWriteKey")
+      ;var scriptLoadingMode="async"
+      ;var r=["setDefaultInstanceKey","load","ready","page","track","identify","alias","group","reset","setAnonymousId","startSession","endSession","consent"]
+      ;for(var n=0;n<r.length;n++){var t=r[n];rudderanalytics[t]=function(r){return function(){var n
+      ;Array.isArray(window[e])?rudderanalytics.push([r].concat(Array.prototype.slice.call(arguments))):null===(n=window[e][r])||void 0===n||n.apply(window[e],arguments)
+      }}(t)}try{
+      new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}'),
+      window.rudderAnalyticsBuildType="modern"}catch(o){}var d=document.head||document.getElementsByTagName("head")[0]
+      ;var i=document.body||document.getElementsByTagName("body")[0];window.rudderAnalyticsAddScript=function(e,r,n){
+      var t=document.createElement("script");t.src=e,t.setAttribute("data-loader","RS_JS_SDK"),r&&n&&t.setAttribute(r,n),
+      "async"===scriptLoadingMode?t.async=true:"defer"===scriptLoadingMode&&(t.defer=true),
+      d?d.insertBefore(t,d.firstChild):i.insertBefore(t,i.firstChild)},window.rudderAnalyticsMount=function(){!function(){
+      if("undefined"==typeof globalThis){var e;var r=function getGlobal(){
+      return"undefined"!=typeof self?self:"undefined"!=typeof window?window:null}();r&&Object.defineProperty(r,"globalThis",{
+      value:r,configurable:true})}
+      }(),window.rudderAnalyticsAddScript("".concat(sdkBaseUrl,"/").concat(window.rudderAnalyticsBuildType,"/").concat(sdkName),"data-rsa-write-key","dummyWriteKey")
       },
       "undefined"==typeof Promise||"undefined"==typeof globalThis?window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount"):window.rudderAnalyticsMount()
       ;}}}();

--- a/examples/nextjs/hooks/sample-app/src/app/layout.tsx
+++ b/examples/nextjs/hooks/sample-app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.10";
+              window.RudderSnippetVersion = "3.0.29";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];

--- a/examples/nextjs/js/sample-app/src/app/layout.js
+++ b/examples/nextjs/js/sample-app/src/app/layout.js
@@ -17,7 +17,7 @@ export default function RootLayout({ children }) {
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.10";
+              window.RudderSnippetVersion = "3.0.29";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];

--- a/examples/nextjs/page-router/sample-app/src/pages/_document.tsx
+++ b/examples/nextjs/page-router/sample-app/src/pages/_document.tsx
@@ -9,7 +9,7 @@ export default function Document() {
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.10";
+              window.RudderSnippetVersion = "3.0.29";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];

--- a/examples/nextjs/ts/sample-app/src/app/layout.tsx
+++ b/examples/nextjs/ts/sample-app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.10";
+              window.RudderSnippetVersion = "3.0.29";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];

--- a/examples/reactjs/hooks/sample-app/public/index.html
+++ b/examples/reactjs/hooks/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/reactjs/js/sample-app/public/index.html
+++ b/examples/reactjs/js/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/reactjs/ts/sample-app/public/index.html
+++ b/examples/reactjs/ts/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/reactjs/vite/sample-app/index.html
+++ b/examples/reactjs/vite/sample-app/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/v3-beacon/index.html
+++ b/examples/v3-beacon/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -22,8 +22,7 @@
             window.rudderAnalyticsBuildType = "legacy";
             var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
             var sdkName = "rsa.min.js";
-            var asyncScript = true;
-            var deferScript = false;
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -39,7 +38,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -51,9 +50,9 @@
               if (extraAttributeKey && extraAttributeVal) {
                 scriptTag.setAttribute(extraAttributeKey, extraAttributeVal);
               }
-              if (asyncScript) {
+              if (scriptLoadingMode === "async") {
                 scriptTag.async = true;
-              } else if (deferScript) {
+              } else if (scriptLoadingMode === "defer") {
                 scriptTag.defer = true;
               }
               if (head) {
@@ -63,16 +62,26 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
+                    }
+                    if (typeof window !== "undefined") {
+                      return window;
+                    }
+                    return null;
+                  };
+                  var global = getGlobal();
+                  if (global) {
+                    Object.defineProperty(global, "globalThis", {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/examples/v3-legacy-minimum-plugins/index.html
+++ b/examples/v3-legacy-minimum-plugins/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -22,8 +22,7 @@
             window.rudderAnalyticsBuildType = "legacy";
             var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
             var sdkName = "rsa.min.js";
-            var asyncScript = true;
-            var deferScript = false;
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -39,7 +38,7 @@
               }(method);
             }
             // try {
-            //   new Function('return import("")');
+            //   new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
             //   window.rudderAnalyticsBuildType = "modern";
             // } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -51,9 +50,9 @@
               if (extraAttributeKey && extraAttributeVal) {
                 scriptTag.setAttribute(extraAttributeKey, extraAttributeVal);
               }
-              if (asyncScript) {
+              if (scriptLoadingMode === "async") {
                 scriptTag.async = true;
-              } else if (deferScript) {
+              } else if (scriptLoadingMode === "defer") {
                 scriptTag.defer = true;
               }
               if (head) {
@@ -63,16 +62,26 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
+                    }
+                    if (typeof window !== "undefined") {
+                      return window;
+                    }
+                    return null;
+                  };
+                  var global = getGlobal();
+                  if (global) {
+                    Object.defineProperty(global, "globalThis", {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/examples/v3-legacy/index.html
+++ b/examples/v3-legacy/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -22,8 +22,7 @@
             window.rudderAnalyticsBuildType = "legacy";
             var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
             var sdkName = "rsa.min.js";
-            var asyncScript = true;
-            var deferScript = false;
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -39,7 +38,7 @@
               }(method);
             }
             // try {
-            //   new Function('return import("")');
+            //   new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
             //   window.rudderAnalyticsBuildType = "modern";
             // } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -51,9 +50,9 @@
               if (extraAttributeKey && extraAttributeVal) {
                 scriptTag.setAttribute(extraAttributeKey, extraAttributeVal);
               }
-              if (asyncScript) {
+              if (scriptLoadingMode === "async") {
                 scriptTag.async = true;
-              } else if (deferScript) {
+              } else if (scriptLoadingMode === "defer") {
                 scriptTag.defer = true;
               }
               if (head) {
@@ -63,16 +62,26 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
+                    }
+                    if (typeof window !== "undefined") {
+                      return window;
+                    }
+                    return null;
+                  };
+                  var global = getGlobal();
+                  if (global) {
+                    Object.defineProperty(global, "globalThis", {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/examples/v3-minimum-plugins/index.html
+++ b/examples/v3-minimum-plugins/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -22,8 +22,7 @@
             window.rudderAnalyticsBuildType = "legacy";
             var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
             var sdkName = "rsa.min.js";
-            var asyncScript = true;
-            var deferScript = false;
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -39,7 +38,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -51,9 +50,9 @@
               if (extraAttributeKey && extraAttributeVal) {
                 scriptTag.setAttribute(extraAttributeKey, extraAttributeVal);
               }
-              if (asyncScript) {
+              if (scriptLoadingMode === "async") {
                 scriptTag.async = true;
-              } else if (deferScript) {
+              } else if (scriptLoadingMode === "defer") {
                 scriptTag.defer = true;
               }
               if (head) {
@@ -63,16 +62,26 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
+                    }
+                    if (typeof window !== "undefined") {
+                      return window;
+                    }
+                    return null;
+                  };
+                  var global = getGlobal();
+                  if (global) {
+                    Object.defineProperty(global, "globalThis", {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/examples/v3/index.html
+++ b/examples/v3/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -22,8 +22,7 @@
             window.rudderAnalyticsBuildType = "legacy";
             var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
             var sdkName = "rsa.min.js";
-            var asyncScript = true;
-            var deferScript = false;
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -39,7 +38,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -51,9 +50,9 @@
               if (extraAttributeKey && extraAttributeVal) {
                 scriptTag.setAttribute(extraAttributeKey, extraAttributeVal);
               }
-              if (asyncScript) {
+              if (scriptLoadingMode === "async") {
                 scriptTag.async = true;
-              } else if (deferScript) {
+              } else if (scriptLoadingMode === "defer") {
                 scriptTag.defer = true;
               }
               if (head) {
@@ -63,16 +62,26 @@
               }
             };
             window.rudderAnalyticsMount = function() {
-              if (typeof globalThis === "undefined") {
-                Object.defineProperty(Object.prototype, "__globalThis_magic__", {
-                  get: function get() {
-                    return this;
-                  },
-                  configurable: true
-                });
-                __globalThis_magic__.globalThis = __globalThis_magic__;
-                delete Object.prototype.__globalThis_magic__;
-              }
+              (function() {
+                if (typeof globalThis === "undefined") {
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
+                    }
+                    if (typeof window !== "undefined") {
+                      return window;
+                    }
+                    return null;
+                  };
+                  var global = getGlobal();
+                  if (global) {
+                    Object.defineProperty(global, "globalThis", {
+                      value: global,
+                      configurable: true
+                    });
+                  }
+                }
+              })();
               window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {

--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -141,22 +141,11 @@
   "devDependencies": {},
   "browserslist": {
     "production": [
-      "defaults",
-      "Edge >= 80",
-      "Firefox >= 47",
-      "IE >= 11",
-      "Chrome >= 54",
-      "Safari >= 7",
-      "Opera >= 43"
+      "> 0.1%",
+      "IE >= 11"
     ],
     "modern": [
-      "defaults and supports es6-module-dynamic-import"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 edge version",
-      "last 1 safari version"
+      "defaults and supports es6-module-dynamic-import and not dead"
     ]
   },
   "dependencies": {

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -5,7 +5,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -35,7 +35,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -61,7 +61,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  let getGlobal = function() {
+                  var getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -71,7 +71,7 @@
                     return null;
                   };
                   
-                  let global = getGlobal();
+                  var global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/loading-scripts/src/index.ts
+++ b/packages/loading-scripts/src/index.ts
@@ -57,10 +57,12 @@ if (Array.isArray(rudderanalytics)) {
         })(method);
     }
 
-    // Feature detection of dynamic imports
+    // Feature detection of dynamic imports and other legacy browser features
     try {
       // eslint-disable-next-line no-new, @typescript-eslint/no-implied-eval
-      new Function('return import("")');
+      new Function(
+        'class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}',
+      );
       window.rudderAnalyticsBuildType = 'modern';
     } catch (e) {
       // Do nothing
@@ -101,7 +103,7 @@ if (Array.isArray(rudderanalytics)) {
       // globalThis polyfill as polyfill-fastly.io one does not work in legacy safari
       (function () {
         if (typeof globalThis === 'undefined') {
-          let getGlobal = function () {
+          const getGlobal = function () {
             if (typeof self !== 'undefined') {
               return self;
             }
@@ -111,7 +113,7 @@ if (Array.isArray(rudderanalytics)) {
             return null;
           };
 
-          let global = getGlobal();
+          const global = getGlobal();
 
           if (global) {
             Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/index-cdn.html
+++ b/packages/sanity-suite/public/v3/index-cdn.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -57,9 +57,10 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
-            } catch (e) {}
+            } catch (e) {
+            }
             var head = document.head || document.getElementsByTagName("head")[0];
             var body = document.body || document.getElementsByTagName("body")[0];
             window.rudderAnalyticsAddScript = function(url, extraAttributeKey, extraAttributeVal) {
@@ -83,7 +84,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  let getGlobal = function() {
+                  var getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +94,7 @@
                     return null;
                   };
                   
-                  let global = getGlobal();
+                  var global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/index-local.html
+++ b/packages/sanity-suite/public/v3/index-local.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -57,7 +57,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  let getGlobal = function() {
+                  var getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  let global = getGlobal();
+                  var global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/index-npm-bundled.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/index-npm.html
+++ b/packages/sanity-suite/public/v3/index-npm.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v3/integrations/index-cdn.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -57,7 +57,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  let getGlobal = function() {
+                  var getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  let global = getGlobal();
+                  var global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/integrations/index-local.html
+++ b/packages/sanity-suite/public/v3/integrations/index-local.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -57,7 +57,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  let getGlobal = function() {
+                  var getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  let global = getGlobal();
+                  var global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -57,7 +57,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  let getGlobal = function() {
+                  var getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  let global = getGlobal();
+                  var global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -57,7 +57,7 @@
               }(method);
             }
             try {
-              new Function('return import("")');
+              new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
             } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
@@ -83,7 +83,7 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  let getGlobal = function() {
+                  var getGlobal = function() {
                     if (typeof self !== "undefined") { 
                       return self; 
                     }
@@ -93,7 +93,7 @@
                     return null;
                   };
                   
-                  let global = getGlobal();
+                  var global = getGlobal();
                   
                   if (global) {
                     Object.defineProperty(global, 'globalThis', {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
@@ -27,7 +27,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.10";
+        window.RudderSnippetVersion = "3.0.29";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/src/ignoredProperties/ignoredProperties.js
+++ b/packages/sanity-suite/src/ignoredProperties/ignoredProperties.js
@@ -158,6 +158,7 @@ const ignoredProperties = [
   {
     key: `message.integrations.Google Analytics 4 (GA4).sessionNumber`,
     type: 'number',
+    optional: true,
   },
   {
     key: `source.liveEventsConfig.eventUploadTS`,


### PR DESCRIPTION
## PR Description

- SDK loading snippet has a check to decide whether to load a modern or legacy bundle. That check is not strengthened to also include other syntaxes that some legacy browsers support.
  - This includes `?.`, `??`, default function parameters, etc.
  - The checking code is optimized to make use of all the features at once.
- Moreover, the browserslist configuration for `production` (legacy) is updated to drop support for a lot of legacy browsers that do not have any significant market share. The updated configuration gives us a good amount of market share.
  - Visit https://browsersl.ist/ to find out the exact list of browsers we support now.
  - Accordingly, the webdriverIO browser configurations have been updated. https://github.com/rudderlabs/rudder-client-side-test/pull/287

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2261/e2e-test-suite-runs-for-hours-on-some-mobile-browsers-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
