### PR TITLE
chore: delay full e2e test suite for sanity suite run

### DIFF
--- a/.github/workflows/trigger-test-suites.yml
+++ b/.github/workflows/trigger-test-suites.yml
@@ -68,6 +68,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
+          # Sleep for 15 minutes to allow the sanity test suite to complete first
+          sleep 15m
+
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## PR Description

Updated the workflow to trigger the full E2E test suite run with a delay of 15 minutes. This should give enough time for the previously triggered sanity suite.

Running both the test suites simultaneously results in them fighting for BrowserStack resources (5 parallel threads) resulting in longer execution times. 
Moreover, WebDriverIO sometimes fails a test when BS resources are not available to run. This results in reduced test coverage.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
