### PR TITLE
fix: fixing display name issues

### DIFF
--- a/packages/analytics-js-common/src/constants/integrations/ActiveCampaign/constants.js
+++ b/packages/analytics-js-common/src/constants/integrations/ActiveCampaign/constants.js
@@ -1,6 +1,6 @@
 const DIR_NAME = 'ActiveCampaign';
 const NAME = 'ACTIVE_CAMPAIGN';
-const DISPLAY_NAME = 'Active Campaign';
+const DISPLAY_NAME = 'ActiveCampaign';
 
 const DISPLAY_NAME_TO_DIR_NAME_MAP = { [DISPLAY_NAME]: DIR_NAME };
 const CNameMapping = {

--- a/packages/analytics-js-common/src/constants/integrations/ConvertFlow/constants.ts
+++ b/packages/analytics-js-common/src/constants/integrations/ConvertFlow/constants.ts
@@ -1,6 +1,6 @@
 const DIR_NAME = 'ConvertFlow';
 const NAME = 'CONVERTFLOW';
-const DISPLAY_NAME = 'ConvertFlow';
+const DISPLAY_NAME = 'Convertflow';
 
 const DISPLAY_NAME_TO_DIR_NAME_MAP = { [DISPLAY_NAME]: DIR_NAME };
 const CNameMapping = {

--- a/packages/analytics-js-common/src/constants/integrations/Lemnisk/constants.ts
+++ b/packages/analytics-js-common/src/constants/integrations/Lemnisk/constants.ts
@@ -1,6 +1,6 @@
 const DIR_NAME = 'Lemnisk';
 const NAME = 'LEMNISK';
-const DISPLAY_NAME = 'Lemnisk';
+const DISPLAY_NAME = 'Lemnisk Marketing Automation';
 
 const DISPLAY_NAME_TO_DIR_NAME_MAP = { [DISPLAY_NAME]: DIR_NAME };
 const CNameMapping = {

--- a/packages/analytics-js-common/src/constants/integrations/LiveChat/constants.ts
+++ b/packages/analytics-js-common/src/constants/integrations/LiveChat/constants.ts
@@ -1,6 +1,6 @@
 const DIR_NAME = 'LiveChat';
 const NAME = 'LIVECHAT';
-const DISPLAY_NAME = 'LiveChat';
+const DISPLAY_NAME = 'livechat';
 
 const DISPLAY_NAME_TO_DIR_NAME_MAP = { [DISPLAY_NAME]: DIR_NAME };
 const CNameMapping = {


### PR DESCRIPTION
## PR Description

While verifying the device mode destinations loading across the entire repository we found out that the below destinations were not loading due to display name mismatch:

- Active campaign
- Livechat
- Lemnisk
- ConvertFlow

<img width="1728" alt="Screenshot 2024-11-07 at 12 17 04 PM" src="https://github.com/user-attachments/assets/1c2cc940-3b71-41e2-b8a1-6537c95673f0">

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-2811/test-web-device-mode-destinations-for-proper-loading
Resolves INT-2811

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated display names for various integrations to improve consistency:
		- ActiveCampaign: Changed to 'ActiveCampaign'
		- ConvertFlow: Changed to 'Convertflow'
		- Lemnisk: Changed to 'Lemnisk Marketing Automation'
		- LiveChat: Changed to 'livechat'
  
These updates enhance clarity and standardization across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->