### PR TITLE
feat: add legacy sdk deprecation warnings

### DIFF
--- a/packages/analytics-v1.1/.size-limit.js
+++ b/packages/analytics-v1.1/.size-limit.js
@@ -37,7 +37,7 @@ module.exports = [
     name: 'Core (Content Script - v1.1) - NPM (UMD)',
     path: 'dist/npm/content-script/index.js',
     import: '*',
-    limit: '30 KiB',
+    limit: '30.5 KiB',
   },
   {
     name: 'Core (v1.1) - Legacy - CDN',

--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -1658,19 +1658,15 @@ const startSession = instance.startSession.bind(instance);
 const endSession = instance.endSession.bind(instance);
 const setAuthToken = instance.setAuthToken.bind(instance);
 
-// TODO: Need to remove this in the next release
-// eslint-disable-next-line sonarjs/no-gratuitous-expressions, no-constant-condition
-if (false) {
-  // eslint-disable-next-line no-constant-condition
-  if ('__MODULE_TYPE__' === 'npm') {
-    logger.error(
-      'This RudderStack JavaScript SDK package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest [@rudderstack/analytics-js](https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
-    );
-  } else {
-    logger.error(
-      'This version of the RudderStack JavaScript SDK is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest version (v3) for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
-    );
-  }
+// eslint-disable-next-line no-constant-condition
+if ('__MODULE_TYPE__' === 'npm') {
+  logger.warn(
+    'This RudderStack JavaScript SDK package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest [@rudderstack/analytics-js](https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
+  );
+} else {
+  logger.warn(
+    'This version of the RudderStack JavaScript SDK is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest version (v3) for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
+  );
 }
 
 export {


### PR DESCRIPTION
## PR Description

I've added deprecated warnings for the legacy SDK on start up.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2949/add-deprecation-warnings-in-legacy-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated deprecation notifications for the RudderStack SDK so that alerts now appear as warnings instead of errors, providing clearer and less alarming guidance for migration.
  
- **Chores**
  - Adjusted size limit for the Core (Content Script - v1.1) - NPM (UMD) entry from 30 KiB to 30.5 KiB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->