### PR TITLE
chore: enable more teams to manually run workflows

### DIFF
--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -8,10 +8,19 @@ on:
         required: true
 
 jobs:
+  validate-actor:
+    # Only allow creating hotfix branches from the main branch
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/validate-actor.yml
+    with:
+      team_names: 'js-sdk,integrations'
+    secrets:
+      PAT: ${{ secrets.PAT }}
+
   create-branch:
     name: Create a new hotfix branch
     runs-on: [self-hosted, Linux, X64]
-    if: github.ref == 'refs/heads/main'
+    needs: validate-actor
     steps:
       - name: Create branch
         uses: peterjgrainger/action-create-branch@v3.0.0

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -15,6 +15,8 @@ jobs:
     # Only allow to draft a new release from develop and hotfix branches
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/')
     uses: ./.github/workflows/validate-actor.yml
+    with:
+      team_names: 'js-sdk,integrations'
     secrets:
       PAT: ${{ secrets.PAT }}
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -8,6 +8,8 @@ jobs:
     # Only allow to be deployed from tags and main branch
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     uses: ./.github/workflows/validate-actor.yml
+    with:
+      team_names: 'js-sdk,integrations'
     secrets:
       PAT: ${{ secrets.PAT }}
 

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -5,6 +5,11 @@ on:
     secrets:
       PAT:
         required: true
+    inputs:
+      team_names:
+        description: 'Comma-separated list of team names'
+        type: string
+        default: 'js-sdk'
 
 jobs:
   validate-actor:
@@ -13,24 +18,39 @@ jobs:
       - name: Validate if actor is allowed to trigger the workflow
         env:
           ORG_NAME: rudderlabs
-          TEAM_NAME: js-sdk
+          TEAM_NAMES: ${{ inputs.team_names }}
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
           actor=${{ github.actor || github.triggering_actor }}
+          allowed=false
 
-          # Use gh api to fetch the membership details
-          response=$(gh api "/orgs/$ORG_NAME/teams/$TEAM_NAME/memberships/$actor" -H "X-GitHub-Api-Version: 2022-11-28" 2>/dev/null || echo "error")
+          # Split TEAM_NAMES into an array and loop through each team
+          IFS=',' read -ra TEAMS <<< "$TEAM_NAMES"
 
-          # Check if API request failed
-          if [ "$response" = "error" ]; then
-            echo "Error: Unable to fetch membership details for '$actor'."
-            exit 1
-          fi
+          for TEAM_NAME in "${TEAMS[@]}"; do
+            echo "Checking membership for actor '$actor' in team '@${ORG_NAME}/${TEAM_NAME}'..."
 
-          # Extract the state of the membership
-          if echo "$response" | grep -q '"state":"active"'; then
-            echo "'$actor' is a member of '@${ORG_NAME}/${TEAM_NAME}' team"
+            # Use gh api to fetch the membership details
+            response=$(gh api "/orgs/$ORG_NAME/teams/$TEAM_NAME/memberships/$actor" -H "X-GitHub-Api-Version: 2022-11-28" 2>/dev/null || echo "error")
+
+            # Check if API request failed
+            if [ "$response" = "error" ]; then
+              echo "Warning: Unable to fetch membership details for '$actor' in team '$TEAM_NAME'."
+              continue
+            fi
+
+            # Check if the actor is an active member
+            if echo "$response" | grep -q '"state":"active"'; then
+              echo "'$actor' is an active member of '@${ORG_NAME}/${TEAM_NAME}' team."
+              allowed=true
+              break
+            fi
+          done
+
+          # Final validation result
+          if [ "$allowed" = true ]; then
+            echo "'$actor' is allowed to trigger the workflow."
           else
-            echo "Error: '$actor' is NOT a member of '@${ORG_NAME}/${TEAM_NAME}' team. Access denied."
+            echo "Error: '$actor' is NOT a member of any of the specified teams '${TEAM_NAMES}'. Access denied."
             exit 1
           fi


### PR DESCRIPTION
## PR Description

I've improved the actor validation workflow to allow specifying team(s) as an input. I've allowed the integrations teams also run some of the important workflows now.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
