### PR TITLE
chore: automatically link post release pr to release ticket

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -110,14 +110,22 @@ jobs:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'main'
           github_token: ${{ secrets.PAT }}
-          pr_title: 'chore(release): pull ${{ steps.create-release.outputs.branch_name }} into main'
+          pr_title: 'chore(release): merge ${{ steps.create-release.outputs.branch_name }} into main [${{ github.event.inputs.release_ticket_id }}]'
           pr_body: |
-            :crown: *An automated PR*
+            :crown: **Automated Release PR**
 
-            This PR is created automatically by the GitHub Actions workflow to merge the release branch into the main branch.
+            This pull request was created automatically by the GitHub Actions workflow. It merges the release branch (`${{ steps.create-release.outputs.branch_name }}`) into the `main` branch.
 
-            Linear Ticket: 
-            https://linear.app/rudderstack/issue/${{ github.event.inputs.release_ticket_id }}
+            This ensures that the latest release branch changes are incorporated into the `main` branch for production.
+
+            ### Details
+            - **Release Version**: v$NEW_VERSION_VALUE
+            - **Release Branch**: `${{ steps.create-release.outputs.branch_name }}`
+            - **Related Ticket**: [${{ github.event.inputs.release_ticket_id }}](https://linear.app/rudderstack/issue/${{ github.event.inputs.release_ticket_id }})
+
+            ---
+            Please review and merge when ready. :rocket:
+
 
       - name: Delete hotfix release base branch
         continue-on-error: true

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -31,6 +31,11 @@ jobs:
           VERSION=${BRANCH_NAME#hotfix-}
           VERSION=${VERSION#release/}
 
+          # Extract the ticket ID (case-insensitive match for -SDK-<ticket_number>)
+          RELEASE_TICKET_ID=$(echo "$BRANCH_NAME" | grep -oE '[sS][dD][kK]-[0-9]+')
+
+          echo "release_ticket_id=$RELEASE_TICKET_ID" >> $GITHUB_OUTPUT
+
           # Remove the -SDK-<ticket_number> suffix case insensitively
           VERSION=$(echo "$VERSION" | awk '{sub(/-[sS][dD][kK]-[0-9]+$/, ""); print}')
 
@@ -104,8 +109,20 @@ jobs:
           source_branch: 'main'
           destination_branch: 'develop'
           github_token: ${{ secrets.PAT }}
-          pr_title: 'chore(release): pull main into develop post release v${{ steps.extract-version.outputs.release_version }}'
-          pr_body: ':crown: *An automated PR*'
+          pr_title: 'chore(release): merge main into develop after release v${{ steps.extract-version.outputs.release_version }} [${{ steps.extract-version.outputs.release_ticket_id }}]'
+          pr_body: |
+            :crown: **Automated Post-Release PR**
+
+            This pull request was created automatically by the GitHub Actions workflow. It merges changes from the `main` branch into the `develop` branch after a release has been completed.
+
+            This ensures that the `develop` branch stays up to date with all release-related changes from the `main` branch.
+
+            ### Details
+            - **Release Version**: v${{ steps.extract-version.outputs.release_version }}
+            - **Related Ticket**: [${{ steps.extract-version.outputs.release_ticket_id }}](https://linear.app/rudderstack/issue/${{ steps.extract-version.outputs.release_ticket_id }})
+
+            ---
+            Please review and merge it before closing the release ticket :rocket:
 
       - name: Send message to Slack channel
         id: slack

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -122,7 +122,7 @@ jobs:
             - **Related Ticket**: [${{ steps.extract-version.outputs.release_ticket_id }}](https://linear.app/rudderstack/issue/${{ steps.extract-version.outputs.release_ticket_id }})
 
             ---
-            Please review and merge it before closing the release ticket :rocket:
+            Please review and merge it before closing the release ticket. :rocket:
 
       - name: Send message to Slack channel
         id: slack


### PR DESCRIPTION
## PR Description

I've included the release ticket ID in the PR title, so that it is automatically linked to the ticket.
Additionally, I've formatted the PR title and description of the automated PRs to look more professional.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
