### PR TITLE
chore: update changelog to clarify the version locking feature changes

### DIFF
--- a/packages/analytics-js/CHANGELOG.md
+++ b/packages/analytics-js/CHANGELOG.md
@@ -20,6 +20,9 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Features
 
 * lock plugins and integrations versions for npm package ([#2020](https://github.com/rudderlabs/rudder-sdk-js/issues/2020)) ([447e524](https://github.com/rudderlabs/rudder-sdk-js/commit/447e524dd1ee5782e6d7a8e834c03c57ebf3c196))
+  * Plugins and integration SDKs will now be loaded from a versioned directory (`/3.x.y/`) on the CDN instead of the common `/v3/` path.
+  * This ensures that SDK updates do not unexpectedly break existing integrations due to changes in dependencies.
+  * If you are using a CDN proxy, ensure that it does not block requests to versioned paths like `/3.13.0/`, otherwise the SDK will not load correctly.
 
 ## [3.12.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.11.17...@rudderstack/analytics-js@3.12.0) (2025-01-24)
 
@@ -32,6 +35,9 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Features
 
 * lock plugins and integrations version by default ([#1956](https://github.com/rudderlabs/rudder-sdk-js/issues/1956)) ([45e716e](https://github.com/rudderlabs/rudder-sdk-js/commit/45e716e6df3d6e665c25aa907531adb746961d50))
+  * Plugins and integration SDKs will now be loaded from a versioned directory (`/3.x.y/`) on the CDN instead of the common `/v3/` path.
+  * This ensures that SDK updates do not unexpectedly break existing integrations due to changes in dependencies.
+  * If you are using a CDN proxy, ensure that it does not block requests to versioned paths like `/3.13.0/`, otherwise the SDK will not load correctly.
 
 ## [3.11.17](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.11.16...@rudderstack/analytics-js@3.11.17) (2025-01-03)
 


### PR DESCRIPTION
## PR Description

I've updated the changelog of the analytics-js package to clarify the version locking feature change we released recently.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release 3.14.0 delivers enhanced error reporting now integrated into the core, along with updated dependency management for improved stability.
  
- **Documentation**
  - The release notes have been updated to reflect that integration resources will now load from versioned CDN paths (e.g., /3.x.y/). If you use a CDN proxy, please ensure that requests to these new endpoints are allowed to avoid any loading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->