### PR TITLE
fix: move page visit id to context

### DIFF
--- a/packages/analytics-js-common/__tests__/utilities/timestamp.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/timestamp.test.ts
@@ -1,0 +1,32 @@
+import { getCurrentTimeFormatted, getFormattedTimestamp } from '../../src/utilities/timestamp';
+
+describe('timestamp', () => {
+  describe('getFormattedTimestamp', () => {
+    it('should return the formatted timestamp', () => {
+      // Arrange
+      const date = new Date('2021-01-01T00:00:00Z');
+
+      // Act
+      const result = getFormattedTimestamp(date);
+
+      // Assert
+      expect(result).toBe('2021-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('getCurrentTimeFormatted', () => {
+    it('should return the current formatted timestamp', () => {
+      // Arrange
+      const date = new Date('2021-01-01T00:00:00Z');
+      const dateSpy = jest.spyOn(global, 'Date').mockImplementationOnce(() => date);
+
+      // Act
+      const result = getCurrentTimeFormatted();
+
+      // Assert
+      expect(result).toBe('2021-01-01T00:00:00.000Z');
+
+      dateSpy.mockRestore();
+    });
+  });
+});

--- a/packages/analytics-js-common/src/types/Event.ts
+++ b/packages/analytics-js-common/src/types/Event.ts
@@ -8,6 +8,14 @@ import type { ApiObject } from './ApiObject';
 // TODO: fix type
 export type BufferedEvent = any[];
 
+export type PageLifecycle = {
+  visitId: string; // UUID
+};
+
+export type AutoTrack = {
+  page: PageLifecycle;
+};
+
 export type RudderContext = {
   [index: string]:
     | string
@@ -32,6 +40,7 @@ export type RudderContext = {
   campaign?: UTMParameters;
   trulyAnonymousTracking?: boolean;
   timezone: string;
+  autoTrack?: AutoTrack;
 };
 
 export type RudderEvent = {

--- a/packages/analytics-js-common/src/utilities/timestamp.ts
+++ b/packages/analytics-js-common/src/utilities/timestamp.ts
@@ -1,10 +1,9 @@
+const getFormattedTimestamp = (date: Date): string => date.toISOString();
+
 /**
  * To get the current timestamp in ISO string format
  * @returns ISO formatted timestamp string
  */
-const getCurrentTimeFormatted = (): string => {
-  const curDateTime = new Date().toISOString();
-  return curDateTime;
-};
+const getCurrentTimeFormatted = (): string => getFormattedTimestamp(new Date());
 
-export { getCurrentTimeFormatted };
+export { getCurrentTimeFormatted, getFormattedTimestamp };

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -339,12 +339,7 @@ describe('trackPageLifecycleEvents', () => {
     });
 
     expect(bufferedEvents).toEqual([
-      [
-        'track',
-        'Page Loaded',
-        { visitId: expect.any(String) },
-        { key: 'value', originalTimestamp: expect.any(String) },
-      ],
+      ['track', 'Page Loaded', {}, { key: 'value', originalTimestamp: expect.any(String) }],
     ]);
   });
 
@@ -375,12 +370,7 @@ describe('trackPageLifecycleEvents', () => {
     });
 
     expect(bufferedEvents).toEqual([
-      [
-        'track',
-        'Page Loaded',
-        { visitId: expect.any(String) },
-        { originalTimestamp: expect.any(String) },
-      ],
+      ['track', 'Page Loaded', {}, { originalTimestamp: expect.any(String) }],
     ]);
   });
 
@@ -402,7 +392,7 @@ describe('trackPageLifecycleEvents', () => {
 
     expect(rudderAnalyticsInstance.track).toHaveBeenCalledWith(
       'Page Unloaded',
-      { visitId: expect.any(String), visitDuration: expect.any(Number) },
+      { visitDuration: expect.any(Number) },
       { originalTimestamp: expect.any(String) },
     );
   });

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -189,11 +189,12 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
       options = autoTrackOptions,
     } = pageLifecycle ?? {};
 
+    state.autoTrack.pageLifecycle.enabled.value = pageLifecycleEnabled;
+
     // Set the autoTrack enabled state
     // if at least one of the autoTrack options is enabled
+    // IMPORTANT: make sure this is done at the end as it depends on the above states
     state.autoTrack.enabled.value = autoTrackEnabled || pageLifecycleEnabled;
-
-    state.autoTrack.pageLifecycle.enabled.value = pageLifecycleEnabled;
 
     if (!pageLifecycleEnabled) {
       return;

--- a/packages/analytics-js/src/components/eventManager/utilities.ts
+++ b/packages/analytics-js/src/components/eventManager/utilities.ts
@@ -259,6 +259,16 @@ const getEnrichedEvent = (
       campaign: extractUTMParameters(globalThis.location.href),
       page: getContextPageProperties(pageProps),
       timezone: state.context.timezone.value,
+      // Add auto tracking information
+      ...(state.autoTrack.enabled.value && {
+        autoTrack: {
+          ...(state.autoTrack.pageLifecycle.enabled.value && {
+            page: {
+              visitId: state.autoTrack.pageLifecycle.visitId.value,
+            },
+          }),
+        },
+      }),
     },
     originalTimestamp: getCurrentTimeFormatted(),
     messageId: generateUUID(),


### PR DESCRIPTION
## PR Description

Page visit ID has been moved to context. It is attached to all the events.
Also, the global auto-tracking enabled status is set if at least one of the components are enabled.

Additionally, cleaned up some code in the src and test suites.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
