### PR TITLE
fix: update matomo native sdk loader with correct setTracerUrl

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/Matomo/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/Matomo/nativeSdkLoader.js
@@ -3,7 +3,7 @@ import { LOAD_ORIGIN } from '@rudderstack/analytics-js-common/v1.1/utils/constan
 function loadNativeSdk(matomoVersion, premiseUrl, serverUrl, siteId) {
   window._paq = window._paq || [];
   (function (matomoVersion, premiseUrl, serverUrl, siteId) {
-    let u = serverUrl || '';
+    let u = matomoVersion === 'premise' ? premiseUrl.replace('matomo.js', '') : serverUrl || '';
     window._paq.push(['setTrackerUrl', `${u}matomo.php`]);
     window._paq.push(['setSiteId', siteId]);
     const d = document;

--- a/packages/analytics-js-integrations/src/integrations/Matomo/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/Matomo/nativeSdkLoader.js
@@ -3,7 +3,19 @@ import { LOAD_ORIGIN } from '@rudderstack/analytics-js-common/v1.1/utils/constan
 function loadNativeSdk(matomoVersion, premiseUrl, serverUrl, siteId) {
   window._paq = window._paq || [];
   (function (matomoVersion, premiseUrl, serverUrl, siteId) {
-    let u = matomoVersion === 'premise' ? premiseUrl.replace('matomo.js', '') : serverUrl || '';
+    // let u = matomoVersion === 'premise' ? premiseUrl.replace('matomo.js', '') : serverUrl || '';
+    let u = '';
+    if (matomoVersion === 'premise') {
+      if (!premiseUrl || typeof premiseUrl !== 'string') {
+        throw new Error('premiseUrl is required for premise deployments and must be a string');
+      }
+      const suffix = 'matomo.js';
+      u = premiseUrl.endsWith(suffix)
+        ? premiseUrl.slice(0, -suffix.length)
+        : premiseUrl;
+    } else {
+      u = serverUrl || '';
+    }
     window._paq.push(['setTrackerUrl', `${u}matomo.php`]);
     window._paq.push(['setSiteId', siteId]);
     const d = document;

--- a/packages/analytics-js-integrations/src/integrations/Matomo/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/Matomo/nativeSdkLoader.js
@@ -3,7 +3,6 @@ import { LOAD_ORIGIN } from '@rudderstack/analytics-js-common/v1.1/utils/constan
 function loadNativeSdk(matomoVersion, premiseUrl, serverUrl, siteId) {
   window._paq = window._paq || [];
   (function (matomoVersion, premiseUrl, serverUrl, siteId) {
-    // let u = matomoVersion === 'premise' ? premiseUrl.replace('matomo.js', '') : serverUrl || '';
     let u = '';
     if (matomoVersion === 'premise') {
       if (!premiseUrl || typeof premiseUrl !== 'string') {


### PR DESCRIPTION
## PR Description

We have introduced a new feature supporting the on-premise deployment of Matomo. But that implementation is erroneous. We are not correctly using the premise URL everywhere. So we are fixing this with this pr.

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-3216/investigate-broken-matomo-script-loader-for-on-prem-installs

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the analytics tracking configuration to ensure the correct endpoint is used across deployment types, including on-premise setups. Improved error handling and URL construction for the Matomo tracking script based on version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->