### PR TITLE
chore: trigger test suites on all deployments

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,3 +26,30 @@ jobs:
       BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
+
+  deploy-sanity-suite:
+    name: Deploy sanity suite
+    needs: deploy
+    uses: ./.github/workflows/deploy-sanity-suite.yml
+    with:
+      environment: 'development'
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_DEV_ACCOUNT_ID }}
+      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_DEV_S3_BUCKET_NAME }}
+      AWS_S3_SYNC_ROLE: ${{ secrets.AWS_DEV_S3_SYNC_ROLE }}
+      AWS_CF_DISTRIBUTION_ID: ${{ secrets.AWS_DEV_CF_DISTRIBUTION_ID }}
+      SANITY_SUITE_WRITE_KEY: ${{ secrets.SANITY_SUITE_DEV_WRITE_KEY }}
+      SANITY_SUITE_DATAPLANE_URL: ${{ secrets.SANITY_SUITE_DEV_DATAPLANE_URL }}
+      SANITY_SUITE_CONFIG_SERVER_HOST: ${{ secrets.SANITY_SUITE_DEV_CONFIG_SERVER_HOST }}
+      BUGSNAG_API_KEY: ${{ secrets.RS_DEV_BUGSNAG_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
+
+  trigger-test-suites:
+    uses: ./.github/workflows/trigger-test-suites.yml
+    name: Trigger test suites
+    needs: deploy-sanity-suite
+    with:
+      environment: development
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,9 +8,21 @@ on:
       - closed
 
 jobs:
+  validate-actor:
+    # Run only for workflow_dispatch events with a merged pull request
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      github.event.pull_request.merged == true
+    uses: ./.github/workflows/validate-actor.yml
+    secrets:
+      PAT: ${{ secrets.PAT }}
+
   deploy:
-    name: Deploy to development environment
-    if: github.event.pull_request.merged == true
+    needs: [validate-actor]
+    name: Deploy to Development Environment
+    if: >
+      (needs.validate-actor.result == 'success' || needs.validate-actor.result == 'skipped') &&
+      github.event.pull_request.merged == true
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'development'

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -18,18 +18,31 @@ on:
         required: true
 
 permissions:
-  id-token: write # allows the JWT to be requested from GitHub's OIDC provider
-  contents: read # This is required for actions/checkout
+  id-token: write # Allows the JWT to be requested from GitHub's OIDC provider
+  contents: read # Required for actions/checkout
 
 env:
   NODE_OPTIONS: '--no-warnings'
 
 jobs:
+  validate-actor:
+    # Run validation for workflow_dispatch with tags
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/validate-actor.yml
+    secrets:
+      PAT: ${{ secrets.PAT }}
+
   deploy:
+    needs: [validate-actor]
     name: Deploy to NPM
-    # As we publish the NPM package with provenance, we need to only use the GitHub hosted runners
+    # As we publish the NPM package with provenance, we must use GitHub-hosted runners
     runs-on: ubuntu-latest
-    if: ${{ inputs.is_called == 'true' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) }}
+    # Deploy if validate-actor was successful or skipped
+    # or if the workflow was invoked by another workflow
+    if: >
+      (needs.validate-actor.result == 'success' || needs.validate-actor.result == 'skipped') || inputs.is_called == 'true'
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,26 +27,26 @@ jobs:
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
 
   deploy-sanity-suite:
-    name: Deploy Sanity Suite
+    name: Deploy sanity suite
     needs: deploy
     uses: ./.github/workflows/deploy-sanity-suite.yml
     with:
       environment: 'production'
     secrets:
-      AWS_PROD_ACCOUNT_ID: ${{ secrets.AWS_PROD_ACCOUNT_ID }}
-      AWS_PROD_S3_BUCKET_NAME: ${{ secrets.AWS_PROD_S3_BUCKET_NAME }}
-      AWS_PROD_S3_SYNC_ROLE: ${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
-      AWS_PROD_CF_DISTRIBUTION_ID: ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}
-      SANITY_SUITE_PROD_WRITE_KEY: ${{ secrets.SANITY_SUITE_PROD_WRITE_KEY }}
-      SANITY_SUITE_PROD_DATAPLANE_URL: ${{ secrets.SANITY_SUITE_PROD_DATAPLANE_URL }}
-      SANITY_SUITE_PROD_CONFIG_SERVER_HOST: ${{ secrets.SANITY_SUITE_PROD_CONFIG_SERVER_HOST }}
-      RS_PROD_BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_PROD_ACCOUNT_ID }}
+      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_PROD_S3_BUCKET_NAME }}
+      AWS_S3_SYNC_ROLE: ${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
+      AWS_CF_DISTRIBUTION_ID: ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}
+      SANITY_SUITE_WRITE_KEY: ${{ secrets.SANITY_SUITE_PROD_WRITE_KEY }}
+      SANITY_SUITE_DATAPLANE_URL: ${{ secrets.SANITY_SUITE_PROD_DATAPLANE_URL }}
+      SANITY_SUITE_CONFIG_SERVER_HOST: ${{ secrets.SANITY_SUITE_PROD_CONFIG_SERVER_HOST }}
+      BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 
-  trigger-sanity-suite:
-    uses: ./.github/workflows/trigger-sanity-suite.yml
-    name: Trigger Sanity Suite
+  trigger-test-suites:
+    uses: ./.github/workflows/trigger-test-suites.yml
+    name: Trigger test suites
     needs: deploy-sanity-suite
     with:
       environment: production

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -7,38 +7,22 @@ on:
         type: string
         required: true
     secrets:
-      AWS_STAGING_ACCOUNT_ID:
-        required: false
-      AWS_PROD_ACCOUNT_ID:
-        required: false
-      AWS_STAGING_S3_BUCKET_NAME:
-        required: false
-      AWS_PROD_S3_BUCKET_NAME:
-        required: false
-      AWS_STAGING_S3_SYNC_ROLE:
-        required: false
-      AWS_PROD_S3_SYNC_ROLE:
-        required: false
-      AWS_STAGING_CF_DISTRIBUTION_ID:
-        required: false
-      AWS_PROD_CF_DISTRIBUTION_ID:
-        required: false
-      SANITY_SUITE_STAGING_WRITE_KEY:
-        required: false
-      SANITY_SUITE_PROD_WRITE_KEY:
-        required: false
-      SANITY_SUITE_STAGING_DATAPLANE_URL:
-        required: false
-      SANITY_SUITE_PROD_DATAPLANE_URL:
-        required: false
-      SANITY_SUITE_STAGING_CONFIG_SERVER_HOST:
-        required: false
-      SANITY_SUITE_PROD_CONFIG_SERVER_HOST:
-        required: false
-      RS_STAGING_BUGSNAG_API_KEY:
-        required: false
-      RS_PROD_BUGSNAG_API_KEY:
-        required: false
+      AWS_ACCOUNT_ID:
+        required: true
+      AWS_S3_BUCKET_NAME:
+        required: true
+      AWS_S3_SYNC_ROLE:
+        required: true
+      AWS_CF_DISTRIBUTION_ID:
+        required: true
+      SANITY_SUITE_WRITE_KEY:
+        required: true
+      SANITY_SUITE_DATAPLANE_URL:
+        required: true
+      SANITY_SUITE_CONFIG_SERVER_HOST:
+        required: true
+      BUGSNAG_API_KEY:
+        required: true
       SLACK_BOT_TOKEN:
         required: true
       SLACK_RELEASE_CHANNEL_ID:
@@ -69,35 +53,17 @@ jobs:
           current_version=$(jq -r .version packages/sanity-suite/package.json)
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "DATE=$(date)" >> $GITHUB_ENV
-
+          echo "BUGSNAG_RELEASE_STAGE=${{ inputs.environment }}" >> $GITHUB_ENV
+          
           if [ "${{ inputs.environment }}" == "staging" ]; then
-            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_STAGING_ACCOUNT_ID }}" >> $GITHUB_ENV
-            echo "AWS_S3_SYNC_ROLE=${{ secrets.AWS_STAGING_S3_SYNC_ROLE }}" >> $GITHUB_ENV
-            echo "AWS_S3_BUCKET_NAME=${{ secrets.AWS_STAGING_S3_BUCKET_NAME }}" >> $GITHUB_ENV
-            echo "AWS_CF_DISTRIBUTION_ID=${{ secrets.AWS_STAGING_CF_DISTRIBUTION_ID }}" >> $GITHUB_ENV
-
-            echo "WRITE_KEY=${{ secrets.SANITY_SUITE_STAGING_WRITE_KEY }}" >> $GITHUB_ENV
-            echo "DATAPLANE_URL=${{ secrets.SANITY_SUITE_STAGING_DATAPLANE_URL }}" >> $GITHUB_ENV
-            echo "CONFIG_SERVER_HOST=${{ secrets.SANITY_SUITE_STAGING_CONFIG_SERVER_HOST }}" >> $GITHUB_ENV
-            echo "BUGSNAG_API_KEY=${{ secrets.RS_STAGING_BUGSNAG_API_KEY }}" >> $GITHUB_ENV
-            echo "BUGSNAG_RELEASE_STAGE=staging" >> $GITHUB_ENV
-
             echo "SDK_CDN_VERSION_PATH_PREFIX=staging/latest/" >> $GITHUB_ENV
             echo "SUITE_CDN_PATH=/staging/" >> $GITHUB_ENV
           elif [ "${{ inputs.environment }}" == "production" ]; then
-            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_PROD_ACCOUNT_ID }}" >> $GITHUB_ENV
-            echo "AWS_S3_SYNC_ROLE=${{ secrets.AWS_PROD_S3_SYNC_ROLE }}" >> $GITHUB_ENV
-            echo "AWS_S3_BUCKET_NAME=${{ secrets.AWS_PROD_S3_BUCKET_NAME }}" >> $GITHUB_ENV
-            echo "AWS_CF_DISTRIBUTION_ID=${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}" >> $GITHUB_ENV
-
-            echo "WRITE_KEY=${{ secrets.SANITY_SUITE_PROD_WRITE_KEY }}" >> $GITHUB_ENV
-            echo "DATAPLANE_URL=${{ secrets.SANITY_SUITE_PROD_DATAPLANE_URL }}" >> $GITHUB_ENV
-            echo "CONFIG_SERVER_HOST=${{ secrets.SANITY_SUITE_PROD_CONFIG_SERVER_HOST }}" >> $GITHUB_ENV
-            echo "BUGSNAG_API_KEY=${{ secrets.RS_PROD_BUGSNAG_API_KEY }}" >> $GITHUB_ENV
-            echo "BUGSNAG_RELEASE_STAGE=production" >> $GITHUB_ENV
-
             echo "SDK_CDN_VERSION_PATH_PREFIX=" >> $GITHUB_ENV
             echo "SUITE_CDN_PATH=/" >> $GITHUB_ENV
+          else
+            echo "SDK_CDN_VERSION_PATH_PREFIX=dev/latest/" >> $GITHUB_ENV
+            echo "SUITE_CDN_PATH=/dev/" >> $GITHUB_ENV
           fi
 
       - name: Install AWS CLI
@@ -106,7 +72,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.AWS_S3_SYNC_ROLE }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_S3_SYNC_ROLE }}
           aws-region: us-east-1
 
       - name: Setup Node
@@ -123,10 +89,10 @@ jobs:
 
       - name: Build artifacts
         env:
-          WRITE_KEY: ${{ env.WRITE_KEY }}
-          DATAPLANE_URL: ${{ env.DATAPLANE_URL }}
-          CONFIG_SERVER_HOST: ${{ env.CONFIG_SERVER_HOST }}
-          BUGSNAG_API_KEY: ${{ env.BUGSNAG_API_KEY }}
+          WRITE_KEY: ${{ secrets.SANITY_SUITE_WRITE_KEY }}
+          DATAPLANE_URL: ${{ secrets.SANITY_SUITE_DATAPLANE_URL }}
+          CONFIG_SERVER_HOST: ${{ secrets.SANITY_SUITE_CONFIG_SERVER_HOST }}
+          BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
           BUGSNAG_RELEASE_STAGE: ${{ env.BUGSNAG_RELEASE_STAGE }}
           SDK_CDN_VERSION_PATH_PREFIX: ${{ env.SDK_CDN_VERSION_PATH_PREFIX }}
           HUSKY: 0
@@ -135,11 +101,11 @@ jobs:
 
       - name: Sync files to S3
         run: |
-          aws s3 cp packages/sanity-suite/dist/ s3://${{ env.AWS_S3_BUCKET_NAME }}/sanity-suite${{ env.SUITE_CDN_PATH }} --recursive --cache-control ${{ env.CACHE_CONTROL }}
+          aws s3 cp packages/sanity-suite/dist/ s3://${{ secrets.AWS_S3_BUCKET_NAME }}/sanity-suite${{ env.SUITE_CDN_PATH }} --recursive --cache-control ${{ env.CACHE_CONTROL }}
 
       - name: Create Cloudfront invalidation
         run: |
-          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --paths "/sanity-suite${{ env.SUITE_CDN_PATH }}*"
+          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/sanity-suite${{ env.SUITE_CDN_PATH }}*"
 
       - name: Send message to Slack channel
         id: slack
@@ -149,7 +115,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'Sanity suite - ${{ inputs.environment }}'
           CDN_URL: 'https://cdn.rudderlabs.com/sanity-suite${{ env.SUITE_CDN_PATH }}v3/cdn/index.html'
-          LINK_TEXT: ${{ ((inputs.environment == 'staging' && format('v{0} - Staging', env.CURRENT_VERSION_VALUE)) || format('v{0}', env.CURRENT_VERSION_VALUE)) }}
+          LINK_TEXT: ${{ ((inputs.environment == 'development' && format('v{0} - Development', env.CURRENT_VERSION_VALUE)) || (inputs.environment == 'staging' && format('v{0} - Staging', env.CURRENT_VERSION_VALUE)) || format('v{0}', env.CURRENT_VERSION_VALUE)) }}
         with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,11 +10,28 @@ on:
       - reopened
 
 jobs:
+  validate-actor:
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      (
+        startsWith(github.ref, 'refs/tags/v') ||
+        startsWith(github.head_ref, 'hotfix-release/') ||
+        startsWith(github.head_ref, 'release/')
+      )
+    uses: ./.github/workflows/validate-actor.yml
+    secrets:
+      PAT: ${{ secrets.PAT }}
+
   deploy:
+    needs: [validate-actor]
     name: Deploy to staging environment
-    # Only manually run the workflow for tags
-    # and PRs raised from release branches to main
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'hotfix-release/') || startsWith(github.head_ref, 'release/')
+    if: >
+      (needs.validate-actor.result == 'success' || needs.validate-actor.result == 'skipped') &&
+      (
+        startsWith(github.ref, 'refs/tags/v') ||
+        startsWith(github.head_ref, 'hotfix-release/') ||
+        startsWith(github.head_ref, 'release/')
+      )
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'staging'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -38,21 +38,21 @@ jobs:
     with:
       environment: 'staging'
     secrets:
-      AWS_STAGING_ACCOUNT_ID: ${{ secrets.AWS_STAGING_ACCOUNT_ID }}
-      AWS_STAGING_S3_BUCKET_NAME: ${{ secrets.AWS_STAGING_S3_BUCKET_NAME }}
-      AWS_STAGING_S3_SYNC_ROLE: ${{ secrets.AWS_STAGING_S3_SYNC_ROLE }}
-      AWS_STAGING_CF_DISTRIBUTION_ID: ${{ secrets.AWS_STAGING_CF_DISTRIBUTION_ID }}
-      SANITY_SUITE_STAGING_WRITE_KEY: ${{ secrets.SANITY_SUITE_STAGING_WRITE_KEY }}
-      SANITY_SUITE_STAGING_DATAPLANE_URL: ${{ secrets.SANITY_SUITE_STAGING_DATAPLANE_URL }}
-      SANITY_SUITE_STAGING_CONFIG_SERVER_HOST: ${{ secrets.SANITY_SUITE_STAGING_CONFIG_SERVER_HOST }}
-      RS_STAGING_BUGSNAG_API_KEY: ${{ secrets.RS_STAGING_BUGSNAG_API_KEY }}
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_STAGING_ACCOUNT_ID }}
+      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_STAGING_S3_BUCKET_NAME }}
+      AWS_S3_SYNC_ROLE: ${{ secrets.AWS_STAGING_S3_SYNC_ROLE }}
+      AWS_CF_DISTRIBUTION_ID: ${{ secrets.AWS_STAGING_CF_DISTRIBUTION_ID }}
+      SANITY_SUITE_WRITE_KEY: ${{ secrets.SANITY_SUITE_STAGING_WRITE_KEY }}
+      SANITY_SUITE_DATAPLANE_URL: ${{ secrets.SANITY_SUITE_STAGING_DATAPLANE_URL }}
+      SANITY_SUITE_CONFIG_SERVER_HOST: ${{ secrets.SANITY_SUITE_STAGING_CONFIG_SERVER_HOST }}
+      BUGSNAG_API_KEY: ${{ secrets.RS_STAGING_BUGSNAG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 
   trigger-sanity-suite:
-    uses: ./.github/workflows/trigger-sanity-suite.yml
+    uses: ./.github/workflows/trigger-test-suites.yml
     needs: deploy-sanity-suite
-    name: Trigger Sanity Suite
+    name: Trigger test suites
     with:
       environment: staging
     secrets:

--- a/.github/workflows/trigger-test-suites.yml
+++ b/.github/workflows/trigger-test-suites.yml
@@ -48,12 +48,15 @@ jobs:
 
     steps:
       - name: Trigger sanity test suite workflow
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
-          curl -X POST \
-          -H "Authorization: Bearer ${{ secrets.PAT }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/rudderlabs/rudder-client-side-test/actions/workflows/sdk-team-js-sanity-suite.yaml/dispatches \
-          -d '{"inputs": {"environment": "${{ inputs.environment }}", "monorepoVersion": "${{ needs.extract-monorepo-version.outputs.version }}"}}'
+          gh api \
+            -X POST \
+            "/repos/rudderlabs/rudder-client-side-test/actions/workflows/sdk-team-js-sanity-suite.yaml/dispatches" \
+            -f ref=main \
+            -F inputs.environment=${{ inputs.environment }} \
+            -F inputs.monorepo_version=${{ needs.extract-monorepo-version.outputs.version }}
 
   trigger-e2e-test-suite:
     runs-on: [self-hosted, Linux, X64]
@@ -61,9 +64,12 @@ jobs:
 
     steps:
       - name: Trigger E2E test suite workflow
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
-          curl -X POST \
-          -H "Authorization: Bearer ${{ secrets.PAT }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/rudderlabs/rudder-client-side-test/actions/workflows/sdk-team-js-regression.yaml/dispatches \
-          -d '{"inputs": {"environment": "${{ inputs.environment }}", "monorepoVersion": "${{ needs.extract-monorepo-version.outputs.version }}"}}'
+          gh api \
+            -X POST \
+            "/repos/rudderlabs/rudder-client-side-test/actions/workflows/sdk-team-js-regression.yaml/dispatches" \
+            -f ref=main \
+            -F inputs.environment=${{ inputs.environment }} \
+            -F inputs.monorepo_version=${{ needs.extract-monorepo-version.outputs.version }}

--- a/.github/workflows/trigger-test-suites.yml
+++ b/.github/workflows/trigger-test-suites.yml
@@ -1,17 +1,6 @@
-name: Run sanity suite on BrowserStack
+name: Trigger Sanity Test Suites
 
 on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        type: choice
-        description: Select specific environment to run the tests
-        options:
-          - staging
-          - production
-      monorepoVersion:
-        description: Version of the Monorepo
-        required: true
   workflow_call:
     inputs:
       environment:
@@ -25,7 +14,7 @@ on:
 jobs:
   extract-monorepo-version:
     name: Extract Monorepo Version
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     outputs:
       version: ${{ steps.determine_version.outputs.current_version }}
@@ -34,7 +23,7 @@ jobs:
       - name: Determine checkout SHA
         id: getSHA
         run: |
-          if [ "${{ github.event.inputs.environment || inputs.environment }}" = 'staging' ]; then
+          if [ "${{ inputs.environment }}" = 'staging' ]; then
             sha=${{ github.event.pull_request.head.sha }}
           else
             sha=${{ github.sha }}
@@ -50,22 +39,31 @@ jobs:
       - name: Determine the Monorepo version
         id: determine_version
         run: |
-          if [ -n "${{ github.event.inputs.monorepoVersion }}" ]; then
-            current_version="${{ github.event.inputs.monorepoVersion }}"
-          else
-            current_version=$(jq -r .version package.json)
-          fi
+          current_version=$(jq -r .version package.json)
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
 
-  trigger:
+  trigger-sanity-test-suite:
     runs-on: [self-hosted, Linux, X64]
     needs: extract-monorepo-version
 
     steps:
-      - name: Trigger sanity suite test workflow on rudder-client-side-test
+      - name: Trigger sanity test suite workflow
         run: |
           curl -X POST \
           -H "Authorization: Bearer ${{ secrets.PAT }}" \
           -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/rudderlabs/rudder-client-side-test/dispatches \
-          -d '{"event_type":"triggered_by_source_repo", "client_payload": {"environment": "${{ github.event.inputs.environment || inputs.environment }}", "monorepoVersion": "${{ needs.extract-monorepo-version.outputs.version }}"}}'
+          https://api.github.com/repos/rudderlabs/rudder-client-side-test/actions/workflows/sdk-team-js-sanity-suite.yaml/dispatches \
+          -d '{"inputs": {"environment": "${{ inputs.environment }}", "monorepoVersion": "${{ needs.extract-monorepo-version.outputs.version }}"}}'
+
+  trigger-e2e-test-suite:
+    runs-on: [self-hosted, Linux, X64]
+    needs: extract-monorepo-version
+
+    steps:
+      - name: Trigger E2E test suite workflow
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.PAT }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/rudderlabs/rudder-client-side-test/actions/workflows/sdk-team-js-regression.yaml/dispatches \
+          -d '{"inputs": {"environment": "${{ inputs.environment }}", "monorepoVersion": "${{ needs.extract-monorepo-version.outputs.version }}"}}'

--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -1,7 +1,6 @@
 name: Unit Tests and Lint
 
 on:
-  workflow_dispatch:
   push:
     branches: ['main', 'develop']
   pull_request:

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -14,17 +14,24 @@ jobs:
         env:
           ORG_NAME: rudderlabs
           TEAM_NAME: js-sdk
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           actor=${{ github.actor || github.triggering_actor }}
-          response=$(curl -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PAT }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/${{ env.ORG_NAME }}/teams/${{ env.TEAM_NAME }}/memberships/$actor)
           
-          if echo "$response" | grep -q '"state": "active"'; then
-            echo "$actor is a member of $TEAM_NAME team"
-          else
-            echo "$actor is NOT a member of $TEAM_NAME team"
+          # Use gh api to fetch the membership details
+          response=$(gh api "/orgs/$ORG_NAME/teams/$TEAM_NAME/memberships/$actor" -H "X-GitHub-Api-Version: 2022-11-28" 2>/dev/null || echo "error")
+          
+          # Check if API request failed
+          if [ "$response" = "error" ]; then
+            echo "Error: Unable to fetch membership details for '$actor'."
             exit 1
           fi
+
+          # Extract the state of the membership
+          if echo "$response" | grep -q '"state": "active"'; then
+            echo "'$actor' is a member of '@${ORG_NAME}/${TEAM_NAME}' team"
+          else
+            echo "Error: '$actor' is NOT a member of '@${ORG_NAME}/${TEAM_NAME}' team. Access denied."
+            exit 1
+          fi
+


### PR DESCRIPTION
## PR Description

Along with the sanity test suite, we're now triggering the full E2E test suite for deployments to all environments.

The sanity suite deployment workflow has been refactored to accommodate all environments.

Moreover, the external workflow trigger method has been revamped as per the changes in this PR, https://github.com/rudderlabs/rudder-client-side-test/pull/389

Additionally, I've refactored other workflows to validate action in case of manual triggers. The validation also uses GH API instead of curl requests.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2824/run-e2e-test-suite-pre-and-post-release

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
