### PR TITLE
chore: add the ability update cache policy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,15 @@ jobs:
 
           aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
+      - name: Determine cache policy based on environment
+        id: cache_policy
+        run: |
+          if [ "${{ inputs.environment }}" == "production" ]; then
+            echo "CACHE_CONTROL=${{ env.CACHE_CONTROL_NO_STORE }}" >> $GITHUB_ENV
+          else
+            echo "CACHE_CONTROL=${{ env.CACHE_CONTROL_MAX_AGE }}" >> $GITHUB_ENV
+          fi
+
       - name: Copy SDK artifacts to S3
         run: |
           core_sdk_path_prefix="packages/analytics-js/dist/cdn"
@@ -133,7 +142,7 @@ jobs:
           plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
           s3_relative_path_prefix="${{ inputs.s3_dir_path }}"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
 
           integration_sdks_zip_file="all_integration_sdks.tar.gz"
           plugins_zip_file="all_plugins.tar.gz"
@@ -275,7 +284,7 @@ jobs:
           core_sdk_path_prefix="packages/analytics-v1.1/dist/cdn"
           integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path_legacy }}"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
 
           aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
           aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,8 +126,9 @@ jobs:
 
           aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
-      - name: Sync files to S3
+      - name: Copy SDK artifacts to S3
         run: |
+          core_sdk_path_prefix="packages/analytics-js/dist/cdn"
           integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
           s3_relative_path_prefix="${{ inputs.s3_dir_path }}"
@@ -155,8 +156,10 @@ jobs:
           mv "$tmp_file" "$plugins_path_prefix/modern/plugins/$plugins_zip_file"
 
           # Upload all the files to S3
-          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/legacy/js-integrations/ $copy_args
+          aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
+          aws s3 cp $core_sdk_path_prefix/modern/iife/ $s3_path_prefix/modern/ $copy_args
 
+          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/legacy/js-integrations/ $copy_args
           aws s3 cp $plugins_path_prefix/modern/plugins/ $s3_path_prefix/modern/plugins/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
@@ -173,26 +176,16 @@ jobs:
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/$integration_sdks_html_file $s3_path_prefix/modern/js-integrations/$integration_sdks_html_file $copy_args
           aws s3 cp $plugins_path_prefix/modern/plugins/$plugins_html_file $s3_path_prefix/modern/plugins/$plugins_html_file $copy_args
 
-      - name: Copy core SDK artifacts to S3
-        run: |
-          core_sdk_path_prefix="packages/analytics-js/dist/cdn"
-          s3_relative_path_prefix="${{ inputs.s3_dir_path }}"
-          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
-
-          # Upload all the files to S3
-          aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
-          aws s3 cp $core_sdk_path_prefix/modern/iife/ $s3_path_prefix/modern/ $copy_args
-
       - name: Invalidate CloudFront cache for all the SDK artifacts
         run: |
           invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ inputs.s3_dir_path }}/*" --query "Invalidation.Id" --output text)
 
           aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
-      - name: Copy SDK dependencies to S3 (versioned directory)
+      - name: Copy SDK artifacts to S3 (versioned directory)
         if: ${{ inputs.environment == 'production' }}
         run: |
+          core_sdk_path_prefix="packages/analytics-js/dist/cdn"
           integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
           s3_relative_path_prefix="${{ env.CURRENT_VERSION_VALUE }}"
@@ -206,8 +199,10 @@ jobs:
           plugins_html_file="list.html"
 
           # Copy all the files to S3
-          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/legacy/js-integrations/ $copy_args
+          aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
+          aws s3 cp $core_sdk_path_prefix/modern/iife/ $s3_path_prefix/modern/ $copy_args
 
+          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/legacy/js-integrations/ $copy_args
           aws s3 cp $plugins_path_prefix/modern/plugins/ $s3_path_prefix/modern/plugins/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
@@ -223,18 +218,6 @@ jobs:
           aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/$integration_sdks_html_file $s3_path_prefix/legacy/js-integrations/$integration_sdks_html_file $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/$integration_sdks_html_file $s3_path_prefix/modern/js-integrations/$integration_sdks_html_file $copy_args
           aws s3 cp $plugins_path_prefix/modern/plugins/$plugins_html_file $s3_path_prefix/modern/plugins/$plugins_html_file $copy_args
-
-      - name: Copy core SDK artifacts to S3 (versioned directory)
-        if: ${{ inputs.environment == 'production' }}
-        run: |
-          core_sdk_path_prefix="packages/analytics-js/dist/cdn"
-          s3_relative_path_prefix="${{ env.CURRENT_VERSION_VALUE }}"
-          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_MAX_AGE }}"
-
-          # Copy all the files to S3
-          aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
-          aws s3 cp $core_sdk_path_prefix/modern/iife/ $s3_path_prefix/modern/ $copy_args
 
       - name: Invalidate CloudFront cache for all the SDK artifacts (versioned directory)
         if: ${{ inputs.environment == 'production' }}
@@ -287,23 +270,18 @@ jobs:
 
       # Below steps are for v1.1 SDK (legacy)
 
-      - name: Copy legacy SDK dependencies to S3
-        run: |
-          integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
-          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path_legacy }}"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
-
-          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
-          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
-
-      - name: Copy core legacy SDK artifacts to S3
+      - name: Copy legacy SDK artifacts to S3
         run: |
           core_sdk_path_prefix="packages/analytics-v1.1/dist/cdn"
+          integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path_legacy }}"
           copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
 
           aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
           aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args
+          
+          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
+          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
       - name: Invalidate CloudFront cache for all the legacy SDK artifacts
         run: |
@@ -311,23 +289,18 @@ jobs:
 
           aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
-      - name: Copy legacy SDK dependencies to S3 (versioned directory)
-        run: |
-          integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
-          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ env.CURRENT_VERSION_V1_VALUE }}"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_MAX_AGE }}"
-
-          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
-          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
-
-      - name: Copy core legacy SDK artifacts to S3 (versioned directory)
+      - name: Copy legacy SDK artifacts to S3 (versioned directory)
         run: |
           core_sdk_path_prefix="packages/analytics-v1.1/dist/cdn"
+          integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ env.CURRENT_VERSION_V1_VALUE }}"
           copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_MAX_AGE }}"
 
           aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
           aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args
+          
+          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
+          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
       - name: Invalidate CloudFront cache for all the legacy SDK artifacts (versioned directory)
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,8 @@ permissions:
 
 env:
   NODE_OPTIONS: "--no-warnings"
-  CACHE_CONTROL: "\"no-store\"" # "\"max-age=3600\""
+  CACHE_CONTROL_NO_STORE: "\"no-store\""
+  CACHE_CONTROL_MAX_AGE: "\"max-age=3600\""
 
 jobs:
   deploy:
@@ -116,7 +117,7 @@ jobs:
       - name: Copy assets to S3
         if: ${{ inputs.environment == 'production' }}
         run: |
-          aws s3 cp assets/integrations/AdobeAnalytics/ s3://${{ secrets.AWS_S3_BUCKET_NAME }}/adobe-analytics-js --recursive --cache-control ${{ env.CACHE_CONTROL }}
+          aws s3 cp assets/integrations/AdobeAnalytics/ s3://${{ secrets.AWS_S3_BUCKET_NAME }}/adobe-analytics-js --recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
 
       - name: Invalidate CloudFront cache for assets
         if: ${{ inputs.environment == 'production' }}
@@ -131,7 +132,7 @@ jobs:
           plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
           s3_relative_path_prefix="${{ inputs.s3_dir_path }}"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
 
           integration_sdks_zip_file="all_integration_sdks.tar.gz"
           plugins_zip_file="all_plugins.tar.gz"
@@ -177,7 +178,7 @@ jobs:
           core_sdk_path_prefix="packages/analytics-js/dist/cdn"
           s3_relative_path_prefix="${{ inputs.s3_dir_path }}"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
 
           # Upload all the files to S3
           aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
@@ -196,7 +197,7 @@ jobs:
           plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
           s3_relative_path_prefix="${{ env.CURRENT_VERSION_VALUE }}"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_MAX_AGE }}"
 
           integration_sdks_zip_file="all_integration_sdks.tar.gz"
           plugins_zip_file="all_plugins.tar.gz"
@@ -229,7 +230,7 @@ jobs:
           core_sdk_path_prefix="packages/analytics-js/dist/cdn"
           s3_relative_path_prefix="${{ env.CURRENT_VERSION_VALUE }}"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_MAX_AGE }}"
 
           # Copy all the files to S3
           aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
@@ -290,7 +291,7 @@ jobs:
         run: |
           integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path_legacy }}"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
 
           aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
@@ -299,7 +300,7 @@ jobs:
         run: |
           core_sdk_path_prefix="packages/analytics-v1.1/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path_legacy }}"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
 
           aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
           aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args
@@ -314,7 +315,7 @@ jobs:
         run: |
           integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ env.CURRENT_VERSION_V1_VALUE }}"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_MAX_AGE }}"
 
           aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
@@ -323,7 +324,7 @@ jobs:
         run: |
           core_sdk_path_prefix="packages/analytics-v1.1/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ env.CURRENT_VERSION_V1_VALUE }}"
-          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL_MAX_AGE }}"
 
           aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
           aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,12 +77,12 @@ jobs:
           echo "Checkout SHA: $sha"
           echo "SHA=$sha" >> $GITHUB_OUTPUT
 
-      - name: Checkout
+      - name: Checkout source code
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.getSHA.outputs.SHA }}
 
-      - name: Get new version number
+      - name: Get new versions
         run: |
           current_version_v1=$(jq -r .version packages/analytics-v1.1/package.json)
           current_version=$(jq -r .version packages/analytics-js/package.json)
@@ -96,7 +96,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Setup workspace
         env:
           HUSKY: 0
           REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/${{ inputs.s3_dir_path }}/modern/plugins'
@@ -105,7 +105,7 @@ jobs:
         run: |
           npm run setup:ci
 
-      - name: Build release artifacts
+      - name: Build artifacts
         env:
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
           BUGSNAG_RELEASE_STAGE: ${{ inputs.bugsnag_release_stage }}
@@ -113,22 +113,24 @@ jobs:
           npm run build:browser
           npm run build:browser:modern
 
-      - name: Sync Adobe Analytics assets to S3
+      - name: Copy assets to S3
         if: ${{ inputs.environment == 'production' }}
         run: |
           aws s3 cp assets/integrations/AdobeAnalytics/ s3://${{ secrets.AWS_S3_BUCKET_NAME }}/adobe-analytics-js --recursive --cache-control ${{ env.CACHE_CONTROL }}
 
-      - name: Create Cloudfront invalidation
+      - name: Invalidate CloudFront cache for assets
         if: ${{ inputs.environment == 'production' }}
         run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/adobe-analytics-js*"
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/adobe-analytics-js*" --query "Invalidation.Id" --output text)
+
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
       - name: Sync files to S3
         run: |
-          core_sdk_path_prefix="packages/analytics-js/dist/cdn"
           integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
-          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path }}"
+          s3_relative_path_prefix="${{ inputs.s3_dir_path }}"
+          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
           copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
 
           integration_sdks_zip_file="all_integration_sdks.tar.gz"
@@ -152,72 +154,93 @@ jobs:
           mv "$tmp_file" "$plugins_path_prefix/modern/plugins/$plugins_zip_file"
 
           # Upload all the files to S3
-          aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/legacy/js-integrations/ $copy_args
 
-          aws s3 cp $core_sdk_path_prefix/modern/iife/ $s3_path_prefix/modern/ $copy_args
           aws s3 cp $plugins_path_prefix/modern/plugins/ $s3_path_prefix/modern/plugins/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
           # Generate the HTML file to list all the integrations
-          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} ${{ inputs.s3_dir_path }}/legacy/js-integrations $integration_sdks_html_file $integration_sdks_path_prefix/legacy/js-integrations "Device Mode Integrations" $integration_sdks_zip_file
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} $s3_relative_path_prefix/legacy/js-integrations $integration_sdks_html_file $integration_sdks_path_prefix/legacy/js-integrations "Device Mode Integrations (Legacy)" $integration_sdks_zip_file
 
-          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} ${{ inputs.s3_dir_path }}/modern/js-integrations $integration_sdks_html_file $integration_sdks_path_prefix/modern/js-integrations "Device Mode Integrations" $integration_sdks_zip_file
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} $s3_relative_path_prefix/modern/js-integrations $integration_sdks_html_file $integration_sdks_path_prefix/modern/js-integrations "Device Mode Integrations (Modern)" $integration_sdks_zip_file
 
           # Generate the HTML file to list all the plugins
-          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} ${{ inputs.s3_dir_path }}/modern/plugins $plugins_html_file $plugins_path_prefix/modern/plugins "Plugins" $plugins_zip_file
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} $s3_relative_path_prefix/modern/plugins $plugins_html_file $plugins_path_prefix/modern/plugins "Plugins" $plugins_zip_file
 
           # Copy the HTML files to S3
-          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/$integration_sdks_html_file $s3_path_prefix/legacy/js-integrations/$integration_sdks_html_file --cache-control ${{ env.CACHE_CONTROL }}
-          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/$integration_sdks_html_file $s3_path_prefix/modern/js-integrations/$integration_sdks_html_file --cache-control ${{ env.CACHE_CONTROL }}
-          aws s3 cp $plugins_path_prefix/modern/plugins/$plugins_html_file $s3_path_prefix/modern/plugins/$plugins_html_file --cache-control ${{ env.CACHE_CONTROL }}
+          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/$integration_sdks_html_file $s3_path_prefix/legacy/js-integrations/$integration_sdks_html_file $copy_args
+          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/$integration_sdks_html_file $s3_path_prefix/modern/js-integrations/$integration_sdks_html_file $copy_args
+          aws s3 cp $plugins_path_prefix/modern/plugins/$plugins_html_file $s3_path_prefix/modern/plugins/$plugins_html_file $copy_args
 
-      - name: Create Cloudfront invalidation
-        run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ inputs.s3_dir_path }}/*"
-
-      - name: Sync files to S3 versioned directory
-        if: ${{ inputs.environment == 'production' }}
+      - name: Copy core SDK artifacts to S3
         run: |
           core_sdk_path_prefix="packages/analytics-js/dist/cdn"
-          integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
-          plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
-          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ env.CURRENT_VERSION_VALUE }}"
+          s3_relative_path_prefix="${{ inputs.s3_dir_path }}"
+          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
           copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
 
+          # Upload all the files to S3
           aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
+          aws s3 cp $core_sdk_path_prefix/modern/iife/ $s3_path_prefix/modern/ $copy_args
+
+      - name: Invalidate CloudFront cache for all the SDK artifacts
+        run: |
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ inputs.s3_dir_path }}/*" --query "Invalidation.Id" --output text)
+
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
+
+      - name: Copy SDK dependencies to S3 (versioned directory)
+        if: ${{ inputs.environment == 'production' }}
+        run: |
+          integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
+          plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
+          s3_relative_path_prefix="${{ env.CURRENT_VERSION_VALUE }}"
+          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+
+          integration_sdks_zip_file="all_integration_sdks.tar.gz"
+          plugins_zip_file="all_plugins.tar.gz"
+
+          integration_sdks_html_file="list.html"
+          plugins_html_file="list.html"
+
+          # Copy all the files to S3
           aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/legacy/js-integrations/ $copy_args
 
-          aws s3 cp $core_sdk_path_prefix/modern/iife/ $s3_path_prefix/modern/ $copy_args
           aws s3 cp $plugins_path_prefix/modern/plugins/ $s3_path_prefix/modern/plugins/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
-      - name: Create Cloudfront invalidation
-        if: ${{ inputs.environment == 'production' }}
-        run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ env.CURRENT_VERSION_VALUE }}/*"
+          # Generate the HTML file to list all the integrations
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} $s3_relative_path_prefix/legacy/js-integrations $integration_sdks_html_file $integration_sdks_path_prefix/legacy/js-integrations "Device Mode Integrations (Legacy)" $integration_sdks_zip_file
 
-      # TODO: The '/latest' directory is unused. Might be removed in future.
-      - name: Sync files to S3 latest
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} $s3_relative_path_prefix/modern/js-integrations $integration_sdks_html_file $integration_sdks_path_prefix/modern/js-integrations "Device Mode Integrations (Modern)" $integration_sdks_zip_file
+
+          # Generate the HTML file to list all the plugins
+          ./scripts/list-sdk-components.sh ${{ secrets.AWS_S3_BUCKET_NAME }} $s3_relative_path_prefix/modern/plugins $plugins_html_file $plugins_path_prefix/modern/plugins "Plugins" $plugins_zip_file
+
+          # Copy all the HTML files to S3
+          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/$integration_sdks_html_file $s3_path_prefix/legacy/js-integrations/$integration_sdks_html_file $copy_args
+          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/$integration_sdks_html_file $s3_path_prefix/modern/js-integrations/$integration_sdks_html_file $copy_args
+          aws s3 cp $plugins_path_prefix/modern/plugins/$plugins_html_file $s3_path_prefix/modern/plugins/$plugins_html_file $copy_args
+
+      - name: Copy core SDK artifacts to S3 (versioned directory)
         if: ${{ inputs.environment == 'production' }}
         run: |
           core_sdk_path_prefix="packages/analytics-js/dist/cdn"
-          integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
-          plugins_path_prefix="packages/analytics-js-plugins/dist/cdn"
-          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/latest"
+          s3_relative_path_prefix="${{ env.CURRENT_VERSION_VALUE }}"
+          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/$s3_relative_path_prefix"
           copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
 
+          # Copy all the files to S3
           aws s3 cp $core_sdk_path_prefix/legacy/iife/ $s3_path_prefix/legacy/ $copy_args
-          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/legacy/js-integrations/ $copy_args
-
           aws s3 cp $core_sdk_path_prefix/modern/iife/ $s3_path_prefix/modern/ $copy_args
-          aws s3 cp $plugins_path_prefix/modern/plugins/ $s3_path_prefix/modern/plugins/ $copy_args
-          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
-      - name: Create Cloudfront invalidation
+      - name: Invalidate CloudFront cache for all the SDK artifacts (versioned directory)
         if: ${{ inputs.environment == 'production' }}
         run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/latest*"
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ env.CURRENT_VERSION_VALUE }}/*" --query "Invalidation.Id" --output text)
+
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
       - name: Send message to Slack channel
         id: slack
@@ -263,57 +286,50 @@ jobs:
 
       # Below steps are for v1.1 SDK (legacy)
 
-      - name: Sync files to S3 v1.1 directory
+      - name: Copy legacy SDK dependencies to S3
         run: |
-          core_sdk_path_prefix="packages/analytics-v1.1/dist/cdn"
           integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path_legacy }}"
           copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
 
-          aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
-
-          aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
-      - name: Create Cloudfront invalidation
-        run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ inputs.s3_dir_path_legacy }}*"
-
-      - name: Sync files to S3 v1.1 versioned directory
-        if: ${{ inputs.environment == 'production' }}
+      - name: Copy core legacy SDK artifacts to S3
         run: |
           core_sdk_path_prefix="packages/analytics-v1.1/dist/cdn"
+          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ inputs.s3_dir_path_legacy }}"
+          copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
+
+          aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
+          aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args
+
+      - name: Invalidate CloudFront cache for all the legacy SDK artifacts
+        run: |
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ inputs.s3_dir_path_legacy }}/*" --query "Invalidation.Id" --output text)
+
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
+
+      - name: Copy legacy SDK dependencies to S3 (versioned directory)
+        run: |
           integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
           s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ env.CURRENT_VERSION_V1_VALUE }}"
           copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
 
-          aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
-
-          aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args
           aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
-      - name: Create Cloudfront invalidation
-        if: ${{ inputs.environment == 'production' }}
-        run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ env.CURRENT_VERSION_V1_VALUE }}*"
-
-      - name: Sync files to S3 latest (v1.1)
-        if: ${{ inputs.environment == 'production' }}
+      - name: Copy core legacy SDK artifacts to S3 (versioned directory)
         run: |
           core_sdk_path_prefix="packages/analytics-v1.1/dist/cdn"
-          integration_sdks_path_prefix="packages/analytics-js-integrations/dist/cdn"
-          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/latest"
+          s3_path_prefix="s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ env.CURRENT_VERSION_V1_VALUE }}"
           copy_args="--recursive --cache-control ${{ env.CACHE_CONTROL }}"
 
           aws s3 cp $core_sdk_path_prefix/legacy/ $s3_path_prefix/ $copy_args
-          aws s3 cp $integration_sdks_path_prefix/legacy/js-integrations/ $s3_path_prefix/js-integrations/ $copy_args
-
           aws s3 cp $core_sdk_path_prefix/modern/ $s3_path_prefix/modern/ $copy_args
-          aws s3 cp $integration_sdks_path_prefix/modern/js-integrations/ $s3_path_prefix/modern/js-integrations/ $copy_args
 
-      - name: Create Cloudfront invalidation
-        if: ${{ inputs.environment == 'production' }}
+      - name: Invalidate CloudFront cache for all the legacy SDK artifacts (versioned directory)
         run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/latest*"
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ env.CURRENT_VERSION_V1_VALUE }}/*" --query "Invalidation.Id" --output text)
+
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -11,10 +11,17 @@ env:
   NODE_OPTIONS: '--no-warnings'
 
 jobs:
+  validate-actor:
+    # Only allow to draft a new release from develop and hotfix branches
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/')
+    uses: ./.github/workflows/validate-actor.yml
+    secrets:
+      PAT: ${{ secrets.PAT }}
+
   draft-new-release:
+    needs: validate-actor
     name: Draft a new release
     runs-on: [self-hosted, Linux, X64]
-    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -4,9 +4,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
-    name: Rollback production deployment
+  validate-actor:
+    # Only allow to be deployed from tags and main branch
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/validate-actor.yml
+    secrets:
+      PAT: ${{ secrets.PAT }}
+
+  deploy:
+    needs: validate-actor
+    name: Rollback production deployment
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'production'

--- a/.github/workflows/update-cache-policy.yml
+++ b/.github/workflows/update-cache-policy.yml
@@ -1,0 +1,83 @@
+name: Update cache control policy
+
+on:
+  workflow_dispatch:
+    inputs:
+      policy_type:
+        type: choice
+        description: Select the cache control policy type
+        required: true
+        options:
+          - no-store
+          - max-age=3600
+
+permissions:
+  id-token: write # allows the JWT to be requested from GitHub's OIDC provider
+  contents: read # This is required for actions/checkout
+
+jobs:
+  validate-actor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate if actor is allowed to trigger the workflow
+        env:
+          ORG_NAME: rudderlabs
+          TEAM_NAME: js-sdk
+        run: |
+          actor=${{ github.actor || github.triggering_actor }}
+          response=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/orgs/${{ env.ORG_NAME }}/teams/${{ env.TEAM_NAME }}/memberships/$actor)
+          
+          if echo "$response" | grep -q '"state": "active"'; then
+            echo "$actor is a member of $TEAM_NAME team"
+          else
+            echo "$actor is NOT a member of $TEAM_NAME team"
+            exit 1
+          fi
+
+  update-cache-policy:
+    needs: validate-actor
+    name: Update cache control policy for SDK artifacts
+    runs-on: [self-hosted, Linux, X64]
+
+    steps:
+      - name: Install AWS CLI
+        uses: unfor19/install-aws-cli-action@master
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_PROD_ACCOUNT_ID }}:role/${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
+          aws-region: us-east-1
+
+      - name: Determine the cache control policy
+        id: determine_policy
+        run: |
+          echo "cache_control_policy=${{ github.event.inputs.policy_type || inputs.policy_type }}" >> $GITHUB_ENV
+
+      - name: Update cache control policy
+        run: |
+          # Get the number of CPU cores in the runner and leave one core free
+          num_cores=$(nproc --ignore=1 || echo 1) # Default to 1 if nproc is unavailable
+          # Use a factor to set the parallel jobs (e.g., number of cores or slightly lower)
+          parallel_jobs=$((num_cores * 2))
+          echo "Detected $num_cores cores. Using $parallel_jobs parallel jobs."
+
+          prefixes=("adobe-analytics-js" "v3" "v1.1")
+          
+          for prefix in "${prefixes[@]}"; do
+            echo "Processing prefix: $prefix"
+            
+            aws s3api list-objects --bucket ${{ secrets.AWS_PROD_S3_BUCKET_NAME }} --prefix "$prefix" --query "Contents[].Key" --output text | tr '\t' '\n' | \
+            parallel --retries 10 -j "$parallel_jobs" "aws s3api copy-object \
+                --bucket ${{ secrets.AWS_PROD_S3_BUCKET_NAME }} \
+                --copy-source ${{ secrets.AWS_PROD_S3_BUCKET_NAME }}/{} \
+                --key {} \
+                --metadata-directive REPLACE \
+                --cache-control '${{ env.cache_control_policy }}'"
+          done
+
+

--- a/.github/workflows/update-cache-policy.yml
+++ b/.github/workflows/update-cache-policy.yml
@@ -17,26 +17,11 @@ permissions:
 
 jobs:
   validate-actor:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate if actor is allowed to trigger the workflow
-        env:
-          ORG_NAME: rudderlabs
-          TEAM_NAME: js-sdk
-        run: |
-          actor=${{ github.actor || github.triggering_actor }}
-          response=$(curl -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PAT }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/${{ env.ORG_NAME }}/teams/${{ env.TEAM_NAME }}/memberships/$actor)
-          
-          if echo "$response" | grep -q '"state": "active"'; then
-            echo "$actor is a member of $TEAM_NAME team"
-          else
-            echo "$actor is NOT a member of $TEAM_NAME team"
-            exit 1
-          fi
+    # Only allow to be deployed from tags and main branch
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/validate-actor.yml
+    secrets:
+      PAT: ${{ secrets.PAT }}
 
   update-cache-policy:
     needs: validate-actor

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -1,0 +1,30 @@
+name: Validate Actor
+
+on:
+  workflow_call:
+    secrets:
+      PAT:
+        required: true
+
+jobs:
+  validate-actor:
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - name: Validate if actor is allowed to trigger the workflow
+        env:
+          ORG_NAME: rudderlabs
+          TEAM_NAME: js-sdk
+        run: |
+          actor=${{ github.actor || github.triggering_actor }}
+          response=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/orgs/${{ env.ORG_NAME }}/teams/${{ env.TEAM_NAME }}/memberships/$actor)
+          
+          if echo "$response" | grep -q '"state": "active"'; then
+            echo "$actor is a member of $TEAM_NAME team"
+          else
+            echo "$actor is NOT a member of $TEAM_NAME team"
+            exit 1
+          fi

--- a/packages/analytics-js-plugins/__tests__/errorReporting/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/errorReporting/index.test.ts
@@ -24,6 +24,14 @@ describe('Plugin - ErrorReporting', () => {
       id: 'test-source-id',
       config: {},
     }),
+    session: {
+      sessionInfo: signal({ id: 'test-session-id' }),
+    },
+    autoTrack: {
+      pageLifecycle: {
+        visitId: signal('test-visit-id'),
+      },
+    },
   };
 
   let state: any;

--- a/packages/analytics-js-plugins/__tests__/errorReporting/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/errorReporting/utils.test.ts
@@ -319,6 +319,14 @@ describe('Error Reporting utilities', () => {
           breadcrumbs: signal([]),
         },
         source: signal({ id: 'sample_source_id' }),
+        session: {
+          sessionInfo: signal({ id: 'test-session-id' }),
+        },
+        autoTrack: {
+          pageLifecycle: {
+            visitId: signal('test-visit-id'),
+          },
+        },
       };
       (window as any).RudderSnippetVersion = 'sample_snippet_version';
       const enhancedError = getBugsnagErrorEvent(errorPayload, errorState, appState);
@@ -392,13 +400,23 @@ describe('Error Reporting utilities', () => {
                 source: {
                   id: 'sample_source_id',
                 },
+                session: {
+                  sessionInfo: {
+                    id: 'test-session-id',
+                  },
+                },
+                autoTrack: {
+                  pageLifecycle: {
+                    visitId: 'test-visit-id',
+                  },
+                },
               },
               source: {
                 snippetVersion: 'sample_snippet_version',
               },
             },
             user: {
-              id: 'sample_source_id',
+              id: 'sample_source_id - test-session-id - test-visit-id',
             },
           },
         ],

--- a/packages/analytics-js-plugins/src/errorReporting/utils.ts
+++ b/packages/analytics-js-plugins/src/errorReporting/utils.ts
@@ -132,7 +132,8 @@ const getBugsnagErrorEvent = (
         },
       },
       user: {
-        id: state.source.value?.id ?? (state.lifecycle.writeKey.value as string),
+        // Combination of source, session and visit ids
+        id: `${state.source.value?.id ?? (state.lifecycle.writeKey.value as string)} - ${state.session.sessionInfo.value?.id ?? 'NA'} - ${state.autoTrack.pageLifecycle.visitId.value ?? 'NA'}`,
       },
     },
   ],


### PR DESCRIPTION
## PR Description

A new workflow has been created to update the cache control policy of AWS S3 artifacts. We'll run the workflow manually before and after the release to ensure the cache control values are properly set.

The sensitive workflows are guarded to be run by users from a specific GitHub team.

Additional updates:
- The user ID field in the Bugsnag error reporting payload is updated to also add session ID and page visit ID.
  - This will help us identify the impacted user sessions.
- The deployment workflow has been improved.
  - Step titles updated to reflect the exact operations.
  - CloudFront cache invalidation requests are awaited to completion.
  - No longer copying files to the `/latest` paths.
  - Cache-control policy is set separately for different paths on S3.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2711/manipulate-cache-control-headers-for-sdk-artifacts-during-releases-to

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
