### PR TITLE
fix: filter non error type errors

### DIFF
--- a/packages/analytics-js-plugins/__tests__/errorReporting/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/errorReporting/utils.test.ts
@@ -304,7 +304,7 @@ describe('Error Reporting utilities', () => {
         unhandled: false,
         severityReason: { type: 'handledException' },
       };
-      const errorPayload = ErrorFormat.create(normalizedError, true, errorState, 'notify()', 2);
+      const errorPayload = ErrorFormat.create(normalizedError, 'notify()');
 
       const appState = {
         context: {

--- a/packages/analytics-js-plugins/__tests__/errorReporting/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/errorReporting/utils.test.ts
@@ -510,8 +510,6 @@ describe('Error Reporting utilities', () => {
       const config = getConfigForPayloadCreation(error, 'unhandledException');
       expect(config).toEqual({
         component: 'unhandledException handler',
-        tolerateNonErrors: true,
-        errorFramesToSkip: 1,
         normalizedError: error,
       });
     });
@@ -521,8 +519,6 @@ describe('Error Reporting utilities', () => {
       const config = getConfigForPayloadCreation(error, 'unhandledPromiseRejection');
       expect(config).toEqual({
         component: 'unhandledrejection handler',
-        tolerateNonErrors: false,
-        errorFramesToSkip: 1,
         normalizedError: 'test error',
       });
     });
@@ -532,8 +528,6 @@ describe('Error Reporting utilities', () => {
       const config = getConfigForPayloadCreation(error, 'handledException');
       expect(config).toEqual({
         component: 'notify()',
-        tolerateNonErrors: true,
-        errorFramesToSkip: 2,
         normalizedError: error,
       });
     });
@@ -543,8 +537,6 @@ describe('Error Reporting utilities', () => {
       const config = getConfigForPayloadCreation(error, 'randomValue');
       expect(config).toEqual({
         component: 'notify()',
-        tolerateNonErrors: true,
-        errorFramesToSkip: 2,
         normalizedError: error,
       });
     });

--- a/packages/analytics-js-plugins/src/errorReporting/event/event.ts
+++ b/packages/analytics-js-plugins/src/errorReporting/event/event.ts
@@ -62,20 +62,12 @@ const getStacktrace = (error: any, errorFramesToSkip: number) => {
   return [];
 };
 
-const hasNecessaryFields = (error: any) =>
-  (typeof error.name === 'string' || typeof error.errorClass === 'string') &&
-  (typeof error.message === 'string' || typeof error.errorMessage === 'string');
-
 const normaliseError = (maybeError: any, component: string, logger?: ILogger) => {
   let error;
   let internalFrames = 0;
 
   if (isError(maybeError)) {
     error = maybeError;
-  } else if (typeof maybeError === 'object' && hasNecessaryFields(maybeError)) {
-    error = new Error(maybeError.message || maybeError.errorMessage);
-    error.name = maybeError.name || maybeError.errorClass;
-    internalFrames += 1;
   } else {
     logger?.warn(
       `${ERROR_REPORTING_PLUGIN}:: ${component} received a non-error: ${stringifyWithoutCircular(error)}`,

--- a/packages/analytics-js-plugins/src/errorReporting/event/event.ts
+++ b/packages/analytics-js-plugins/src/errorReporting/event/event.ts
@@ -64,7 +64,6 @@ const getStacktrace = (error: any, errorFramesToSkip: number) => {
 
 const normaliseError = (maybeError: any, component: string, logger?: ILogger) => {
   let error;
-  let internalFrames = 0;
 
   if (isError(maybeError)) {
     error = maybeError;
@@ -76,20 +75,10 @@ const normaliseError = (maybeError: any, component: string, logger?: ILogger) =>
   }
 
   if (error && !hasStack(error)) {
-    // in IE10/11 a new Error() doesn't have a stacktrace until you throw it, so try that here
-    try {
-      throw error;
-    } catch (e) {
-      if (hasStack(e)) {
-        error = e;
-        // if the error only got a stacktrace after we threw it here, we know it
-        // will only have one extra internal frame from this function
-        internalFrames = 1;
-      }
-    }
+    error = undefined;
   }
 
-  return [error, internalFrames];
+  return [error, 0];
 };
 
 class ErrorFormat implements IErrorFormat {

--- a/packages/analytics-js-plugins/src/errorReporting/index.ts
+++ b/packages/analytics-js-plugins/src/errorReporting/index.ts
@@ -71,18 +71,13 @@ const ErrorReporting = (): ExtensionPlugin => ({
       errorState?: ErrorState,
     ): void => {
       if (httpClient) {
-        const { component, tolerateNonErrors, errorFramesToSkip, normalizedError } =
-          getConfigForPayloadCreation(error, errorState?.severityReason.type as string);
+        const { component, normalizedError } = getConfigForPayloadCreation(
+          error,
+          errorState?.severityReason.type as string,
+        );
 
         // Generate the error payload
-        const errorPayload = ErrorFormat.create(
-          normalizedError,
-          tolerateNonErrors,
-          errorState as ErrorState,
-          component,
-          errorFramesToSkip,
-          logger,
-        );
+        const errorPayload = ErrorFormat.create(normalizedError, component, logger);
 
         if (!errorPayload || !isAllowedToBeNotified(errorPayload.errors[0])) {
           return;

--- a/packages/analytics-js-plugins/src/errorReporting/utils.ts
+++ b/packages/analytics-js-plugins/src/errorReporting/utils.ts
@@ -35,8 +35,6 @@ const getConfigForPayloadCreation = (err: SDKError, errorType: string) => {
       const { error } = err as ErrorEvent;
       return {
         component: 'unhandledException handler',
-        tolerateNonErrors: true,
-        errorFramesToSkip: 1,
         normalizedError: error || err,
       };
     }
@@ -44,8 +42,6 @@ const getConfigForPayloadCreation = (err: SDKError, errorType: string) => {
       const error = err as PromiseRejectionEvent;
       return {
         component: 'unhandledrejection handler',
-        tolerateNonErrors: false,
-        errorFramesToSkip: 1,
         normalizedError: error.reason,
       };
     }
@@ -53,8 +49,6 @@ const getConfigForPayloadCreation = (err: SDKError, errorType: string) => {
     default:
       return {
         component: 'notify()',
-        tolerateNonErrors: true,
-        errorFramesToSkip: 2,
         normalizedError: err,
       };
   }


### PR DESCRIPTION
## PR Description

This PR fixes a scenario where we create new errors from error messages if the type of the error is not an error.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-2284/filter-errors-that-do-not-have-a-stack-trace)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified the error normalization process by directly checking for `Error` instances, improving error handling.
	- Removed unnecessary properties from error configuration, streamlining the payload creation process.

These changes enhance the reliability and efficiency of error reporting within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->