### PR TITLE
fix: set default log level to warn

### DIFF
--- a/packages/analytics-js-common/src/v1.1/utils/logUtil.js
+++ b/packages/analytics-js-common/src/v1.1/utils/logUtil.js
@@ -2,7 +2,7 @@ const LOG_LEVEL_INFO = 1;
 const LOG_LEVEL_DEBUG = 2;
 const LOG_LEVEL_WARN = 3;
 const LOG_LEVEL_ERROR = 4;
-const DEF_LOG_LEVEL = LOG_LEVEL_ERROR;
+const DEF_LOG_LEVEL = LOG_LEVEL_WARN;
 let LOG_LEVEL = DEF_LOG_LEVEL;
 
 const logger = {


### PR DESCRIPTION
## PR Description

Updated the default log level of the legacy SDK to "warn". This will allow the deprecated warning to be printed on the console for NPM installations.

## Linear task (optional)
https://linear.app/rudderstack/issue/SDK-2949/add-deprecation-warnings-in-legacy-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default logging configuration so that, by default, warnings and less severe messages (such as informational and debug logs) are recorded. This change provides enhanced visibility for monitoring and troubleshooting without requiring manual configuration adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->