### PR TITLE
feat: Allow skip initialization on meta

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
@@ -48,6 +48,7 @@ class FacebookPixel {
     this.userIdAsPixelId = config.userIdAsPixelId || [];
     this.whitelistPiiProperties = config.whitelistPiiProperties;
     this.useUpdatedMapping = config.useUpdatedMapping;
+    this.skipInitialization = config.skipInitialization;
     this.name = NAME;
     this.analytics = analytics;
     ({
@@ -74,6 +75,12 @@ class FacebookPixel {
     window.fbq.version = '2.0';
     window.fbq.queue = [];
     window.fbq('set', 'autoConfig', this.autoConfig, this.pixelId); // toggle autoConfig : sends button click and page metadata
+
+    if (this.skipInitialization) {
+      ScriptLoader('fbpixel-integration', 'https://connect.facebook.net/en_US/fbevents.js');
+      return;
+    }
+
     if (this.advancedMapping) {
       if (this.useUpdatedMapping) {
         const userData = {
@@ -110,7 +117,8 @@ class FacebookPixel {
   }
 
   isReady() {
-    return this.isLoaded();
+    const isInitialized = (window.fbq?.getState?.().pixels || []).some(p => p.id === this.pixelId); 
+    return this.isLoaded() && isInitialized;
   }
 
   page(rudderElement) {


### PR DESCRIPTION
## PR Description

Some tools like hubspot tracking initialize meta with their own external id.

To avoid the double initialization we want to delegate fb initialization to hubspot.

On this PR we aim to conditionally disbale meta intialization through rudderstack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option for Facebook Pixel that allows users to control its automatic initialization.
  - Enhanced the readiness verification to ensure the integration is fully loaded and initialized before it is considered ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->