### PR TITLE
feat: improve error report payload

### DIFF
--- a/packages/analytics-js-common/src/types/Metrics.ts
+++ b/packages/analytics-js-common/src/types/Metrics.ts
@@ -15,6 +15,7 @@ export type MetricServicePayload = {
 
 // https://bugsnagerrorreportingapi.docs.apiary.io/#reference/0/notify/send-error-reports
 export type ErrorEventPayload = {
+  payloadVersion: string;
   notifier: {
     name: string;
     version: string;
@@ -24,7 +25,6 @@ export type ErrorEventPayload = {
 };
 
 export type ErrorEvent = Pick<Event, 'severity' | 'app' | 'device' | 'request' | 'context'> & {
-  payloadVersion: string;
   exceptions: Exception[];
   unhandled: boolean;
   severityReason: { type: string };

--- a/packages/analytics-js-common/src/types/Source.ts
+++ b/packages/analytics-js-common/src/types/Source.ts
@@ -15,5 +15,6 @@ export type SourceConfig = {
 export type Source = {
   id: string;
   config?: SourceConfig;
+  name: string;
   workspaceId: string;
 };

--- a/packages/analytics-js/__tests__/components/configManager/ConfigManager.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/ConfigManager.test.ts
@@ -151,6 +151,7 @@ describe('ConfigManager', () => {
     const expectedSourceState = {
       id: dummySourceConfigResponse.source.id,
       config: dummySourceConfigResponse.source.config,
+      name: dummySourceConfigResponse.source.name,
       workspaceId: dummySourceConfigResponse.source.workspaceId,
     };
     state.lifecycle.dataPlaneUrl.value = sampleDataPlaneUrl;

--- a/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable max-classes-per-file */
 import { signal } from '@preact/signals-core';
 import type { ErrorEventPayload, Exception } from '@rudderstack/analytics-js-common/types/Metrics';
+import type { Event } from '@bugsnag/js';
 import { state, resetState } from '../../../src/state';
 import * as errorReportingConstants from '../../../src/services/ErrorHandler/constants';
 import {
@@ -312,7 +313,7 @@ describe('Error Reporting utilities', () => {
       };
 
       const errorState = {
-        severity: 'error',
+        severity: 'error' as Event['severity'],
         unhandled: false,
         severityReason: { type: 'handledException' },
       };
@@ -334,6 +335,7 @@ describe('Error Reporting utilities', () => {
       const bsErrorEvent = getBugsnagErrorEvent(exception, errorState, state);
 
       const expectedOutcome = {
+        payloadVersion: '5',
         notifier: {
           name: 'RudderStack JavaScript SDK',
           version: '__PACKAGE_VERSION__',
@@ -358,13 +360,13 @@ describe('Error Reporting utilities', () => {
             ],
             severity: 'error',
             unhandled: false,
-            payloadVersion: '5',
             severityReason: {
               type: 'handledException',
             },
             app: {
               version: '__PACKAGE_VERSION__',
               releaseStage: 'development',
+              type: 'cdn',
             },
             device: {
               locale: 'en-US',
@@ -392,186 +394,187 @@ describe('Error Reporting utilities', () => {
             ],
             context: 'dummy message',
             metaData: {
-              sdk: {
-                name: 'JS',
-                installType: 'cdn',
+              app: {
+                snippetVersion: 'sample_snippet_version',
               },
-              source: {
-                snippetVersion: undefined,
+              device: {
+                density: 1,
+                width: 2,
+                height: 3,
+                innerWidth: 4,
+                innerHeight: 5,
               },
-              state: {
-                autoTrack: {
+              autoTrack: {
+                enabled: false,
+                pageLifecycle: {
                   enabled: false,
-                  pageLifecycle: {
-                    enabled: false,
-                    visitId: 'test-visit-id',
-                  },
+                  visitId: 'test-visit-id',
                 },
-                capabilities: {
-                  isAdBlocked: false,
-                  isBeaconAvailable: false,
-                  isCryptoAvailable: false,
-                  isIE11: false,
-                  isLegacyDOM: false,
-                  isOnline: true,
-                  isUaCHAvailable: false,
-                  storage: {
-                    isCookieStorageAvailable: false,
-                    isLocalStorageAvailable: false,
-                    isSessionStorageAvailable: false,
-                  },
+              },
+              capabilities: {
+                isAdBlocked: false,
+                isBeaconAvailable: false,
+                isCryptoAvailable: false,
+                isIE11: false,
+                isLegacyDOM: false,
+                isOnline: true,
+                isUaCHAvailable: false,
+                storage: {
+                  isCookieStorageAvailable: false,
+                  isLocalStorageAvailable: false,
+                  isSessionStorageAvailable: false,
                 },
-                consents: {
-                  data: {},
+              },
+              consents: {
+                data: {},
+                enabled: false,
+                initialized: false,
+                postConsent: {},
+                preConsent: {
                   enabled: false,
-                  initialized: false,
-                  postConsent: {},
-                  preConsent: {
-                    enabled: false,
-                  },
-                  resolutionStrategy: 'and',
                 },
-                context: {
-                  app: {
-                    installType: 'cdn',
-                    name: 'RudderLabs JavaScript SDK',
-                    namespace: 'com.rudderlabs.javascript',
-                    version: '__PACKAGE_VERSION__',
-                  },
-                  device: null,
-                  library: {
-                    name: 'RudderLabs JavaScript SDK',
-                    snippetVersion: 'sample_snippet_version',
-                    version: '__PACKAGE_VERSION__',
-                  },
-                  locale: 'en-US',
-                  network: null,
-                  os: {
-                    name: '',
-                    version: '',
-                  },
-                  screen: {
-                    density: 1,
-                    height: 3,
-                    innerHeight: 5,
-                    innerWidth: 4,
-                    width: 2,
-                  },
-                  userAgent:
-                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+                resolutionStrategy: 'and',
+              },
+              context: {
+                app: {
+                  installType: 'cdn',
+                  name: 'RudderLabs JavaScript SDK',
+                  namespace: 'com.rudderlabs.javascript',
+                  version: '__PACKAGE_VERSION__',
                 },
-                dataPlaneEvents: {
-                  deliveryEnabled: true,
+                device: null,
+                library: {
+                  name: 'RudderLabs JavaScript SDK',
+                  snippetVersion: 'sample_snippet_version',
+                  version: '__PACKAGE_VERSION__',
                 },
-                lifecycle: {
-                  initialized: false,
-                  integrationsCDNPath: 'https://cdn.rudderlabs.com/v3/modern/js-integrations',
-                  pluginsCDNPath: 'https://cdn.rudderlabs.com/v3/modern/plugins',
-                  loaded: false,
-                  logLevel: 'ERROR',
-                  readyCallbacks: [],
+                locale: 'en-US',
+                network: null,
+                os: {
+                  name: '',
+                  version: '',
                 },
-                loadOptions: {
-                  beaconQueueOptions: {},
-                  bufferDataPlaneEventsUntilReady: false,
-                  configUrl: 'https://api.rudderstack.com',
-                  dataPlaneEventsBufferTimeout: 10000,
-                  destinationsQueueOptions: {},
-                  integrations: {
-                    All: true,
-                  },
-                  loadIntegration: true,
-                  lockIntegrationsVersion: false,
-                  lockPluginsVersion: false,
-                  logLevel: 'ERROR',
-                  plugins: [],
-                  polyfillIfRequired: true,
-                  queueOptions: {},
-                  sameSiteCookie: 'Lax',
-                  sendAdblockPageOptions: {},
-                  sessions: {
-                    autoTrack: true,
-                    timeout: 1800000,
-                  },
-                  storage: {
-                    cookie: {},
-                    encryption: {
-                      version: 'v3',
-                    },
-                    migrate: true,
-                  },
-                  uaChTrackLevel: 'none',
-                  useBeacon: false,
-                  useGlobalIntegrationsConfigInEvents: false,
-                  useServerSideCookies: false,
+                screen: {
+                  density: 1,
+                  height: 3,
+                  innerHeight: 5,
+                  innerWidth: 4,
+                  width: 2,
                 },
-                metrics: {
-                  dropped: 0,
-                  queued: 0,
-                  retries: 0,
-                  sent: 0,
-                  triggered: 0,
+                userAgent:
+                  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+              },
+              dataPlaneEvents: {
+                deliveryEnabled: true,
+              },
+              lifecycle: {
+                initialized: false,
+                integrationsCDNPath: 'https://cdn.rudderlabs.com/v3/modern/js-integrations',
+                pluginsCDNPath: 'https://cdn.rudderlabs.com/v3/modern/plugins',
+                loaded: false,
+                logLevel: 'ERROR',
+                readyCallbacks: [],
+              },
+              loadOptions: {
+                beaconQueueOptions: {},
+                bufferDataPlaneEventsUntilReady: false,
+                configUrl: 'https://api.rudderstack.com',
+                dataPlaneEventsBufferTimeout: 10000,
+                destinationsQueueOptions: {},
+                integrations: {
+                  All: true,
                 },
-                nativeDestinations: {
-                  activeDestinations: [],
-                  clientDestinationsReady: false,
-                  configuredDestinations: [],
-                  failedDestinations: [],
-                  initializedDestinations: [],
-                  integrationsConfig: {},
-                  loadIntegration: true,
-                  loadOnlyIntegrations: {},
-                },
-                plugins: {
-                  activePlugins: [],
-                  failedPlugins: [],
-                  loadedPlugins: [],
-                  pluginsToLoadFromConfig: [],
-                  ready: false,
-                  totalPluginsToLoad: 0,
-                },
-                reporting: {
-                  breadcrumbs: [
-                    {
-                      metaData: {},
-                      name: 'sample breadcrumb message',
-                      timestamp: expect.any(String),
-                      type: 'manual',
-                    },
-                    {
-                      metaData: {},
-                      name: 'sample breadcrumb message 2',
-                      timestamp: expect.any(String),
-                      type: 'manual',
-                    },
-                  ],
-                  isErrorReportingEnabled: false,
-                  isMetricsReportingEnabled: false,
-                },
-                serverCookies: {
-                  isEnabledServerSideCookies: false,
-                },
-                session: {
-                  initialReferrer: '',
-                  initialReferringDomain: '',
-                  sessionInfo: {
-                    id: 123,
-                  },
-                },
-                source: {
-                  id: 'dummy-source-id',
-                  name: 'dummy-source-name',
-                  workspaceId: 'dummy-workspace-id',
+                loadIntegration: true,
+                lockIntegrationsVersion: false,
+                lockPluginsVersion: false,
+                plugins: [],
+                polyfillIfRequired: true,
+                queueOptions: {},
+                sameSiteCookie: 'Lax',
+                sendAdblockPageOptions: {},
+                sessions: {
+                  autoTrack: true,
+                  timeout: 1800000,
                 },
                 storage: {
-                  entries: {},
-                  migrate: false,
-                  trulyAnonymousTracking: false,
+                  cookie: {},
+                  encryption: {
+                    version: 'v3',
+                  },
+                  migrate: true,
                 },
+                uaChTrackLevel: 'none',
+                useBeacon: false,
+                useGlobalIntegrationsConfigInEvents: false,
+                useServerSideCookies: false,
+              },
+              metrics: {
+                dropped: 0,
+                queued: 0,
+                retries: 0,
+                sent: 0,
+                triggered: 0,
+              },
+              nativeDestinations: {
+                activeDestinations: [],
+                clientDestinationsReady: false,
+                configuredDestinations: [],
+                failedDestinations: [],
+                initializedDestinations: [],
+                integrationsConfig: {},
+                loadIntegration: true,
+                loadOnlyIntegrations: {},
+              },
+              plugins: {
+                activePlugins: [],
+                failedPlugins: [],
+                loadedPlugins: [],
+                pluginsToLoadFromConfig: [],
+                ready: false,
+                totalPluginsToLoad: 0,
+              },
+              reporting: {
+                breadcrumbs: [
+                  {
+                    metaData: {},
+                    name: 'sample breadcrumb message',
+                    timestamp: expect.any(String),
+                    type: 'manual',
+                  },
+                  {
+                    metaData: {},
+                    name: 'sample breadcrumb message 2',
+                    timestamp: expect.any(String),
+                    type: 'manual',
+                  },
+                ],
+                isErrorReportingEnabled: false,
+                isMetricsReportingEnabled: false,
+              },
+              serverCookies: {
+                isEnabledServerSideCookies: false,
+              },
+              session: {
+                initialReferrer: '',
+                initialReferringDomain: '',
+                sessionInfo: {
+                  id: 123,
+                },
+              },
+              source: {
+                id: 'dummy-source-id',
+                name: 'dummy-source-name',
+                workspaceId: 'dummy-workspace-id',
+              },
+              storage: {
+                entries: {},
+                migrate: false,
+                trulyAnonymousTracking: false,
               },
             },
             user: {
               id: 'dummy-source-id..123..test-visit-id',
+              name: 'dummy-source-name',
             },
           },
         ],
@@ -666,6 +669,7 @@ describe('Error Reporting utilities', () => {
       );
       expect(userDetails).toEqual({
         id: 'dummy-source-id..123..test-visit-id',
+        name: 'dummy-source-name',
       });
     });
 
@@ -680,6 +684,7 @@ describe('Error Reporting utilities', () => {
       );
       expect(userDetails).toEqual({
         id: 'dummy-write-key..NA..NA',
+        name: 'NA',
       });
     });
   });
@@ -703,7 +708,7 @@ describe('Error Reporting utilities', () => {
       const deviceDetails = getDeviceDetails(state.context.locale, state.context.userAgent);
       expect(deviceDetails).toEqual({
         locale: 'NA',
-        userAgent: '',
+        userAgent: 'NA',
         time: expect.any(Date),
       });
     });

--- a/packages/analytics-js/src/components/configManager/ConfigManager.ts
+++ b/packages/analytics-js/src/components/configManager/ConfigManager.ts
@@ -174,6 +174,7 @@ class ConfigManager implements IConfigManager {
       // set source related information in state
       state.source.value = {
         config: res.source.config,
+        name: res.source.name,
         id: res.source.id,
         workspaceId: res.source.workspaceId,
       };

--- a/packages/analytics-js/src/state/slices/context.ts
+++ b/packages/analytics-js/src/state/slices/context.ts
@@ -15,7 +15,7 @@ const contextState: ContextState = {
     version: APP_VERSION,
     snippetVersion: (globalThis as typeof window).RudderSnippetVersion,
   }),
-  userAgent: signal(''),
+  userAgent: signal(null),
   device: signal(null),
   network: signal(null),
   os: signal({

--- a/packages/analytics-js/src/state/slices/loadOptions.ts
+++ b/packages/analytics-js/src/state/slices/loadOptions.ts
@@ -11,7 +11,6 @@ import { DEFAULT_CONFIG_BE_URL } from '../../constants/urls';
 import { DEFAULT_STORAGE_ENCRYPTION_VERSION } from '../../components/configManager/constants';
 
 const defaultLoadOptions: LoadOptions = {
-  logLevel: 'ERROR',
   configUrl: DEFAULT_CONFIG_BE_URL,
   loadIntegration: true,
   sessions: {


### PR DESCRIPTION
## PR Description

The payload we send to Bugsnag has been enriched:
- The payload version is correctly positioned.
- SDK installation type and snippet version are set in the app object.
- Screen and timezone fields are added in the device object.
- Source name is added in the user object.
Most importantly, "app" and "user" in Bugsnag terms are correctly mapped to "sdk" and "source" in the SDK terms.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2826/move-error-reporting-functionality-to-the-core-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
