### PR TITLE
fix: adroll bugsnag issue

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Adroll/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Adroll/browser.test.js
@@ -15,6 +15,9 @@ beforeEach(() => {
 afterEach(() => {
   // Reset DOM to original state
   document.getElementById('dummyScript')?.remove();
+  // Reset window.__adroll
+  delete window.__adroll;
+  delete window._adroll_email;
 });
 
 describe('Init tests', () => {

--- a/packages/analytics-js-integrations/__tests__/integrations/Adroll/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Adroll/browser.test.js
@@ -3,7 +3,6 @@ import { Adroll } from '../../../src/integrations/Adroll';
 
 beforeEach(() => {
   window.__adroll = {};
-
   // Add a dummy script as it is required by the init script
   const scriptElement = document.createElement('script');
   scriptElement.type = 'text/javascript';
@@ -11,11 +10,9 @@ beforeEach(() => {
   const headElements = document.getElementsByTagName('head');
   headElements[0].insertBefore(scriptElement, headElements[0].firstChild);
 });
-
 afterEach(() => {
   // Reset DOM to original state
   document.getElementById('dummyScript')?.remove();
-  // Reset window.__adroll
   delete window.__adroll;
   delete window._adroll_email;
 });
@@ -163,6 +160,30 @@ describe('Track tests', () => {
       },
     });
     expect(window.__adroll.record_user).not.toHaveBeenCalled();
+  });
+
+  test('should handle non-string event names', () => {
+    // Test number event
+    adroll.track({
+      message: {
+        event: 123,
+        properties: {}
+      }
+    });
+    
+    // Test object event
+    adroll.track({
+      message: {
+        event: { toString: () => 'custom event' },
+        properties: {}
+      }
+    });
+    
+    expect(window.__adroll.record_user).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adroll_segments: 'ghi789'
+      })
+    );
   });
 });
 

--- a/packages/analytics-js-integrations/__tests__/integrations/Adroll/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Adroll/browser.test.js
@@ -1,0 +1,211 @@
+/* eslint-disable no-underscore-dangle */
+import { Adroll } from '../../../src/integrations/Adroll';
+
+beforeEach(() => {
+  window.__adroll = {};
+
+  // Add a dummy script as it is required by the init script
+  const scriptElement = document.createElement('script');
+  scriptElement.type = 'text/javascript';
+  scriptElement.id = 'dummyScript';
+  const headElements = document.getElementsByTagName('head');
+  headElements[0].insertBefore(scriptElement, headElements[0].firstChild);
+});
+
+afterEach(() => {
+  // Reset DOM to original state
+  document.getElementById('dummyScript')?.remove();
+});
+
+describe('Init tests', () => {
+  let adroll;
+
+  test('Basic initialization', () => {
+    adroll = new Adroll({ advId: 'TEST_ADV_ID', pixId: 'TEST_PIX_ID' }, { logLevel: 'debug' });
+    adroll.init();
+    expect(window.adroll_adv_id).toBe('TEST_ADV_ID');
+    expect(window.adroll_pix_id).toBe('TEST_PIX_ID');
+  });
+});
+
+describe('isLoaded and isReady tests', () => {
+  let adroll;
+
+  beforeEach(() => {
+    adroll = new Adroll({ advId: 'TEST_ADV_ID', pixId: 'TEST_PIX_ID' }, { logLevel: 'debug' });
+  });
+
+  test('isLoaded should return true when window.__adroll is available', () => {
+    window.__adroll = { record_user: jest.fn() };
+    expect(adroll.isLoaded()).toBe(true);
+  });
+
+  test('isLoaded should return false when window.__adroll is not available', () => {
+    window.__adroll = undefined;
+    expect(adroll.isLoaded()).toBe(false);
+  });
+
+  test('isReady should match isLoaded', () => {
+    window.__adroll = { record_user: jest.fn() };
+    expect(adroll.isReady()).toBe(adroll.isLoaded());
+  });
+});
+
+describe('Identify tests', () => {
+  let adroll;
+
+  beforeEach(() => {
+    adroll = new Adroll({ advId: 'TEST_ADV_ID', pixId: 'TEST_PIX_ID' }, { logLevel: 'debug' });
+    window.__adroll = {
+      record_adroll_email: jest.fn(),
+    };
+  });
+
+  test('should identify user with email from context.traits', () => {
+    const email = 'test@example.com';
+    adroll.identify({
+      message: {
+        context: {
+          traits: { email },
+        },
+      },
+    });
+    expect(window._adroll_email).toBe(email);
+    expect(window.__adroll.record_adroll_email).toHaveBeenCalledWith('segment');
+  });
+
+  test('should identify user with email from traits', () => {
+    const email = 'test@example.com';
+    adroll.identify({
+      message: {
+        traits: { email },
+      },
+    });
+    expect(window._adroll_email).toBe(email);
+    expect(window.__adroll.record_adroll_email).toHaveBeenCalledWith('segment');
+  });
+
+  test('should not call record_adroll_email when email is missing', () => {
+    adroll.identify({
+      message: {
+        traits: {},
+      },
+    });
+    expect(window.__adroll.record_adroll_email).not.toHaveBeenCalled();
+  });
+});
+
+describe('Track tests', () => {
+  let adroll;
+
+  beforeEach(() => {
+    adroll = new Adroll(
+      {
+        advId: 'TEST_ADV_ID',
+        pixId: 'TEST_PIX_ID',
+        eventsMap: [
+          { from: 'product viewed', to: 'abc123' },
+          { from: 'order completed', to: 'def456' },
+          { from: 'custom event', to: 'ghi789' },
+        ],
+      },
+      { logLevel: 'debug' },
+    );
+    window.__adroll = {
+      record_user: jest.fn(),
+    };
+  });
+
+  test('should track product events', () => {
+    adroll.track({
+      message: {
+        event: 'Product Viewed',
+        properties: {
+          product_id: '123',
+          price: 99.99,
+        },
+      },
+    });
+    expect(window.__adroll.record_user).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adroll_segments: 'abc123',
+        product_id: '123',
+      }),
+    );
+  });
+
+  test('should track order events', () => {
+    adroll.track({
+      message: {
+        event: 'Order Completed',
+        properties: {
+          order_id: 'ORDER123',
+          revenue: 199.99,
+        },
+      },
+    });
+    expect(window.__adroll.record_user).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adroll_segments: 'def456',
+        order_id: 'ORDER123',
+      }),
+    );
+  });
+
+  test('should not track unmapped events', () => {
+    adroll.track({
+      message: {
+        event: 'Unmapped Event',
+        properties: {},
+      },
+    });
+    expect(window.__adroll.record_user).not.toHaveBeenCalled();
+  });
+});
+
+describe('Page tests', () => {
+  let adroll;
+
+  beforeEach(() => {
+    adroll = new Adroll(
+      {
+        advId: 'TEST_ADV_ID',
+        pixId: 'TEST_PIX_ID',
+        eventsMap: [
+          { from: 'Viewed Landing Home Page', to: 'page123' }, // Updated mapping
+        ],
+      },
+      { logLevel: 'debug' },
+    );
+    window.__adroll = {
+      record_user: jest.fn(),
+    };
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/',
+        href: 'https://www.test-host.com/',
+      },
+      writable: true,
+    });
+  });
+
+  test('should track page view with category and name', () => {
+    adroll.page({
+      message: {
+        name: 'Home',
+        category: 'Landing',
+        properties: {},
+      },
+    });
+    expect(window.__adroll.record_user).toHaveBeenCalledWith({
+      name: 'Viewed Landing Home Page',
+      path: '/',
+      url: 'https://www.test-host.com/',
+      adroll_segments: 'page123',
+      referrer: '',
+      search: undefined,
+      title: '',
+    });
+  });
+});

--- a/packages/analytics-js-integrations/src/integrations/Adroll/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Adroll/browser.js
@@ -61,24 +61,24 @@ class Adroll {
     const { userId, event, properties } = message;
     const eventsHashmap = getHashFromArray(this.eventsMap);
     let data;
-    if (eventsHashmap[event.toLowerCase()]) {
+    if (eventsHashmap[event.toString().toLowerCase()]) {
       if (userId) {
         properties.user_id = userId;
       }
-      if (PRODUCT_EVENTS.indexOf(event.toLowerCase()) !== -1) {
+      if (PRODUCT_EVENTS.indexOf(event.toString().toLowerCase()) !== -1) {
         data = productEvent(properties);
-      } else if (ORDER_EVENTS.indexOf(event.toLowerCase()) !== -1) {
+      } else if (ORDER_EVENTS.indexOf(event.toString().toLowerCase()) !== -1) {
         data = orderEvent(properties);
       } else {
         if (properties.revenue) {
           properties.adroll_conversion_value = properties.revenue;
           delete properties.revenue;
         }
-        const segmentId = eventsHashmap[event.toLowerCase()];
+        const segmentId = eventsHashmap[event.toString().toLowerCase()];
         properties.adroll_segments = segmentId;
         data = properties;
       }
-      const segmentId = eventsHashmap[event.toLowerCase()];
+      const segmentId = eventsHashmap[event.toString().toLowerCase()];
       data.adroll_segments = segmentId;
       window.__adroll.record_user(data);
     } else {


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Linear task (optional)

<img width="1728" alt="Screenshot 2024-11-18 at 10 02 22 PM" src="https://github.com/user-attachments/assets/a9e46e60-cd18-47a3-9dbf-697af4a142d5">


https://linear.app/rudderstack/issue/INT-2873/bugsnag-alerts

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced comprehensive unit tests for the `Adroll` integration, covering initialization, loading states, user identification, event tracking, and page tracking.
  
- **Bug Fixes**
	- Improved the `track` method to ensure event variables are processed correctly by converting them to strings before applying transformations.

- **Tests**
	- Added various tests to validate the functionality of the `Adroll` integration, ensuring robust performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->