### PR TITLE
fix: suppress deprecation error log temporarily

### DIFF
--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -1658,15 +1658,19 @@ const startSession = instance.startSession.bind(instance);
 const endSession = instance.endSession.bind(instance);
 const setAuthToken = instance.setAuthToken.bind(instance);
 
-// eslint-disable-next-line no-constant-condition
-if ('__MODULE_TYPE__' === 'npm') {
-  logger.error(
-    'This RudderStack JavaScript SDK package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest [@rudderstack/analytics-js](https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
-  );
-} else {
-  logger.error(
-    'This version of the RudderStack JavaScript SDK is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest version (v3) for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
-  );
+// TODO: Need to remove this in the next release
+// eslint-disable-next-line sonarjs/no-gratuitous-expressions, no-constant-condition
+if (false) {
+  // eslint-disable-next-line no-constant-condition
+  if ('__MODULE_TYPE__' === 'npm') {
+    logger.error(
+      'This RudderStack JavaScript SDK package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest [@rudderstack/analytics-js](https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
+    );
+  } else {
+    logger.error(
+      'This version of the RudderStack JavaScript SDK is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest version (v3) for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
+    );
+  }
 }
 
 export {


### PR DESCRIPTION
## PR Description

Temporarily suppressing the deprecation error message until the next release.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2941/add-deprecation-error-notices-in-legacy-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Temporarily disabled deprecation warning logging in the analytics SDK.
	- Preserved original deprecation messages as comments for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->