### PR TITLE
feat: add date datatype

### DIFF
--- a/packages/analytics-js-service-worker/src/types.ts
+++ b/packages/analytics-js-service-worker/src/types.ts
@@ -13,7 +13,8 @@ export interface ApiObject {
     | ApiObject
     | unknown
     | Date
-    | (string | number | boolean | ApiObject | Date)[];
+    | null
+    | (string | number | boolean | ApiObject | Date | null | undefined)[];
 }
 
 /**

--- a/packages/analytics-js-service-worker/src/types.ts
+++ b/packages/analytics-js-service-worker/src/types.ts
@@ -11,7 +11,6 @@ export interface ApiObject {
     | boolean
     | undefined
     | ApiObject
-    | unknown
     | Date
     | null
     | (string | number | boolean | ApiObject | Date | null | undefined)[];

--- a/packages/analytics-js-service-worker/src/types.ts
+++ b/packages/analytics-js-service-worker/src/types.ts
@@ -12,7 +12,8 @@ export interface ApiObject {
     | undefined
     | ApiObject
     | unknown
-    | (string | number | boolean | ApiObject)[];
+    | Date
+    | (string | number | boolean | ApiObject | Date)[];
 }
 
 /**


### PR DESCRIPTION
## PR Description

Allow date data type in apiObject interface.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `ApiObject` interface to support `Date` and `null` values, allowing for more complex data representations.

These changes improve the flexibility and capability of data handling within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->