### PR TITLE
feat: lock plugins and integrations versions for npm package

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -71,6 +71,7 @@ jobs:
           HUSKY: 0
           REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/v3/modern/plugins'
           BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
+          LOCK_DEPS_VERSION: 'true'
           BUGSNAG_RELEASE_STAGE: 'production'
         run: |
           npm run setup:ci
@@ -79,6 +80,7 @@ jobs:
         env:
           BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
           BUGSNAG_RELEASE_STAGE: 'production'
+          LOCK_DEPS_VERSION: 'true'
         run: |
           npm run build:package
           npm run build:package:modern

--- a/packages/analytics-js/src/components/utilities/loadOptions.ts
+++ b/packages/analytics-js/src/components/utilities/loadOptions.ts
@@ -11,7 +11,7 @@ import type {
   LoadOptions,
   UaChTrackLevel,
 } from '@rudderstack/analytics-js-common/types/LoadOptions';
-import type { StorageOpts, CookieSameSite } from '@rudderstack/analytics-js-common/types/Storage';
+import type { CookieSameSite } from '@rudderstack/analytics-js-common/types/Storage';
 import { isString } from '@rudderstack/analytics-js-common/utilities/checks';
 import { defaultOptionalPluginsList } from '../pluginsManager/defaultPluginsList';
 import { isNumber } from './number';


### PR DESCRIPTION
## PR Description

Locked the versions of plugins and integrations components by default for the NPM package.

I've fixed a small lint issue (removed unused import statement) in the core SDK package to mark it as updated and qualify for publishing a new version. 

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2708/namespace-the-dynamically-loaded-sdk-artifacts-with-a-release-tag

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
