### PR TITLE
fix: add xpixel missing name mapping

### DIFF
--- a/packages/analytics-js-common/src/constants/integrations/destDisplayNamesToFileNamesMap.ts
+++ b/packages/analytics-js-common/src/constants/integrations/destDisplayNamesToFileNamesMap.ts
@@ -158,6 +158,8 @@ import {
   CommandBarDirectoryName,
   NinetailedDisplayName,
   NinetailedDirectoryName,
+  XPixelDisplayName,
+  XPixelDirectoryName,
 } from './destinationNames';
 
 // The destination directory name is used as the destination SDK file name in CDN
@@ -241,6 +243,7 @@ const destDisplayNamesToFileNamesMap: Record<string, string> = {
   [SpotifyPixelDisplayName]: SpotifyPixelDirectoryName,
   [CommandBarDisplayName]: CommandBarDirectoryName,
   [NinetailedDisplayName]: NinetailedDirectoryName,
+  [XPixelDisplayName]: XPixelDirectoryName,
 };
 
 export { destDisplayNamesToFileNamesMap };

--- a/packages/analytics-js-common/src/constants/integrations/destinationNames.ts
+++ b/packages/analytics-js-common/src/constants/integrations/destinationNames.ts
@@ -290,3 +290,7 @@ export {
   DISPLAY_NAME as NinetailedDisplayName,
   DIR_NAME as NinetailedDirectoryName,
 } from './Ninetailed/constants';
+export {
+  DISPLAY_NAME as XPixelDisplayName,
+  DIR_NAME as XPixelDirectoryName,
+} from './XPixel/constants';


### PR DESCRIPTION
## PR Description

Added missing XPixel name mapping.

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-2798/[fix]-xpixel-name-mapping-in-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
