### PR TITLE
feat: avoid reporting non-actionable errors

### DIFF
--- a/packages/analytics-js-common/src/constants/errors.ts
+++ b/packages/analytics-js-common/src/constants/errors.ts
@@ -1,4 +1,20 @@
 const FAILED_REQUEST_ERR_MSG_PREFIX = 'The request failed';
-const ERROR_MESSAGES_TO_BE_FILTERED = [FAILED_REQUEST_ERR_MSG_PREFIX];
 
-export { FAILED_REQUEST_ERR_MSG_PREFIX, ERROR_MESSAGES_TO_BE_FILTERED };
+const PLUGINS_LOAD_FAILURE_MESSAGES = [/Failed to fetch dynamically imported module: .*/];
+
+const INTEGRATIONS_LOAD_FAILURE_MESSAGES = [
+  /Failed to load the script with the id .*/,
+  /A timeout of \d+ ms occurred while trying to load the script with id .*/,
+];
+
+const ERROR_MESSAGES_TO_BE_FILTERED = [
+  new RegExp(`${FAILED_REQUEST_ERR_MSG_PREFIX}.*`),
+  /A script with the id .* is already loaded\./,
+];
+
+export {
+  FAILED_REQUEST_ERR_MSG_PREFIX,
+  ERROR_MESSAGES_TO_BE_FILTERED,
+  PLUGINS_LOAD_FAILURE_MESSAGES,
+  INTEGRATIONS_LOAD_FAILURE_MESSAGES,
+};

--- a/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
@@ -609,10 +609,46 @@ describe('Error Reporting utilities', () => {
 
   describe('isAllowedToBeNotified', () => {
     const testCases = [
-      ['dummy error', true, 'should allow generic errors'],
       ['The request failed', false, 'should not allow request failures'],
+      [
+        'A script with the id "Google-Analytics-4-(GA4)-V2___1234" is already loaded.',
+        false,
+        'should not allow already loaded script failures',
+      ],
+      [
+        'Failed to fetch dynamically imported module: https://cdn.non-rudderstack.com/3.14.0/modern/plugins/rsa-plugins.js',
+        false,
+        'should not allow plugins load failures from non-RudderStack CDN',
+      ],
+      [
+        'Failed to load the script with the id "Google-Analytics-4-(GA4)-V2___1234" from URL "https://cdn.non-rudderstack.com/3.14.0/modern/js-integrations/GA4_V2.min.js"',
+        false,
+        'should not allow integrations load failures from non-RudderStack CDN',
+      ],
+      [
+        'A timeout of 10000 ms occurred while trying to load the script with id "Google-Analytics-4-(GA4)-V2___1234" from URL "https://cdn.non-rudderstack.com/3.14.0/modern/js-integrations/GA4_V2.min.js"',
+        false,
+        'should not allow integrations load failures from non-RudderStack CDN',
+      ],
+
+      [
+        'Failed to fetch dynamically imported module: https://cdn.rudderlabs.com/v3/modern/plugins/rsa-plugins.js',
+        true,
+        'should allow plugins load failures from RudderStack CDN',
+      ],
+      [
+        'Failed to load the script with the id "Google-Analytics-4-(GA4)-V2___1234" from URL "https://cdn.rudderlabs.com/3.14.0/modern/js-integrations/GA4_V2.min.js"',
+        true,
+        'should allow integrations load failures from RudderStack CDN',
+      ],
+      [
+        'A timeout of 10000 ms occurred while trying to load the script with id "Google-Analytics-4-(GA4)-V2___1234" from URL "https://cdn.rudderlabs.com/3.14.0/modern/js-integrations/GA4_V2.min.js"',
+        true,
+        'should allow integrations load failures from RudderStack CDN',
+      ],
+
+      ['dummy error', true, 'should allow generic errors'],
       ['', true, 'should allow empty messages'],
-      ['Network request failed', true, 'should allow network errors'],
     ];
 
     test.each(testCases)('%s -> %s (%s)', (message, expected, testName) => {

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -74,14 +74,10 @@ class ErrorHandler implements IErrorHandler {
       const stacktrace = getStacktrace(normalizedError) as string;
       const isSdkDispatched = stacktrace.includes(MANUAL_ERROR_IDENTIFIER);
 
-      // Filter unhandled errors that are not originated in the SDK.
-      // However, in case of NPM installations, since we cannot differentiate between SDK and application errors, we should report all errors.
-      if (
-        !isSDKError(bsException) &&
-        state.context.app.value.installType !== 'npm' &&
-        !isSdkDispatched &&
-        errorType !== ErrorType.HANDLEDEXCEPTION
-      ) {
+      // Filter errors that are not originated in the SDK.
+      // In case of NPM installations, the errors from the SDK cannot be identified
+      // and will NOT be reported unless they occur in plugins or integrations.
+      if (!isSdkDispatched && !isSDKError(bsException)) {
         return;
       }
 


### PR DESCRIPTION
## PR Description

We're strictly reporting errors that we're sure from the SDK. Earlier, in case of NPM installations, we reported all the errors.

I've suppressed reporting the following errors:
- Plugin and integrations load failures from non-RS CDN.
- Duplicate script load failures for integrations.

## Linear task (optional)
https://linear.app/rudderstack/issue/SDK-2974/improve-error-reporting

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error notification filtering to accurately identify critical issues. The new logic distinguishes errors related to external resource (plugin/integration) load failures, ensuring that only significant issues trigger alerts.

- **Bug Fixes**
  - Refined error handling to reduce false notifications and unnecessary log clutter. This improvement provides clearer and more reliable error reporting, enhancing the overall user experience during troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->