### PR TITLE
chore: add script to list integraitons and plugin files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,29 @@ jobs:
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path }}"
           copy_args="--recursive --cache-control max-age=${{ env.CACHE_MAX_AGE }}"
 
+          integration_sdks_zip_file="all_integration_sdks.tar.gz"
+          plugins_zip_file="all_plugins.tar.gz"
+
+          integration_sdks_html_file="list.html"
+          plugins_html_file="list.html"
+
+          # Generate a zip file of all the integrations
+          tar -czvf $integration_sdks_path_prefix/legacy/js-integrations/$integration_sdks_zip_file -C $integration_sdks_path_prefix/legacy/js-integrations/ .
+
+          tar -czvf $integration_sdks_path_prefix/modern/js-integrations/$integration_sdks_zip_file -C $integration_sdks_path_prefix/modern/js-integrations/ .
+
+          # Generate the HTML file to list all the integrations
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} ${{ inputs.s3_dir_path }}/legacy/js-integrations $integration_sdks_html_file $integration_sdks_path_prefix/legacy/js-integrations "Device Mode Integrations" $integration_sdks_zip_file
+
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} ${{ inputs.s3_dir_path }}/modern/js-integrations $integration_sdks_html_file $integration_sdks_path_prefix/modern/js-integrations "Device Mode Integrations" $integration_sdks_zip_file
+
+          # Generate a zip file of all the plugins
+          tar -czvf $plugins_path_prefix/modern/plugins/$plugins_zip_file -C $plugins_path_prefix/modern/plugins/ .
+
+          # Generate the HTML file to list all the plugins
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} ${{ inputs.s3_dir_path }}/modern/plugins $plugins_html_file $plugins_path_prefix/modern/plugins "Plugins" $plugins_zip_file
+
+          # Upload all the files to S3
           aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/legacy/js-integrations/ $copy_args
 

--- a/scripts/list-sdk-components.sh
+++ b/scripts/list-sdk-components.sh
@@ -43,6 +43,10 @@ is_excluded() {
 # Get list of files from S3 (non-recursive)
 # Capture the timestamp, file size, and file name for each file
 FILES=$(aws s3 ls s3://$BUCKET_NAME/$DIRECTORY_PATH/ | awk '{print $1, $2, $4}')
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to list files from S3 bucket" >&2
+    exit 1
+fi
 
 # Start creating HTML file
 echo "<!DOCTYPE html>" > $OUTPUT_HTML_FILE_PATH

--- a/scripts/list-sdk-components.sh
+++ b/scripts/list-sdk-components.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Get arguments
+BUCKET_NAME=$1
+DIRECTORY_PATH=$2
+OUTPUT_HTML_FILE_NAME=$3
+OUTPUT_HTML_DIR_PATH=$4
+COMPONENT_NAME=$5
+ZIP_FILE_NAME=$6
+
+OUTPUT_HTML_FILE_PATH="$OUTPUT_HTML_DIR_PATH/$OUTPUT_HTML_FILE_NAME"
+
+# List of files to exclude
+# Exclude the ZIP file and the output HTML file as they'll be
+# in the same directory as the other files
+EXCLUDED_FILES=($ZIP_FILE_NAME $OUTPUT_HTML_FILE)
+
+# Function to check if a file is in the excluded list
+is_excluded() {
+  local file=$1
+  for excluded in "${EXCLUDED_FILES[@]}"; do
+    if [[ "$file" == "$excluded" ]]; then
+      return 0 # File is in the excluded list
+    fi
+  done
+  return 1 # File is not in the excluded list
+}
+
+# Get list of files from S3 (non-recursive)
+# Capture the timestamp, file size, and file name for each file
+FILES=$(aws s3 ls s3://$BUCKET_NAME/$DIRECTORY_PATH/ | awk '{print $1, $2, $4}')
+
+# Start creating HTML file
+echo "<!DOCTYPE html>" > $OUTPUT_HTML_FILE_PATH
+echo "<html>" >> $OUTPUT_HTML_FILE_PATH
+echo "<head><title>S3 File List</title></head>" >> $OUTPUT_HTML_FILE_PATH
+echo "<body>" >> $OUTPUT_HTML_FILE_PATH
+echo "<h1>RudderStack JavaScript SDK - $COMPONENT_NAME</h1>" >> $OUTPUT_HTML_FILE_PATH
+echo "<p><a href=\"https://$BUCKET_NAME.s3.amazonaws.com/$DIRECTORY_PATH/$ZIP_FILE_NAME\" download><button>Download All Files</button></a></p>" >> $OUTPUT_HTML_FILE_PATH
+echo "<table>" >> $OUTPUT_HTML_FILE_PATH
+echo "<tr><th>#</th><th>File Name</th><th>Last Updated</th></tr>" >> $OUTPUT_HTML_FILE_PATH
+
+# Counter for serial number
+COUNTER=1
+
+# Add each file as a table row
+while IFS= read -r LINE; do
+  TIMESTAMP=$(echo $LINE | awk '{print $1, $2}')
+  FILE=$(echo $LINE | awk '{print $3}')
+  URL="https://$BUCKET_NAME.s3.amazonaws.com/$DIRECTORY_PATH/$FILE"
+
+  # Check if the file is in the excluded list
+  if is_excluded "$FILE"; then
+    continue # Skip this file
+  fi
+
+  # Remove the .min.js or .min.js.map extension for display
+  FILE_DISPLAY=$(basename "$FILE" | sed 's/\.min\.js$//' | sed 's/\.min\.js\.map$//' | sed 's/\\.js$//' | sed 's/\\.js\.map$//')
+
+  if [[ "$FILE" == *.min.js.map || "$FILE" == *.js.map ]]; then
+    # Indent map files
+    echo "<tr><td></td><td style=\"padding-left: 20px;\"><a href=\"$URL\">Source Map</a></td><td>$TIMESTAMP</td></tr>" >> $OUTPUT_HTML_FILE_PATH
+  else
+    # Add JS files with serial number
+    echo "<tr><td>$COUNTER</td><td><a href=\"$URL\">$FILE_DISPLAY</a></td><td>$TIMESTAMP</td></tr>" >> $OUTPUT_HTML_FILE_PATH
+    COUNTER=$((COUNTER + 1))
+  fi
+done <<< "$FILES"
+
+# Finish HTML file
+echo "</table>" >> $OUTPUT_HTML_FILE_PATH
+echo "</body>" >> $OUTPUT_HTML_FILE_PATH
+echo "</html>" >> $OUTPUT_HTML_FILE_PATH
+
+echo "HTML file with links to S3 files has been generated: $OUTPUT_HTML_FILE_PATH"

--- a/scripts/list-sdk-components.sh
+++ b/scripts/list-sdk-components.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+if [ "$#" -ne 6 ]; then
+    echo "Error: Incorrect number of arguments"
+    echo "Usage: $0 <BUCKET_NAME> <DIRECTORY_PATH> <OUTPUT_HTML_FILE_NAME> <OUTPUT_HTML_DIR_PATH> <COMPONENT_NAME> <ZIP_FILE_NAME>"
+    exit 1
+fi
+
+# Validate that required arguments are not empty
+for arg in "$@"; do
+    if [ -z "$arg" ]; then
+        echo "Error: Empty argument provided"
+        exit 1
+    fi
+done
+
 # Get arguments
 BUCKET_NAME=$1
 DIRECTORY_PATH=$2
@@ -13,7 +27,7 @@ OUTPUT_HTML_FILE_PATH="$OUTPUT_HTML_DIR_PATH/$OUTPUT_HTML_FILE_NAME"
 # List of files to exclude
 # Exclude the ZIP file and the output HTML file as they'll be
 # in the same directory as the other files
-EXCLUDED_FILES=($ZIP_FILE_NAME $OUTPUT_HTML_FILE)
+EXCLUDED_FILES=("$ZIP_FILE_NAME" "$OUTPUT_HTML_FILE_NAME")
 
 # Function to check if a file is in the excluded list
 is_excluded() {
@@ -54,8 +68,12 @@ while IFS= read -r LINE; do
     continue # Skip this file
   fi
 
-  # Remove the .min.js or .min.js.map extension for display
-  FILE_DISPLAY=$(basename "$FILE" | sed 's/\.min\.js$//' | sed 's/\.min\.js\.map$//' | sed 's/\\.js$//' | sed 's/\\.js\.map$//')
+  # Remove the file extension for display
+  FILE_DISPLAY=$(basename "$FILE")
+  FILE_DISPLAY=${FILE_DISPLAY%.min.js.map}
+  FILE_DISPLAY=${FILE_DISPLAY%.min.js}
+  FILE_DISPLAY=${FILE_DISPLAY%.js.map}
+  FILE_DISPLAY=${FILE_DISPLAY%.js}
 
   if [[ "$FILE" == *.min.js.map || "$FILE" == *.js.map ]]; then
     # Indent map files


### PR DESCRIPTION
## PR Description

Created a shell script to list integration SDK and plugin files in the S3 bucket. It'll generate an HTML file with all the necessary file URLs.
It is integrated directly into the deployment workflows.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-544/have-index-listing-of-integrations-inventory-working-post-s3

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new script to generate an HTML file listing files from an S3 bucket, enhancing component visibility.
- **Documentation**
	- Added details on command-line arguments for the new script to assist users in its implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->