### PR TITLE
fix: auto session tracking

### DIFF
--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -203,6 +203,45 @@ describe('User session manager', () => {
       userSessionManager.syncStorageDataToState();
       expect(state.session.anonymousId.value).toBe('dummy-anonymousId');
     });
+    it('should not set sessionInfo if autoTrack is set to false in loadOption and sessionInfo exists in storage', () => {
+      const customData = {
+        rl_session: {
+          id: 1726655503445,
+          expiresAt: Date.now() + 60 * 1000,
+          timeout: 60000,
+          autoTrack: true,
+          sessionStart: false,
+        },
+      };
+      setDataInCookieStorage(customData);
+      state.loadOptions.value.sessions.autoTrack = false;
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.syncStorageDataToState();
+      expect(state.session.sessionInfo.value).toStrictEqual({});
+    });
+    it('should set sessionInfo if autoTrack is set to false in loadOption and sessionInfo exists in storage with manualTrack enabled', () => {
+      const customData = {
+        rl_session: {
+          id: 1726655503445,
+          expiresAt: Date.now() + 60 * 1000,
+          timeout: 60000,
+          manualTrack: true,
+          sessionStart: false,
+        },
+      };
+      setDataInCookieStorage(customData);
+      state.loadOptions.value.sessions.autoTrack = false;
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.syncStorageDataToState();
+      expect(state.session.sessionInfo.value).toStrictEqual({
+        id: 1726655503445,
+        expiresAt: expect.any(Number),
+        timeout: 60000,
+        manualTrack: true,
+        autoTrack: false,
+        sessionStart: false,
+      });
+    });
   });
 
   describe('init', () => {
@@ -537,10 +576,7 @@ describe('User session manager', () => {
         timeout: 10000,
       };
       userSessionManager.init();
-      expect(state.session.sessionInfo.value).toStrictEqual({
-        autoTrack: false,
-        timeout: DEFAULT_SESSION_TIMEOUT_MS,
-      });
+      expect(state.session.sessionInfo.value).toStrictEqual({});
     });
 
     it('should log a warning and use default timeout if provided timeout is not in number format', () => {
@@ -560,7 +596,7 @@ describe('User session manager', () => {
       expect(defaultLogger.warn).toHaveBeenCalledWith(
         'UserSessionManager:: The session timeout value is 0, which disables the automatic session tracking feature. If you want to enable session tracking, please provide a positive integer value for the timeout.',
       );
-      expect(state.session.sessionInfo.value.autoTrack).toBe(false);
+      expect(state.session.sessionInfo.value).toStrictEqual({});
     });
 
     it('should log a warning if provided timeout is less than 10 seconds', () => {

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -242,6 +242,27 @@ describe('User session manager', () => {
         sessionStart: false,
       });
     });
+    it('should set sessionInfo if sessionInfo exists in storage with autoTrack enabled', () => {
+      const customData = {
+        rl_session: {
+          id: 1726655503445,
+          expiresAt: Date.now() + 60 * 1000,
+          timeout: 1800000,
+          autoTrack: true,
+          sessionStart: false,
+        },
+      };
+      setDataInCookieStorage(customData);
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.syncStorageDataToState();
+      expect(state.session.sessionInfo.value).toStrictEqual({
+        id: 1726655503445,
+        expiresAt: expect.any(Number),
+        timeout: 1800000,
+        autoTrack: true,
+        sessionStart: false,
+      });
+    });
   });
 
   describe('init', () => {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -134,19 +134,22 @@ class UserSessionManager implements IUserSessionManager {
     if (this.isPersistenceEnabledForStorageEntry('sessionInfo')) {
       const configuredSessionTrackingInfo = this.getConfiguredSessionTrackingInfo();
       const initialSessionInfo = sessionInfo ?? defaultSessionConfiguration;
-      sessionInfo = {
-        ...initialSessionInfo,
-        ...configuredSessionTrackingInfo,
-        autoTrack:
-          configuredSessionTrackingInfo.autoTrack && initialSessionInfo.manualTrack !== true,
-      };
+
+      if (!configuredSessionTrackingInfo.autoTrack && initialSessionInfo.manualTrack !== true) {
+        sessionInfo = DEFAULT_USER_SESSION_VALUES.sessionInfo;
+      } else {
+        sessionInfo = {
+          ...initialSessionInfo,
+          ...configuredSessionTrackingInfo,
+          autoTrack:
+            configuredSessionTrackingInfo.autoTrack && initialSessionInfo.manualTrack !== true,
+        };
+      }
+    } else {
+      sessionInfo = DEFAULT_USER_SESSION_VALUES.sessionInfo;
     }
 
-    state.session.sessionInfo.value =
-      this.isPersistenceEnabledForStorageEntry('sessionInfo') &&
-      (sessionInfo?.autoTrack || sessionInfo?.manualTrack)
-        ? (sessionInfo as SessionInfo)
-        : DEFAULT_USER_SESSION_VALUES.sessionInfo;
+    state.session.sessionInfo.value = sessionInfo as SessionInfo;
 
     // If auto session tracking is enabled start the session tracking
     if (state.session.sessionInfo.value.autoTrack) {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -142,9 +142,11 @@ class UserSessionManager implements IUserSessionManager {
       };
     }
 
-    state.session.sessionInfo.value = this.isPersistenceEnabledForStorageEntry('sessionInfo')
-      ? (sessionInfo as SessionInfo)
-      : DEFAULT_USER_SESSION_VALUES.sessionInfo;
+    state.session.sessionInfo.value =
+      this.isPersistenceEnabledForStorageEntry('sessionInfo') &&
+      (sessionInfo?.autoTrack || sessionInfo?.manualTrack)
+        ? (sessionInfo as SessionInfo)
+        : DEFAULT_USER_SESSION_VALUES.sessionInfo;
 
     // If auto session tracking is enabled start the session tracking
     if (state.session.sessionInfo.value.autoTrack) {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -134,16 +134,16 @@ class UserSessionManager implements IUserSessionManager {
     if (this.isPersistenceEnabledForStorageEntry('sessionInfo')) {
       const configuredSessionTrackingInfo = this.getConfiguredSessionTrackingInfo();
       const initialSessionInfo = sessionInfo ?? defaultSessionConfiguration;
-
-      if (!configuredSessionTrackingInfo.autoTrack && initialSessionInfo.manualTrack !== true) {
+      sessionInfo = {
+        ...initialSessionInfo,
+        ...configuredSessionTrackingInfo,
+        // If manualTrack is set to true in the storage, then autoTrack should be false
+        autoTrack:
+          configuredSessionTrackingInfo.autoTrack && initialSessionInfo.manualTrack !== true,
+      };
+      // If both autoTrack and manualTrack are disabled, reset the session info to default values
+      if (!sessionInfo.autoTrack && sessionInfo.manualTrack !== true) {
         sessionInfo = DEFAULT_USER_SESSION_VALUES.sessionInfo;
-      } else {
-        sessionInfo = {
-          ...initialSessionInfo,
-          ...configuredSessionTrackingInfo,
-          autoTrack:
-            configuredSessionTrackingInfo.autoTrack && initialSessionInfo.manualTrack !== true,
-        };
       }
     } else {
       sessionInfo = DEFAULT_USER_SESSION_VALUES.sessionInfo;


### PR DESCRIPTION
## PR Description

This PR has changes to fix the issue, when session information exists in storage and autoTrack is set to false via loadOption, event payload had sessionId.

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced session management logic to ensure correct behavior based on tracking options, preventing invalid session data usage.
	- Adjusted expected outcomes for session info under specific conditions.

- **Tests**
	- Improved test coverage for the `UserSessionManager` component, focusing on session behavior with `autoTrack` and `manualTrack` flags, including new scenarios for session data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->