### PR TITLE
chore: fix typo in example apps documentation

### DIFF
--- a/examples/serverless/USAGE.md
+++ b/examples/serverless/USAGE.md
@@ -77,7 +77,7 @@ You can then utilise the RudderStack JS SDK within the fetch methods as usual:
       }
     });
 
-See relevant [example](https://github.com/rudderlabs/rudder-sdk-js/blob/main/examples/serverless/vencel-edge)
+See relevant [example](https://github.com/rudderlabs/rudder-sdk-js/blob/main/examples/serverless/vercel-edge)
 
 ## External resources
 


### PR DESCRIPTION
## PR Description

I've fixed a typo on the Vercel serverless application example's documentation.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the URL provided in our deployment guidance, ensuring the documentation is accurate and user-friendly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->