### PR TITLE
fix: global integrations object is not used for preloaded events

### DIFF
--- a/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
@@ -10,8 +10,6 @@ import type { ExtensionPlugin } from '@rudderstack/analytics-js-common/types/Plu
 import { destDisplayNamesToFileNamesMap } from '@rudderstack/analytics-js-common/constants/integrations/destDisplayNamesToFileNamesMap';
 import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/ErrorHandler';
 import type { Destination } from '@rudderstack/analytics-js-common/types/Destination';
-import { clone } from 'ramda';
-import { DEFAULT_INTEGRATIONS_CONFIG } from '@rudderstack/analytics-js-common/constants/integrationsConfig';
 import { isDestinationSDKMounted, initializeDestination } from './utils';
 import { DEVICE_MODE_DESTINATIONS_PLUGIN, SCRIPT_LOAD_TIMEOUT_MS } from './constants';
 import { DESTINATION_NOT_SUPPORTED_ERROR, DESTINATION_SDK_LOAD_ERROR } from './logMessages';
@@ -31,10 +29,6 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
       errorHandler?: IErrorHandler,
       logger?: ILogger,
     ): void {
-      // Normalize the integration options from the load API call
-      state.nativeDestinations.loadOnlyIntegrations.value =
-        clone(state.loadOptions.value.integrations) ?? DEFAULT_INTEGRATIONS_CONFIG;
-
       state.nativeDestinations.loadIntegration.value = state.loadOptions.value
         .loadIntegration as boolean;
 

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -11,7 +11,7 @@ import type {
 } from '@rudderstack/analytics-js-common/types/EventContext';
 import type { SessionInfo } from '@rudderstack/analytics-js-common/types/Session';
 import type { RudderContext, RudderEvent } from '@rudderstack/analytics-js-common/types/Event';
-import { state } from '../../../src/state';
+import { resetState, state } from '../../../src/state';
 import {
   checkForReservedElements,
   checkForReservedElementsInObject,
@@ -21,6 +21,7 @@ import {
   updateTopLevelEventElements,
   getUpdatedPageProperties,
   getEnrichedEvent,
+  getEventIntegrationsConfig,
 } from '../../../src/components/eventManager/utilities';
 import { PluginsManager } from '../../../src/components/pluginsManager';
 import { defaultErrorHandler } from '../../../src/services/ErrorHandler';
@@ -1037,6 +1038,87 @@ describe('Event Manager - Utilities', () => {
         integrations: { All: true },
         messageId: 'test_uuid',
         userId: 'user_id',
+      });
+    });
+  });
+
+  describe('getEventIntegrationsConfig', () => {
+    afterEach(() => {
+      resetState();
+    });
+
+    it('should return global load API integrations object', () => {
+      batch(() => {
+        state.loadOptions.value = {
+          useGlobalIntegrationsConfigInEvents: true,
+        };
+
+        state.nativeDestinations.loadOnlyIntegrations.value = {
+          All: false,
+        };
+      });
+
+      expect(getEventIntegrationsConfig()).toEqual({
+        All: false,
+      });
+    });
+
+    it('should return consent API integrations object', () => {
+      batch(() => {
+        state.loadOptions.value = {
+          useGlobalIntegrationsConfigInEvents: true,
+        };
+
+        state.nativeDestinations.loadOnlyIntegrations.value = {
+          All: true,
+          GA4: false,
+        };
+
+        state.consents.postConsent.value = {
+          integrations: {
+            All: false,
+            MP: true,
+          },
+        };
+      });
+
+      expect(getEventIntegrationsConfig()).toEqual({
+        All: false,
+        MP: true,
+      });
+    });
+
+    it('should return global load API integrations object if consent API integrations object is not defined', () => {
+      batch(() => {
+        state.loadOptions.value = {
+          useGlobalIntegrationsConfigInEvents: true,
+        };
+
+        state.nativeDestinations.loadOnlyIntegrations.value = {
+          All: false,
+        };
+      });
+
+      expect(getEventIntegrationsConfig()).toEqual({
+        All: false,
+      });
+    });
+
+    it("should return event's integrations object", () => {
+      expect(
+        getEventIntegrationsConfig({
+          All: true,
+          AM: false,
+        }),
+      ).toEqual({
+        All: true,
+        AM: false,
+      });
+    });
+
+    it("should return default integrations object if event's integrations object is not defined", () => {
+      expect(getEventIntegrationsConfig()).toEqual({
+        All: true,
       });
     });
   });

--- a/packages/analytics-js/__tests__/components/eventRepository/EventRepository.test.ts
+++ b/packages/analytics-js/__tests__/components/eventRepository/EventRepository.test.ts
@@ -60,6 +60,9 @@ describe('EventRepository', () => {
     properties: {
       test: 'test',
     },
+    integrations: {
+      All: true,
+    },
   } as unknown as RudderEvent;
 
   const activeDestinationsWithHybridMode = [

--- a/packages/analytics-js/__tests__/components/utilities/consent.test.ts
+++ b/packages/analytics-js/__tests__/components/utilities/consent.test.ts
@@ -118,9 +118,6 @@ describe('consent utilties', () => {
       };
 
       const expectedOutcome = {
-        integrations: {
-          All: true,
-        },
         discardPreConsentEvents: false,
         sendPageEvent: false,
         trackConsent: false,

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -97,6 +97,10 @@
               destSDKBaseURL:
             '__DEST_SDK_BASE_URL__' + window.rudderAnalyticsBuildType + '/js-integrations',
               pluginsSDKBaseURL: '__PLUGINS_BASE_URL__' + window.rudderAnalyticsBuildType + '/plugins',
+              // integrations: {
+              //   All: false
+              // },
+              // useGlobalIntegrationsConfigInEvents: true,
               // useServerSideCookies:true,
               // queueOptions: {
               //   batch: {

--- a/packages/analytics-js/src/components/configManager/ConfigManager.ts
+++ b/packages/analytics-js/src/components/configManager/ConfigManager.ts
@@ -9,6 +9,7 @@ import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/Error
 import type { Destination } from '@rudderstack/analytics-js-common/types/Destination';
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import { CONFIG_MANAGER } from '@rudderstack/analytics-js-common/constants/loggerContexts';
+import type { IntegrationOpts } from '@rudderstack/analytics-js-common/types/Integration';
 import { isValidSourceConfig, validateLoadArgs } from './util/validate';
 import {
   SOURCE_CONFIG_FETCH_ERROR,
@@ -70,6 +71,7 @@ class ConfigManager implements IConfigManager {
       lockPluginsVersion,
       destSDKBaseURL,
       pluginsSDKBaseURL,
+      integrations,
     } = state.loadOptions.value;
 
     state.lifecycle.activeDataplaneUrl.value = removeTrailingSlashes(
@@ -110,6 +112,8 @@ class ConfigManager implements IConfigManager {
         this.logger,
       );
       state.metrics.metricsServiceUrl.value = `${state.lifecycle.activeDataplaneUrl.value}/${METRICS_SERVICE_ENDPOINT}`;
+      // Data in the loadOptions state is already normalized
+      state.nativeDestinations.loadOnlyIntegrations.value = integrations as IntegrationOpts;
     });
 
     this.getConfig();

--- a/packages/analytics-js/src/components/eventManager/utilities.ts
+++ b/packages/analytics-js/src/components/eventManager/utilities.ts
@@ -7,6 +7,7 @@ import type { RudderContext, RudderEvent } from '@rudderstack/analytics-js-commo
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { IntegrationOpts } from '@rudderstack/analytics-js-common/types/Integration';
 import {
+  isNonEmptyObject,
   isObjectLiteralAndNotNull,
   mergeDeepRight,
 } from '@rudderstack/analytics-js-common/utilities/object';
@@ -138,7 +139,7 @@ const updateTopLevelEventElements = (rudderEvent: RudderEvent, options: ApiOptio
     rudderEvent.anonymousId = options.anonymousId;
   }
 
-  if (isObjectLiteralAndNotNull<IntegrationOpts>(options.integrations)) {
+  if (isNonEmptyObject<IntegrationOpts>(options.integrations)) {
     // eslint-disable-next-line no-param-reassign
     rudderEvent.integrations = options.integrations;
   }
@@ -186,15 +187,6 @@ const getMergedContext = (
 };
 
 /**
- * A function to determine whether SDK should use the integration option provided in load call
- * @returns boolean
- */
-const shouldUseGlobalIntegrationsConfigInEvents = () =>
-  state.loadOptions.value.useGlobalIntegrationsConfigInEvents &&
-  (isObjectLiteralAndNotNull(state.consents.postConsent.value?.integrations) ||
-    isObjectLiteralAndNotNull(state.nativeDestinations.loadOnlyIntegrations.value));
-
-/**
  * Updates rudder event object with data from the API options
  * @param rudderEvent Generated rudder event
  * @param options API options
@@ -213,19 +205,19 @@ const processOptions = (rudderEvent: RudderEvent, options?: Nullable<ApiOptions>
  * @param integrationsConfig Event's integrations config
  * @returns Final integrations config
  */
-const getEventIntegrationsConfig = (integrationsConfig: IntegrationOpts) => {
+const getEventIntegrationsConfig = (integrationsConfig?: IntegrationOpts) => {
   let finalIntgConfig: IntegrationOpts;
-  if (shouldUseGlobalIntegrationsConfigInEvents()) {
-    finalIntgConfig = clone(
-      state.consents.postConsent.value?.integrations ??
-        state.nativeDestinations.loadOnlyIntegrations.value,
-    );
-  } else if (isObjectLiteralAndNotNull(integrationsConfig)) {
+  if (state.loadOptions.value.useGlobalIntegrationsConfigInEvents) {
+    // Prefer the integrations object from the consent API response over the load API integrations object
+    finalIntgConfig =
+      state.consents.postConsent.value.integrations ??
+      state.nativeDestinations.loadOnlyIntegrations.value;
+  } else if (integrationsConfig) {
     finalIntgConfig = integrationsConfig;
   } else {
     finalIntgConfig = DEFAULT_INTEGRATIONS_CONFIG;
   }
-  return finalIntgConfig;
+  return clone(finalIntgConfig);
 };
 
 /**
@@ -269,7 +261,6 @@ const getEnrichedEvent = (
       timezone: state.context.timezone.value,
     },
     originalTimestamp: getCurrentTimeFormatted(),
-    integrations: DEFAULT_INTEGRATIONS_CONFIG,
     messageId: generateUUID(),
     userId: rudderEvent.userId || state.session.userId.value,
   } as Partial<RudderEvent>;
@@ -338,4 +329,5 @@ export {
   getContextPageProperties,
   getMergedContext,
   processOptions,
+  getEventIntegrationsConfig, // For testing
 };

--- a/packages/analytics-js/src/components/eventRepository/utils.ts
+++ b/packages/analytics-js/src/components/eventRepository/utils.ts
@@ -2,7 +2,6 @@ import type { IntegrationOpts } from '@rudderstack/analytics-js-common/types/Int
 import { clone } from 'ramda';
 import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/object';
 import type { ApplicationState } from '@rudderstack/analytics-js-common/types/ApplicationState';
-import { DEFAULT_INTEGRATIONS_CONFIG } from '@rudderstack/analytics-js-common/constants/integrationsConfig';
 import type { RudderEvent } from '@rudderstack/analytics-js-common/types/Event';
 
 /**
@@ -33,10 +32,9 @@ const getFinalEvent = (event: RudderEvent, state: ApplicationState) => {
   const finalEvent = clone(event);
   // Merge the destination specific integrations config with the event's integrations config
   // In general, the preference is given to the event's integrations config
-  const eventIntgConfig = event.integrations ?? DEFAULT_INTEGRATIONS_CONFIG;
   const destinationsIntgConfig = state.nativeDestinations.integrationsConfig.value;
   const overriddenIntgOpts = getOverriddenIntegrationOptions(
-    eventIntgConfig,
+    event.integrations,
     destinationsIntgConfig,
   );
 

--- a/packages/analytics-js/src/components/utilities/consent.ts
+++ b/packages/analytics-js/src/components/utilities/consent.ts
@@ -14,8 +14,6 @@ import {
   mergeDeepRight,
 } from '@rudderstack/analytics-js-common/utilities/object';
 import { clone } from 'ramda';
-import { DEFAULT_INTEGRATIONS_CONFIG } from '@rudderstack/analytics-js-common/constants/integrationsConfig';
-import { isDefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import { state } from '../../state';
 import { UNSUPPORTED_CONSENT_MANAGER_ERROR } from '../../constants/logMessages';
 import { ConsentManagersToPluginNameMap } from '../configManager/constants';
@@ -62,10 +60,8 @@ const getValidPostConsentOptions = (options?: ConsentOptions) => {
     const clonedOptions = clone(options);
 
     validOptions.storage = clonedOptions.storage;
-    if (isDefined(clonedOptions.integrations)) {
-      validOptions.integrations = isObjectLiteralAndNotNull(clonedOptions.integrations)
-        ? clonedOptions.integrations
-        : DEFAULT_INTEGRATIONS_CONFIG;
+    if (isNonEmptyObject(clonedOptions.integrations)) {
+      validOptions.integrations = clonedOptions.integrations;
     }
     validOptions.discardPreConsentEvents = clonedOptions.discardPreConsentEvents === true;
     validOptions.sendPageEvent = clonedOptions.sendPageEvent === true;

--- a/packages/analytics-js/src/components/utilities/loadOptions.ts
+++ b/packages/analytics-js/src/components/utilities/loadOptions.ts
@@ -1,5 +1,6 @@
 import { clone } from 'ramda';
 import {
+  isNonEmptyObject,
   isObjectLiteralAndNotNull,
   mergeDeepRight,
   removeUndefinedAndNullValues,
@@ -36,7 +37,7 @@ const normalizeLoadOptions = (
     delete normalizedLoadOpts.uaChTrackLevel;
   }
 
-  if (!isObjectLiteralAndNotNull(normalizedLoadOpts.integrations)) {
+  if (!isNonEmptyObject(normalizedLoadOpts.integrations)) {
     delete normalizedLoadOpts.integrations;
   }
 

--- a/packages/analytics-js/src/state/slices/loadOptions.ts
+++ b/packages/analytics-js/src/state/slices/loadOptions.ts
@@ -2,6 +2,7 @@ import { signal } from '@preact/signals-core';
 import { clone } from 'ramda';
 import type { LoadOptions } from '@rudderstack/analytics-js-common/types/LoadOptions';
 import type { LoadOptionsState } from '@rudderstack/analytics-js-common/types/ApplicationState';
+import { DEFAULT_INTEGRATIONS_CONFIG } from '@rudderstack/analytics-js-common/constants/integrationsConfig';
 import {
   DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT_MS,
   DEFAULT_SESSION_TIMEOUT_MS,
@@ -19,7 +20,7 @@ const defaultLoadOptions: LoadOptions = {
   },
   sameSiteCookie: 'Lax',
   polyfillIfRequired: true,
-  integrations: { All: true },
+  integrations: DEFAULT_INTEGRATIONS_CONFIG,
   useBeacon: false,
   beaconQueueOptions: {},
   destinationsQueueOptions: {},


### PR DESCRIPTION
## PR Description

Global integrations object specified in the load API options is not included in the preloaded events, even though, `useGlobalIntegrationsConfigInEvents` is enabled.

This is because the data in the state is set in the device mode destinations plugin which is invoked only after the destinations are loaded.
So, the preloaded events do not have the data when they are processed.

I've moved to set the state entry to the config manager. So, the data should be available for all the events now.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2500/fix-issue-where-global-integrations-object-is-tagged-for-preload

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
