### PR TITLE
feat: add legacy sdk deprecation notices

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -141,6 +141,16 @@ jobs:
           echo "CURRENT_NPM_VERSION_COOKIE_UTILS=${{ env.CURRENT_NPM_VERSION_COOKIE_UTILS }}"
           echo "NEW_NPM_VERSION_COOKIE_UTILS=${{ env.NEW_NPM_VERSION_COOKIE_UTILS }}"
 
+      - name: Deprecate the legacy SDK NPM package
+        continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+        run: |
+          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+
+          npm deprecate rudder-sdk-js "This package is deprecated and no longer maintained. Please migrate to the latest package, @rudderstack/analytics-js (https://www.npmjs.com/package/@rudderstack/analytics-js), for the latest features, security updates, and improved performance. For more details, visit: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/."
+
       - name: Send message to Slack channel
         if: env.CURRENT_NPM_VERSION != env.NEW_NPM_VERSION && env.NEW_NPM_VERSION != 'not found'
         id: slack

--- a/packages/analytics-v1.1/README.md
+++ b/packages/analytics-v1.1/README.md
@@ -19,8 +19,8 @@
 
 ---
 
-| :warning: This package is deprecated. Please switch to the latest [@rudderstack/analytics-js](https://www.npmjs.com/package/@rudderstack/analytics-js) package for improved features and support. <br>For more details, visit [link](https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/). |
-| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| :warning: **This package is deprecated and no longer maintained.** Please migrate to the latest [@rudderstack/analytics-js](https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. <br/><br/>For more details, visit the [official documentation](https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/). |
+| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 # RudderStack JavaScript SDK
 

--- a/packages/analytics-v1.1/package.json
+++ b/packages/analytics-v1.1/package.json
@@ -64,7 +64,8 @@
     "build:browser:modern:bundle-size": "VISUALIZER=true npm run build:browser:modern",
     "build:npm:dev": "rollup --config rollup-configs/rollup.sdk.npm.mjs --environment VERSION:$npm_package_version,NPM",
     "package": "npm pack",
-    "release": "npm publish"
+    "release": "npm publish",
+    "postinstall": "echo 'This package is deprecated and no longer maintained. Please migrate to the latest @rudderstack/analytics-js (https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the official documentation: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/.'"
   },
   "keywords": [
     "analytics",

--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -1658,6 +1658,12 @@ const startSession = instance.startSession.bind(instance);
 const endSession = instance.endSession.bind(instance);
 const setAuthToken = instance.setAuthToken.bind(instance);
 
+if ('__MODULE_TYPE__' === 'npm') {
+  logger.error('This package is deprecated and no longer maintained. Please migrate to the latest [@rudderstack/analytics-js](https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the official documentation: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/.');
+} else {
+  logger.error('This version of the RudderStack JavaScript SDK is deprecated and no longer maintained. Please migrate to the latest version (v3) for enhanced features, security updates, and ongoing support. For more details, visit the official documentation: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/.');
+}
+
 export {
   initialized,
   ready,


### PR DESCRIPTION
## PR Description

I've added console error messages in the legacy SDK urging users to migrate to the v3 SDK.

Additionally, we're automatically deprecating the legacy SDK NPM package. I've added added a post install NPM script in the legacy SDK package.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2941/add-deprecation-error-notices-in-legacy-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
