### PR TITLE
feat: add support for Google Tag Manager environment config

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/GoogleTagManager/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/GoogleTagManager/browser.js
@@ -15,6 +15,14 @@ class GoogleTagManager {
     }
     this.analytics = analytics;
     this.containerID = config.containerID;
+    this.containerID = config.containerID;
+    // Validate environment configuration
+    if (config.environmentID && typeof config.environmentID !== 'string') {
+      logger.error('GTM environmentID must be a string');
+    }
+    if (config.authorizationToken && typeof config.authorizationToken !== 'string') {
+      logger.error('GTM authorizationToken must be a string');
+    }
     this.environmentID = config.environmentID;
     this.authorizationToken = config.authorizationToken;
     this.name = NAME;

--- a/packages/analytics-js-integrations/src/integrations/GoogleTagManager/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/GoogleTagManager/browser.js
@@ -15,7 +15,6 @@ class GoogleTagManager {
     }
     this.analytics = analytics;
     this.containerID = config.containerID;
-    this.containerID = config.containerID;
     // Validate environment configuration
     if (config.environmentID && typeof config.environmentID !== 'string') {
       logger.error('GTM environmentID must be a string');

--- a/packages/analytics-js-integrations/src/integrations/GoogleTagManager/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/GoogleTagManager/browser.js
@@ -15,6 +15,8 @@ class GoogleTagManager {
     }
     this.analytics = analytics;
     this.containerID = config.containerID;
+    this.environmentID = config.environmentID;
+    this.authorizationToken = config.authorizationToken;
     this.name = NAME;
     this.serverUrl = config.serverUrl;
     ({
@@ -25,7 +27,7 @@ class GoogleTagManager {
   }
 
   init() {
-    loadNativeSdk(this.containerID, this.serverUrl);
+    loadNativeSdk(this.containerID, this.serverUrl, this.environmentID, this.authorizationToken);
   }
 
   isLoaded() {

--- a/packages/analytics-js-integrations/src/integrations/GoogleTagManager/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/GoogleTagManager/nativeSdkLoader.js
@@ -11,8 +11,8 @@ function loadNativeSdk(containerID, serverUrl, environmentID, authorizationToken
     const f = d.getElementsByTagName(s)[0];
     const j = d.createElement(s);
     const dl = l !== 'dataLayer' ? `&l=${l}` : '';
-    const gtmEnv = environmentID ? `&gtm_preview=env-${environmentID}` : '';
-    const gtmAuth = authorizationToken ? `&gtm_auth=${authorizationToken}` : '';
+    const gtmEnv = environmentID ? `&gtm_preview=env-${encodeURIComponent(environmentID)}` : '';
+    const gtmAuth = authorizationToken ? `&gtm_auth=${encodeURIComponent(authorizationToken)}` : '';
     const gtmCookies = '&gtm_cookies_win=x';
     j.setAttribute('data-loader', LOAD_ORIGIN);
     j.async = true;

--- a/packages/analytics-js-integrations/src/integrations/GoogleTagManager/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/GoogleTagManager/nativeSdkLoader.js
@@ -1,6 +1,6 @@
 import { LOAD_ORIGIN } from '@rudderstack/analytics-js-common/v1.1/utils/constants';
 
-function loadNativeSdk(containerID, serverUrl) {
+function loadNativeSdk(containerID, serverUrl, environmentID, authorizationToken) {
   const defaultUrl = `https://www.googletagmanager.com`;
   // ref: https://developers.google.com/tag-platform/tag-manager/server-side/send-data#update_the_gtmjs_source_domain
 
@@ -11,9 +11,12 @@ function loadNativeSdk(containerID, serverUrl) {
     const f = d.getElementsByTagName(s)[0];
     const j = d.createElement(s);
     const dl = l !== 'dataLayer' ? `&l=${l}` : '';
+    const gtmEnv = environmentID ? `&gtm_preview=env-${environmentID}` : '';
+    const gtmAuth = authorizationToken ? `&gtm_auth=${authorizationToken}` : '';
+    const gtmCookies = '&gtm_cookies_win=x';
     j.setAttribute('data-loader', LOAD_ORIGIN);
     j.async = true;
-    j.src = `${window.finalUrl}/gtm.js?id=${i}${dl}`;
+    j.src = `${window.finalUrl}/gtm.js?id=${i}${dl}${gtmAuth}${gtmEnv}${gtmCookies}`;
     f.parentNode.insertBefore(j, f);
   })(window, document, 'script', 'dataLayer', containerID);
 }


### PR DESCRIPTION
## PR Description

Adds support for Google Tag Manager environment support which requires `gtm_preview` and `gtm_auth` params. This corresponds with the change in the rudder-integrations-config repo: https://github.com/rudderlabs/rudder-integrations-config/pull/1894

## Linear task (optional)

n/a

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced analytics integration by introducing validation checks for environment and authorization properties.
  - Improved resource loading through dynamic URL generation tailored to different deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->