### PR TITLE
chore: fix sonarqube scan

### DIFF
--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           HUSKY: 0
         run: |
-          npm run setup:ci
+          npm run setup:deps
 
       - name: Check for affected projects
         id: check_affected
@@ -61,8 +61,8 @@ jobs:
         run: |
           ./scripts/fix-reports-path-in-github-runner.sh
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "setup": "npm i --include=optional && npm run build:package:modern",
     "setup:ci": "npm ci && npm i @nx/nx-linux-x64-gnu && npm run build:package:modern",
+    "setup:deps": "npm ci && npm i @nx/nx-linux-x64-gnu",
     "clean": "nx run-many -t clean && nx reset && git clean -xdf node_modules",
     "clean:cache": "rimraf -rf ./node_modules/.cache && rimraf -rf ./.nx/cache",
     "start": "nx run-many --targets=start --parallel=3 --projects=@rudderstack/analytics-js-integrations,@rudderstack/analytics-js-plugins,@rudderstack/analytics-js",

--- a/scripts/fix-reports-path-in-github-runner.sh
+++ b/scripts/fix-reports-path-in-github-runner.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Path variables
-defaultPrefixToReplace="/github/workspace"
-defaultAbsolutePathPrefix="home/runner/work/rudder-sdk-js/rudder-sdk-js"
-selfHostedAbsolutePathPrefix="runner/_work/rudder-sdk-js/rudder-sdk-js"
+defaultPrefixToReplace=""
+defaultAbsolutePathPrefix="home/runner/work/rudder-sdk-js/rudder-sdk-js/"
+selfHostedAbsolutePathPrefix="runner/_work/rudder-sdk-js/rudder-sdk-js/"
 absolutePathPrefix="$selfHostedAbsolutePathPrefix"
 # List of package folders
 projectFolderNames=("analytics-js" "analytics-js-common" "analytics-js-integrations" "analytics-js-plugins" "analytics-js-service-worker" "analytics-v1.1" "analytics-js-cookies")


### PR DESCRIPTION
## PR Description

I've used the latest SonarQube action in the workflow as suggested by Sonar.
Also, paths in the reports are fixed per the latest action.

Additionally, optimised the tests workflow by not building the packages.

The warning we used to get in the workflows:
```
[SonarScanner](https://github.com/rudderlabs/rudder-sdk-js/actions/runs/12595041635/job/35103551750#step:11:30)
This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.
```

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2826/move-error-reporting-functionality-to-the-core-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated path variables in GitHub runner script to improve path handling and replacement logic
	- Modified path prefix configurations to include trailing slashes for more consistent path management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->