### PR TITLE
chore: fix env syntax in workflow

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -121,7 +121,7 @@ jobs:
             This ensures that the latest release branch changes are incorporated into the `main` branch for production.
 
             ### Details
-            - **Release Version**: v$NEW_VERSION_VALUE
+            - **Release Version**: v${{ env.NEW_VERSION_VALUE }}
             - **Release Branch**: `${{ steps.create-release.outputs.branch_name }}`
             - **Related Ticket**: [${{ github.event.inputs.release_ticket_id }}](https://linear.app/rudderstack/issue/${{ github.event.inputs.release_ticket_id }})
 


### PR DESCRIPTION
## PR Description

I've fixed the draft new release workflow to fix a syntax issue in accessing the env variable in a string.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
