### PR TITLE
feat: improve user callback execution

### DIFF
--- a/packages/analytics-js-common/src/constants/loggerContexts.ts
+++ b/packages/analytics-js-common/src/constants/loggerContexts.ts
@@ -1,3 +1,4 @@
+const API_SUFFIX = 'API';
 const CAPABILITIES_MANAGER = 'CapabilitiesManager';
 const CONFIG_MANAGER = 'ConfigManager';
 const EVENT_MANAGER = 'EventManager';
@@ -6,14 +7,13 @@ const USER_SESSION_MANAGER = 'UserSessionManager';
 const ERROR_HANDLER = 'ErrorHandler';
 const PLUGIN_ENGINE = 'PluginEngine';
 const STORE_MANAGER = 'StoreManager';
-const READY_API = 'readyApi';
-const LOAD_CONFIGURATION = 'LoadConfiguration';
+const READY_API = `Ready${API_SUFFIX}`;
+const LOAD_API = `Load${API_SUFFIX}`;
 const EVENT_REPOSITORY = 'EventRepository';
 const EXTERNAL_SRC_LOADER = 'ExternalSrcLoader';
 const HTTP_CLIENT = 'HttpClient';
 const RSA = 'RudderStackAnalytics';
 const ANALYTICS_CORE = 'AnalyticsCore';
-
 export {
   CAPABILITIES_MANAGER,
   CONFIG_MANAGER,
@@ -24,10 +24,11 @@ export {
   PLUGIN_ENGINE,
   STORE_MANAGER,
   READY_API,
-  LOAD_CONFIGURATION,
+  LOAD_API,
   EVENT_REPOSITORY,
   EXTERNAL_SRC_LOADER,
   HTTP_CLIENT,
   RSA,
   ANALYTICS_CORE,
+  API_SUFFIX,
 };

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -260,7 +260,7 @@ describe('Core - Analytics', () => {
       analytics.onInitialized();
 
       expect(errorSpy).toHaveBeenCalledTimes(1);
-      expect(errorSpy).toHaveBeenCalledWith('LoadAPI:: The provided callback is not invokable.');
+      expect(errorSpy).toHaveBeenCalledWith('LoadAPI:: The provided callback parameter is not a function.');
     });
 
     it('should log an error if the onLoaded callback throws an error', () => {
@@ -378,7 +378,7 @@ describe('Core - Analytics', () => {
       analytics.ready(true);
 
       expect(errorSpy).toHaveBeenCalledTimes(1);
-      expect(errorSpy).toHaveBeenCalledWith('ReadyAPI:: The provided callback is not invokable.');
+      expect(errorSpy).toHaveBeenCalledWith('ReadyAPI:: The provided callback parameter is not a function.');
     });
 
     it('should log an error if the provided callback throws an error', () => {

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -120,13 +120,31 @@ describe('Core - Analytics', () => {
   describe('load', () => {
     const sampleDataPlaneUrl = 'https://www.dummy.url';
     it('should load the analytics script with the given options', () => {
+      state.loadOptions.value.logLevel = 'WARN';
+
       const startLifecycleSpy = jest.spyOn(analytics, 'startLifecycle');
       const setMinLogLevelSpy = jest.spyOn(analytics.logger, 'setMinLogLevel');
+
       analytics.load(dummyWriteKey, sampleDataPlaneUrl, { logLevel: 'ERROR' });
+
       expect(state.lifecycle.status.value).toBe('browserCapabilitiesReady');
       expect(startLifecycleSpy).toHaveBeenCalledTimes(1);
-      expect(setMinLogLevelSpy).toHaveBeenCalledWith('ERROR');
+      // Once in load API and then in config manager
+      expect(setMinLogLevelSpy).toHaveBeenCalledTimes(2);
+      expect(setMinLogLevelSpy).toHaveBeenNthCalledWith(1, 'ERROR');
       expect(setExposedGlobal).toHaveBeenCalledWith('state', state, dummyWriteKey);
+    });
+
+    it('should set the log level if it is not configured', () => {
+      state.loadOptions.value.logLevel = undefined;
+      const setMinLogLevelSpy = jest.spyOn(analytics.logger, 'setMinLogLevel');
+
+      analytics.load(dummyWriteKey, sampleDataPlaneUrl);
+
+      expect(state.lifecycle.status.value).toBe('browserCapabilitiesReady');
+      // Once in load API and then in config manager
+      expect(setMinLogLevelSpy).toHaveBeenCalledTimes(2);
+      expect(setMinLogLevelSpy).toHaveBeenNthCalledWith(1, 'ERROR');
     });
 
     it('should not load if the write key is invalid', () => {
@@ -233,6 +251,32 @@ describe('Core - Analytics', () => {
         analyticsInstance: undefined,
       });
     });
+
+    it('should log an error if the onLoaded callback is not a function', () => {
+      const errorSpy = jest.spyOn(analytics.logger, 'error');
+      // @ts-expect-error testing invalid callback
+      state.loadOptions.value.onLoaded = true;
+
+      analytics.onInitialized();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith('LoadAPI:: The provided callback is not invokable.');
+    });
+
+    it('should log an error if the onLoaded callback throws an error', () => {
+      const errorSpy = jest.spyOn(analytics.logger, 'error');
+      state.loadOptions.value.onLoaded = () => {
+        throw new Error('Test error');
+      };
+
+      analytics.onInitialized();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'LoadAPI:: The callback threw an exception',
+        new Error('Test error'),
+      );
+    });
   });
 
   describe('onDestinationsReady', () => {
@@ -257,6 +301,22 @@ describe('Core - Analytics', () => {
       state.eventBuffer.readyCallbacksArray.value = [callback, callback];
       analytics.onReady();
       expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should log an error if a ready callback throws an error', () => {
+      const errorSpy = jest.spyOn(analytics.logger, 'error');
+      const callback = () => {
+        throw new Error('Test error');
+      };
+      state.eventBuffer.readyCallbacksArray.value = [callback, jest.fn()];
+
+      analytics.onReady();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'ReadyAPI:: The callback threw an exception',
+        new Error('Test error'),
+      );
     });
 
     it('should ignore calls with no function callback', () => {
@@ -308,6 +368,35 @@ describe('Core - Analytics', () => {
       expect(dispatchEventSpy.mock.calls[0][0].detail).toStrictEqual({
         analyticsInstance: undefined,
       });
+    });
+
+    it('should log an error if the provided callback is not a function', () => {
+      state.lifecycle.loaded.value = true;
+
+      const errorSpy = jest.spyOn(analytics.logger, 'error');
+      // @ts-expect-error testing invalid callback
+      analytics.ready(true);
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith('ReadyAPI:: The provided callback is not invokable.');
+    });
+
+    it('should log an error if the provided callback throws an error', () => {
+      state.lifecycle.loaded.value = true;
+      state.lifecycle.status.value = 'readyExecuted';
+
+      const errorSpy = jest.spyOn(analytics.logger, 'error');
+      const callback = () => {
+        throw new Error('Test error');
+      };
+
+      analytics.ready(callback);
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'ReadyAPI:: The callback threw an exception',
+        new Error('Test error'),
+      );
     });
   });
 

--- a/packages/analytics-js/__tests__/components/eventRepository/EventRepository.test.ts
+++ b/packages/analytics-js/__tests__/components/eventRepository/EventRepository.test.ts
@@ -313,7 +313,7 @@ describe('EventRepository', () => {
 
     expect(defaultLogger.error).toHaveBeenCalledTimes(1);
     expect(defaultLogger.error).toHaveBeenCalledWith(
-      'TrackAPI:: The provided callback is not invokable.',
+      'TrackAPI:: The provided callback parameter is not a function.',
     );
   });
 

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -20,6 +20,7 @@ import type {
 import type { ApiCallback } from '@rudderstack/analytics-js-common/types/EventApi';
 import {
   ANALYTICS_CORE,
+  LOAD_API,
   READY_API,
 } from '@rudderstack/analytics-js-common/constants/loggerContexts';
 import {
@@ -61,13 +62,13 @@ import {
 } from '../../constants/app';
 import {
   DATA_PLANE_URL_VALIDATION_ERROR,
-  READY_API_CALLBACK_ERROR,
-  READY_CALLBACK_INVOKE_ERROR,
+  INVALID_CALLBACK_FN_ERROR,
   WRITE_KEY_VALIDATION_ERROR,
 } from '../../constants/logMessages';
 import type { IAnalytics } from './IAnalytics';
 import { getConsentManagementData, getValidPostConsentOptions } from '../utilities/consent';
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
+import { safelyInvokeCallback } from '../utilities/callbacks';
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events
@@ -314,12 +315,16 @@ class Analytics implements IAnalytics {
     // Process any preloaded events
     this.processDataInPreloadBuffer();
 
+    // Execute onLoaded callback if provided in load options
+    const onLoadedCallbackFn = state.loadOptions.value.onLoaded;
     // TODO: we need to avoid passing the window object to the callback function
     // as this will prevent us from supporting multiple SDK instances in the same page
-    // Execute onLoaded callback if provided in load options
-    if (isFunction(state.loadOptions.value.onLoaded)) {
-      state.loadOptions.value.onLoaded((globalThis as typeof window).rudderanalytics);
-    }
+    safelyInvokeCallback(
+      onLoadedCallbackFn,
+      [(globalThis as typeof window).rudderanalytics],
+      LOAD_API,
+      this.logger,
+    );
 
     // Set lifecycle state
     batch(() => {
@@ -340,11 +345,7 @@ class Analytics implements IAnalytics {
   onReady() {
     state.lifecycle.status.value = 'readyExecuted';
     state.eventBuffer.readyCallbacksArray.value.forEach((callback: ApiCallback) => {
-      try {
-        callback();
-      } catch (err) {
-        this.errorHandler.onError(err, ANALYTICS_CORE, READY_CALLBACK_INVOKE_ERROR);
-      }
+      safelyInvokeCallback(callback, [], READY_API, this.logger);
     });
 
     // Emit an event to use as substitute to the ready callback
@@ -454,7 +455,7 @@ class Analytics implements IAnalytics {
     this.errorHandler.leaveBreadcrumb(`New ${type} invocation`);
 
     if (!isFunction(callback)) {
-      this.logger.error(READY_API_CALLBACK_ERROR(READY_API));
+      this.logger.error(INVALID_CALLBACK_FN_ERROR(READY_API));
       return;
     }
 
@@ -464,11 +465,7 @@ class Analytics implements IAnalytics {
      * will be executed after loading completes
      */
     if (state.lifecycle.status.value === 'readyExecuted') {
-      try {
-        callback();
-      } catch (err) {
-        this.errorHandler.onError(err, ANALYTICS_CORE, READY_CALLBACK_INVOKE_ERROR);
-      }
+      safelyInvokeCallback(callback, [], READY_API, this.logger);
     } else {
       state.eventBuffer.readyCallbacksArray.value = [
         ...state.eventBuffer.readyCallbacksArray.value,

--- a/packages/analytics-js/src/components/utilities/callbacks.ts
+++ b/packages/analytics-js/src/components/utilities/callbacks.ts
@@ -1,0 +1,26 @@
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import { isDefined, isFunction } from '@rudderstack/analytics-js-common/utilities/checks';
+import { CALLBACK_INVOKE_ERROR, INVALID_CALLBACK_FN_ERROR } from '../../constants/logMessages';
+
+const safelyInvokeCallback = (
+  callback: unknown,
+  args: unknown[],
+  apiName: string,
+  logger: ILogger,
+): void => {
+  if (!isDefined(callback)) {
+    return;
+  }
+
+  if (isFunction(callback)) {
+    try {
+      callback(...args);
+    } catch (error) {
+      logger.error(CALLBACK_INVOKE_ERROR(apiName), error);
+    }
+  } else {
+    logger.error(INVALID_CALLBACK_FN_ERROR(apiName));
+  }
+};
+
+export { safelyInvokeCallback };

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -80,7 +80,7 @@ const DATA_PLANE_URL_VALIDATION_ERROR = (context: string, dataPlaneUrl: string):
   `${context}${LOG_CONTEXT_SEPARATOR}The data plane URL "${dataPlaneUrl}" is invalid. It must be a valid URL string. Please check that the data plane URL is correct and try again.`;
 
 const INVALID_CALLBACK_FN_ERROR = (context: string): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}The provided callback is not invokable.`;
+  `${context}${LOG_CONTEXT_SEPARATOR}The provided callback parameter is not a function.`;
 
 const XHR_DELIVERY_ERROR = (
   prefix: string,

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -79,8 +79,8 @@ const WRITE_KEY_VALIDATION_ERROR = (context: string, writeKey: string): string =
 const DATA_PLANE_URL_VALIDATION_ERROR = (context: string, dataPlaneUrl: string): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The data plane URL "${dataPlaneUrl}" is invalid. It must be a valid URL string. Please check that the data plane URL is correct and try again.`;
 
-const READY_API_CALLBACK_ERROR = (context: string): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}The provided callback is not a function.`;
+const INVALID_CALLBACK_FN_ERROR = (context: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The provided callback is not invokable.`;
 
 const XHR_DELIVERY_ERROR = (
   prefix: string,
@@ -190,9 +190,9 @@ const STORAGE_UNAVAILABLE_WARNING = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The storage type "${selectedStorageType}" is not available for entry "${entry}". The SDK will initialize the entry with "${finalStorageType}" storage type instead.`;
 
-const READY_CALLBACK_INVOKE_ERROR = `Failed to invoke the ready callback`;
+const CALLBACK_INVOKE_ERROR = (context: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The callback threw an exception`;
 
-const API_CALLBACK_INVOKE_ERROR = `API Callback Invocation Failed`;
 const NATIVE_DEST_PLUGIN_INITIALIZE_ERROR = `NativeDestinationQueuePlugin initialization failed`;
 const DATAPLANE_PLUGIN_INITIALIZE_ERROR = `XhrQueuePlugin initialization failed`;
 const DMT_PLUGIN_INITIALIZE_ERROR = `DeviceModeTransformationPlugin initialization failed`;
@@ -278,7 +278,6 @@ export {
   DATA_PLANE_URL_ERROR,
   WRITE_KEY_VALIDATION_ERROR,
   DATA_PLANE_URL_VALIDATION_ERROR,
-  READY_API_CALLBACK_ERROR,
   XHR_DELIVERY_ERROR,
   XHR_REQUEST_ERROR,
   XHR_SEND_ERROR,
@@ -289,8 +288,6 @@ export {
   PLUGIN_EXT_POINT_MISSING_ERROR,
   PLUGIN_EXT_POINT_INVALID_ERROR,
   STORAGE_TYPE_VALIDATION_WARNING,
-  READY_CALLBACK_INVOKE_ERROR,
-  API_CALLBACK_INVOKE_ERROR,
   INVALID_CONFIG_URL_WARNING,
   POLYFILL_SCRIPT_LOAD_ERROR,
   UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY,
@@ -315,4 +312,6 @@ export {
   NON_ERROR_WARNING,
   BREADCRUMB_ERROR,
   HANDLE_ERROR_FAILURE,
+  CALLBACK_INVOKE_ERROR,
+  INVALID_CALLBACK_FN_ERROR,
 };


### PR DESCRIPTION
## PR Description

The SDK consumers can provide callback functions in three places:
- Load API options for "onLoaded" status
- Ready API callback
- Event APIs

The validation and execution errors are refactored to make them consistent. Moreover, they are not reported anymore as they are purely user instrumentation errors.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2826/move-error-reporting-functionality-to-the-core-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
