### PR TITLE
fix: preload events not processed with detached load call

### DIFF
--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -55,27 +55,6 @@ describe('Core - Rudder Analytics Facade', () => {
     ]);
   });
 
-  it('should return an empty array when globalThis.rudderanalytics is not an array', () => {
-    const rudderAnalyticsInstance = new RudderAnalytics();
-    (globalThis as typeof window).rudderanalytics = undefined;
-    const result = rudderAnalyticsInstance.getPreloadedEvents();
-    expect(result).toEqual([]);
-  });
-
-  it('should return buffered events array when globalThis.rudderanalytics is an array', () => {
-    const bufferedEvents = [
-      ['track'],
-      ['consent', { sendPageEvent: true }],
-      ['load', 'dummyWriteKey', 'dummyDataPlaneUrl', { option1: true }],
-      ['consent', { sendPageEvent: false }],
-      ['track'],
-    ];
-    (window as any).rudderanalytics = bufferedEvents;
-    const rudderAnalyticsInstance = new RudderAnalytics();
-    const result = rudderAnalyticsInstance.getPreloadedEvents();
-    expect(result).toEqual(bufferedEvents);
-  });
-
   it('should return the global singleton if it exists', () => {
     const globalSingleton = rudderAnalytics;
     rudderAnalytics = new RudderAnalytics();
@@ -850,7 +829,12 @@ describe('Core - Rudder Analytics Facade', () => {
           enabled: true,
         },
       });
-      expect(rudderAnalyticsInstance.trackPageLifecycleEvents).toHaveBeenCalledWith([], {
+      expect(rudderAnalyticsInstance.trackPageLifecycleEvents).toHaveBeenCalledWith([
+        ['consent', { sendPageEvent: true }],
+        ['consent', { sendPageEvent: false }],
+        ['track'],
+        ['track'],
+      ], {
         autoTrack: {
           enabled: true,
         },

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -31,7 +31,7 @@ import {
   promotePreloadedConsentEventsToTop,
 } from '../components/preloadBuffer';
 import type { PreloadedEventCall } from '../components/preloadBuffer/types';
-import { setExposedGlobal } from '../components/utilities/globals';
+import { getExposedGlobal, setExposedGlobal } from '../components/utilities/globals';
 import type { IAnalytics } from '../components/core/IAnalytics';
 import { Analytics } from '../components/core/Analytics';
 import { defaultLogger } from '../services/Logger/Logger';
@@ -158,7 +158,9 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
       }
 
       this.setDefaultInstanceKey(writeKey);
-      const preloadedEventsArray = this.getPreloadedEvents();
+      // Get the preloaded events array from global buffer instead of window.rudderanalytics
+      // as the constructor must have already pushed the events to the global buffer
+      const preloadedEventsArray = getExposedGlobal(GLOBAL_PRELOAD_BUFFER) as PreloadedEventCall[];
 
       // Track page loaded lifecycle event if enabled
       this.trackPageLifecycleEvents(preloadedEventsArray, loadOptions);
@@ -177,17 +179,6 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
     } catch (error: any) {
       dispatchErrorEvent(error);
     }
-  }
-
-  /**
-   * A function to get preloaded events array from global object
-   * @returns preloaded events array
-   */
-  // eslint-disable-next-line class-methods-use-this
-  getPreloadedEvents() {
-    return Array.isArray((globalThis as typeof window).rudderanalytics)
-      ? ((globalThis as typeof window).rudderanalytics as unknown as PreloadedEventCall[])
-      : ([] as PreloadedEventCall[]);
   }
 
   /**
@@ -298,7 +289,9 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
    * remaining preloaded events array in global object
    */
   triggerBufferedLoadEvent() {
-    const preloadedEventsArray = this.getPreloadedEvents();
+    const preloadedEventsArray = Array.isArray((globalThis as typeof window).rudderanalytics)
+      ? ((globalThis as typeof window).rudderanalytics as unknown as PreloadedEventCall[])
+      : ([] as PreloadedEventCall[]);
 
     // Get any load method call that is buffered if any
     // BTW, load method is also removed from the array
@@ -306,7 +299,7 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
     const loadEvent: PreloadedEventCall = getPreloadedLoadEvent(preloadedEventsArray);
 
     // Set the final preloaded events array in global object
-    setExposedGlobal(GLOBAL_PRELOAD_BUFFER, clone(preloadedEventsArray));
+    setExposedGlobal(GLOBAL_PRELOAD_BUFFER, clone([...preloadedEventsArray]));
 
     // Process load method if present in the buffered requests
     if (loadEvent.length > 0) {

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -176,7 +176,7 @@
           window.manualLoad(
             $('#writeKey').val(),
             $('#dataplaneURL').val(),
-            JSON.parse($('#loadOptions').val() ? $('#loadOptions').val() : {}),
+            JSON.parse($('#loadOptions').val() ? $('#loadOptions').val() : {})
           );
         });
       });

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
@@ -179,7 +179,7 @@
           window.manualLoad(
             $('#writeKey').val(),
             $('#dataplaneURL').val(),
-            JSON.parse($('#loadOptions').val() ? $('#loadOptions').val() : {}),
+            JSON.parse($('#loadOptions').val() ? $('#loadOptions').val() : {})
           );
         });
       });

--- a/packages/sanity-suite/src/ignoredProperties/ignoredProperties.js
+++ b/packages/sanity-suite/src/ignoredProperties/ignoredProperties.js
@@ -150,10 +150,12 @@ const ignoredProperties = [
   {
     key: `message.integrations.Google Analytics 4 (GA4).sessionId`,
     type: 'number',
+    optional: true,
   },
   {
     key: `message.integrations.Google Analytics 4 (GA4).clientId`,
     type: 'string',
+    optional: true,
   },
   {
     key: `message.integrations.Google Analytics 4 (GA4).sessionNumber`,


### PR DESCRIPTION
## PR Description

The auto-tracking page life cycle feature added recently introduced a bug in which the preloaded events were discarded when the `load` call was not part of it.

I've fixed the issue by getting the preloaded events from the globals object instead of `window.rudderanalytics` object in the `load` API.

Additional updates:
- Marked the GA4 properties optional in the sanity suite.
- Fixed the issues in the HTML files that'd prevent them from loading in legacy browsers (IE 11).

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2715/fix-e2e-test-suite-failures

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
