### PR TITLE
Fix typo

### DIFF
--- a/examples/serverless/USAGE.md
+++ b/examples/serverless/USAGE.md
@@ -77,7 +77,7 @@ You can then utilise the RudderStack JS SDK within the fetch methods as usual:
       }
     });
 
-See relevant [example](https://github.com/rudderlabs/rudder-sdk-js/blob/main/examples/serverless/vencel-edge)
+See relevant [example](https://github.com/rudderlabs/rudder-sdk-js/blob/main/examples/serverless/vercel-edge)
 
 ## External resources
 


### PR DESCRIPTION
## PR Description

Typo on docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typo in the Vercel Edge example URL in the usage documentation to ensure users can correctly access the referenced example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->