### PR TITLE
chore: fix workspace setup steps in workflows to optimize time

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -66,7 +66,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Setup workspace
         env:
           HUSKY: 0
           REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/v3/modern/plugins'

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -81,7 +81,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Setup workspace
         env:
           HUSKY: 0
         run: |

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -36,11 +36,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Setup workspace
         env:
           HUSKY: 0
         run: |
-          npm run setup:ci
+          npm run setup:deps
 
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -66,11 +66,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Setup workspace
         env:
           HUSKY: 0
         run: |
-          npm run setup:ci
+          npm run setup:deps
 
       - name: Get the two latest versions
         run: |

--- a/.github/workflows/security-code-quality-and-bundle-size-checks.yml
+++ b/.github/workflows/security-code-quality-and-bundle-size-checks.yml
@@ -31,7 +31,7 @@ jobs:
           HUSKY: 0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          install_script: setup:deps
+          install_script: setup:ci
           build_script: check:size:build
           clean_script: clean
           script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --exclude=@rudderstack/analytics-js-sanity-suite

--- a/.github/workflows/security-code-quality-and-bundle-size-checks.yml
+++ b/.github/workflows/security-code-quality-and-bundle-size-checks.yml
@@ -31,7 +31,7 @@ jobs:
           HUSKY: 0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          install_script: setup:ci
+          install_script: setup:deps
           build_script: check:size:build
           clean_script: clean
           script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --exclude=@rudderstack/analytics-js-sanity-suite
@@ -54,7 +54,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Setup workspace
         env:
           HUSKY: 0
         run: |

--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -29,7 +29,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Setup workspace
         env:
           HUSKY: 0
         run: |


### PR DESCRIPTION
## PR Description

I've updated the relevant workflows to use the correct setup NPM script to avoid building packages.
The commands `setup:ci` and `setup` automatically build NPM packages of the monorepo packages. However, for workflows like drafting a new release, publish new GitHub releases etc. don't need them.
So, I've replaced them with `setup:deps` that exactly only installs the dependencies of the project saving the execution time of the workflows.

I've also renamed the step name across all the workflows for consistency.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
