### PR TITLE
fix: data plane events buffer on load option flag

### DIFF
--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -291,11 +291,24 @@ class Analytics implements IAnalytics {
       }
     }
 
+    // Set in state the desired activeDestinations to inject in DOM
+    this.setActiveDestinations();
+
     // Initialize event manager
     this.eventManager?.init();
 
     // Mark the SDK as initialized
     state.lifecycle.status.value = 'initialized';
+  }
+
+  private setActiveDestinations() {
+    this.pluginsManager?.invokeSingle(
+      'nativeDestinations.setActiveDestinations',
+      state,
+      this.pluginsManager,
+      this.errorHandler,
+      this.logger,
+    );
   }
 
   /**
@@ -383,14 +396,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    // Set in state the desired activeDestinations to inject in DOM
-    this.pluginsManager?.invokeSingle(
-      'nativeDestinations.setActiveDestinations',
-      state,
-      this.pluginsManager,
-      this.errorHandler,
-      this.logger,
-    );
+    this.setActiveDestinations();
 
     const totalDestinationsToLoad = state.nativeDestinations.activeDestinations.value.length;
     if (totalDestinationsToLoad === 0) {

--- a/packages/analytics-js/src/components/eventRepository/EventRepository.ts
+++ b/packages/analytics-js/src/components/eventRepository/EventRepository.ts
@@ -116,24 +116,25 @@ class EventRepository implements IEventRepository {
     });
 
     const bufferEventsBeforeConsent = shouldBufferEventsForPreConsent(state);
+    if (!bufferEventsBeforeConsent) {
+      this.startDpEventsQueue();
+    }
+  }
 
-    // Start the queue processing only when the destinations are ready or hybrid mode destinations exist
-    // However, events will be enqueued for now.
-    // At the time of processing the events, the integrations config data from destinations
-    // is merged into the event object
+  private startDpEventsQueue() {
+    const bufferEventsUntilReady = state.loadOptions.value
+      .bufferDataPlaneEventsUntilReady as boolean;
+    const hybridDestExist = state.nativeDestinations.activeDestinations.value.some(
+      (dest: Destination) => isHybridModeDestination(dest),
+    );
+    const shouldBufferDpEvents = bufferEventsUntilReady && hybridDestExist;
+
     let timeoutId: number;
+    // Start the queue when no event buffering is required
+    // or when the client destinations are ready
     effect(() => {
-      const shouldBufferDpEvents =
-        state.loadOptions.value.bufferDataPlaneEventsUntilReady === true &&
-        state.nativeDestinations.clientDestinationsReady.value === false;
-
-      const hybridDestExist = state.nativeDestinations.activeDestinations.value.some(
-        (dest: Destination) => isHybridModeDestination(dest),
-      );
-
       if (
-        (hybridDestExist === false || shouldBufferDpEvents === false) &&
-        !bufferEventsBeforeConsent &&
+        (!shouldBufferDpEvents || state.nativeDestinations.clientDestinationsReady.value) &&
         this.dataplaneEventsQueue?.scheduleTimeoutActive !== true
       ) {
         (globalThis as typeof window).clearTimeout(timeoutId);
@@ -142,7 +143,7 @@ class EventRepository implements IEventRepository {
     });
 
     // Force start the data plane events queue processing after a timeout
-    if (state.loadOptions.value.bufferDataPlaneEventsUntilReady === true) {
+    if (shouldBufferDpEvents) {
       timeoutId = (globalThis as typeof window).setTimeout(() => {
         if (this.dataplaneEventsQueue?.scheduleTimeoutActive !== true) {
           this.dataplaneEventsQueue?.start();
@@ -152,14 +153,15 @@ class EventRepository implements IEventRepository {
   }
 
   resume() {
-    if (this.dataplaneEventsQueue?.scheduleTimeoutActive !== true) {
-      if (state.consents.postConsent.value.discardPreConsentEvents) {
-        this.dataplaneEventsQueue?.clear();
-        this.destinationsEventsQueue?.clear();
-      }
-
-      this.dataplaneEventsQueue?.start();
+    if (
+      this.dataplaneEventsQueue?.scheduleTimeoutActive !== true &&
+      state.consents.postConsent.value.discardPreConsentEvents
+    ) {
+      this.dataplaneEventsQueue?.clear();
+      this.destinationsEventsQueue?.clear();
     }
+
+    this.startDpEventsQueue();
   }
 
   /**


### PR DESCRIPTION
## PR Description

Please include a summary of the change along with the relevant motivation and context.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2862/buffer-data-plane-events-until-ready

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
