### PR TITLE
fix: storage access error when cookies are blocked

### DIFF
--- a/packages/analytics-js/__tests__/components/capabilitiesManager/detection/storage.test.ts
+++ b/packages/analytics-js/__tests__/components/capabilitiesManager/detection/storage.test.ts
@@ -1,3 +1,4 @@
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import {
   isStorageQuotaExceeded,
   isStorageAvailable,
@@ -23,5 +24,79 @@ describe('Capabilities Detection - Storage', () => {
   });
   it('should detect if memoryStorage is available', () => {
     expect(isStorageAvailable('memoryStorage', new InMemoryStorage())).toBeTruthy();
+  });
+
+  it('should log a warning when storage is unavailable', () => {
+    const mockLogger = {
+      warn: jest.fn(),
+    } as ILogger;
+
+    // Store the original descriptor so we can restore it later
+    const originalLsDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    const originalSessionStorageDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'sessionStorage',
+    );
+
+    // Mock using Object.defineProperty
+    Object.defineProperty(window, 'localStorage', {
+      get: jest.fn(),
+      set: jest.fn(),
+      configurable: true,
+    });
+
+    // Mock using Object.defineProperty
+    Object.defineProperty(window, 'sessionStorage', {
+      get: jest.fn(),
+      set: jest.fn(),
+      configurable: true,
+    });
+
+    isStorageAvailable('localStorage', undefined, mockLogger);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'CapabilitiesManager:: The "localStorage" storage type is unavailable.',
+      undefined,
+    );
+
+    isStorageAvailable('sessionStorage', undefined, mockLogger);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'CapabilitiesManager:: The "sessionStorage" storage type is unavailable.',
+      undefined,
+    );
+
+    // Restore the original document.cookie descriptor
+    Object.defineProperty(window, 'localStorage', originalLsDescriptor as PropertyDescriptor);
+    Object.defineProperty(
+      window,
+      'sessionStorage',
+      originalSessionStorageDescriptor as PropertyDescriptor,
+    );
+  });
+
+  it('should log a warning when the local storage is full', () => {
+    const mockLogger = {
+      warn: jest.fn(),
+    } as ILogger;
+
+    // Store the original descriptor so we can restore it later
+    const originalLsDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
+    // Mock using Object.defineProperty
+    Object.defineProperty(window, 'localStorage', {
+      get: jest.fn(() => {
+        throw new DOMException('StorageQuotaExceeded', 'QuotaExceededError');
+      }),
+      set: jest.fn(),
+      configurable: true,
+    });
+
+    isStorageAvailable('localStorage', undefined, mockLogger);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'CapabilitiesManager:: The "localStorage" storage type is full.',
+      new DOMException('StorageQuotaExceeded', 'QuotaExceededError'),
+    );
+
+    // Restore the original document.cookie descriptor
+    Object.defineProperty(window, 'localStorage', originalLsDescriptor as PropertyDescriptor);
   });
 });

--- a/packages/analytics-js/__tests__/services/StoreManager/storages/sessionStorage.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/storages/sessionStorage.test.ts
@@ -28,4 +28,26 @@ describe('SessionStorage', () => {
     expect(engine.keys()).toStrictEqual([]);
     expect(engine.length).toStrictEqual(0);
   });
+
+  it('APIs should respond appropriate when session storage is not available', () => {
+    const sessionStorageEngine = getStorageEngine('sessionStorage');
+
+    sessionStorageEngine.store = undefined;
+
+    sessionStorageEngine.setItem('a', '1');
+    expect(sessionStorageEngine.length).toBe(0);
+    expect(sessionStorageEngine.getItem('a')).toBeNull();
+
+    sessionStorageEngine.removeItem('a');
+
+    expect(sessionStorageEngine.length).toBe(0);
+
+    // clear all entries
+    sessionStorageEngine.clear();
+    expect(sessionStorageEngine.length).toBe(0);
+
+    expect(sessionStorageEngine.key(0)).toBeNull();
+
+    expect(sessionStorageEngine.keys()).toEqual([]);
+  });
 });

--- a/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
@@ -37,7 +37,7 @@ class CookieStorage implements IStorage {
     if (options.sameDomainCookiesOnly) {
       delete this.options.domain;
     }
-    this.isSupportAvailable = isStorageAvailable(COOKIE_STORAGE, this, this.logger);
+    this.isSupportAvailable = isStorageAvailable(COOKIE_STORAGE, this);
     this.isEnabled = Boolean(this.options.enabled && this.isSupportAvailable);
     return this.options;
   }

--- a/packages/analytics-js/src/services/StoreManager/storages/LocalStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/LocalStorage.ts
@@ -31,7 +31,7 @@ class LocalStorage implements IStorage {
 
   configure(options: Partial<ILocalStorageOptions>): ILocalStorageOptions {
     this.options = mergeDeepRight(this.options, options);
-    this.isSupportAvailable = isStorageAvailable(LOCAL_STORAGE, this, this.logger);
+    this.isSupportAvailable = isStorageAvailable(LOCAL_STORAGE, this);
     this.isEnabled = Boolean(this.options.enabled && this.isSupportAvailable);
     return this.options;
   }

--- a/packages/analytics-js/src/services/StoreManager/storages/sessionStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/sessionStorage.ts
@@ -30,7 +30,7 @@ class SessionStorage implements IStorage {
 
   configure(options: Partial<ISessionStorageOptions>): ISessionStorageOptions {
     this.options = mergeDeepRight(this.options, options);
-    this.isSupportAvailable = isStorageAvailable(SESSION_STORAGE, undefined);
+    this.isSupportAvailable = isStorageAvailable(SESSION_STORAGE);
     // when storage is blocked by the user, even accessing the property throws an error
     if (this.isSupportAvailable) {
       this.store = globalThis.sessionStorage;

--- a/packages/analytics-js/src/services/StoreManager/storages/sessionStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/sessionStorage.ts
@@ -20,7 +20,7 @@ class SessionStorage implements IStorage {
   isSupportAvailable = true;
   isEnabled = true;
   length = 0;
-  store = globalThis.sessionStorage;
+  store?: Storage;
 
   constructor(options: ISessionStorageOptions = {}, logger?: ILogger) {
     this.options = getDefaultSessionStorageOptions();
@@ -30,37 +30,54 @@ class SessionStorage implements IStorage {
 
   configure(options: Partial<ISessionStorageOptions>): ISessionStorageOptions {
     this.options = mergeDeepRight(this.options, options);
-    this.isSupportAvailable = isStorageAvailable(SESSION_STORAGE, this, this.logger);
+    this.isSupportAvailable = isStorageAvailable(SESSION_STORAGE, undefined);
+    // when storage is blocked by the user, even accessing the property throws an error
+    if (this.isSupportAvailable) {
+      this.store = globalThis.sessionStorage;
+    }
     this.isEnabled = Boolean(this.options.enabled && this.isSupportAvailable);
     return this.options;
   }
 
   setItem(key: string, value: any) {
+    if (!this.store) {
+      return;
+    }
     this.store.setItem(key, value);
     this.length = this.store.length;
   }
 
   getItem(key: string): any {
+    if (!this.store) {
+      return null;
+    }
     const value = this.store.getItem(key);
     return isUndefined(value) ? null : value;
   }
 
   removeItem(key: string) {
+    if (!this.store) {
+      return;
+    }
     this.store.removeItem(key);
     this.length = this.store.length;
   }
 
   clear() {
-    this.store.clear();
+    this.store?.clear();
     this.length = 0;
   }
 
   key(index: number): Nullable<string> {
-    return this.store.key(index);
+    return this.store?.key(index) ?? null;
   }
 
   keys(): string[] {
     const keys: string[] = [];
+    if (!this.store) {
+      return keys;
+    }
+
     for (let i = 0; i < this.store.length; i += 1) {
       const key = this.store.key(i);
       if (key !== null) {


### PR DESCRIPTION
## PR Description

When all the storage is blocked on the browser, even accessing the `window.sessionStorage` property results in a security error.
Hence, we're handling this properly now.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2462/fix-storage-access-issue-for-session-storage-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
