### PR TITLE
fix: replace vulnerable package with custom implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       ],
       "dependencies": {
         "@lukeed/uuid": "2.0.1",
-        "@ndhoule/defaults": "2.0.1",
         "@ndhoule/each": "2.0.1",
         "@ndhoule/extend": "2.0.0",
         "@preact/signals-core": "1.8.0",
@@ -3984,20 +3983,6 @@
         "@tybys/wasm-util": "^0.9.0"
       }
     },
-    "node_modules/@ndhoule/defaults": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ndhoule/defaults/-/defaults-2.0.1.tgz",
-      "integrity": "sha512-wwuxdvaTbgw9mmeZ516RQWx9V+ToC+B6t3g+eM/CgzXsf+JLvunLd9WOn9yHP4tzxV6nDDTx8fEwhU+xWsX4tA==",
-      "dependencies": {
-        "@ndhoule/drop": "^2.0.0",
-        "@ndhoule/rest": "^2.0.0"
-      }
-    },
-    "node_modules/@ndhoule/drop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ndhoule/drop/-/drop-2.0.0.tgz",
-      "integrity": "sha512-vtVA2bqlzvYhwjxbKUYbGM8Ouba4n3cXKWbDyLaZldjUPQ2Mlizv3LR1J7qqRVTUpxZj41vUOQwqXdocrCrWzw=="
-    },
     "node_modules/@ndhoule/each": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@ndhoule/each/-/each-2.0.1.tgz",
@@ -4015,11 +4000,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@ndhoule/keys/-/keys-2.0.0.tgz",
       "integrity": "sha512-vtCqKBC1Av6dsBA8xpAO+cgk051nfaI+PnmTZep2Px0vYrDvpUmLxv7z40COlWH5yCpu3gzNhepk+02yiQiZNw=="
-    },
-    "node_modules/@ndhoule/rest": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ndhoule/rest/-/rest-2.0.0.tgz",
-      "integrity": "sha512-oBzJczbr6E/McwdSYWzOJvIcIFvLDHM0NHct+B2T7RQStpLMP+H4ay4kzxk0Wts8MaLw5BSRxxelAhWERRol3w=="
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -25533,7 +25513,6 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@lukeed/uuid": "2.0.1",
-        "@ndhoule/defaults": "2.0.1",
         "@preact/signals-core": "1.8.0",
         "@segment/top-domain": "3.0.1",
         "crypto-js": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   },
   "dependencies": {
     "@lukeed/uuid": "2.0.1",
-    "@ndhoule/defaults": "2.0.1",
     "@ndhoule/each": "2.0.1",
     "@ndhoule/extend": "2.0.0",
     "@preact/signals-core": "1.8.0",

--- a/packages/analytics-js-common/package.json
+++ b/packages/analytics-js-common/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@preact/signals-core": "1.8.0",
-    "@ndhoule/defaults": "2.0.1",
     "rudder-component-cookie": "0.0.1",
     "@segment/top-domain": "3.0.1",
     "crypto-js": "4.2.0",

--- a/packages/analytics-js-common/src/utilities/object.ts
+++ b/packages/analytics-js-common/src/utilities/object.ts
@@ -27,6 +27,14 @@ const isObjectAndNotNull = (value: any): value is object =>
 const isObjectLiteralAndNotNull = <T>(value?: T): value is T =>
   !isNull(value) && Object.prototype.toString.call(value) === '[object Object]';
 
+/**
+ * Merges two arrays deeply, right-to-left
+ * In the case of conflicts, the right array's values replace the left array's values in the
+ * same index position
+ * @param leftValue - The left array
+ * @param rightValue - The right array
+ * @returns The merged array
+ */
 const mergeDeepRightObjectArrays = (
   leftValue: any | any[],
   rightValue: any | any[],
@@ -46,6 +54,15 @@ const mergeDeepRightObjectArrays = (
   return mergedArray;
 };
 
+/**
+ * Merges two objects deeply, right-to-left.
+ * In the case of conflicts, the right object's values take precedence.
+ * For arrays, the right array's values replace the left array's values in the
+ * same index position keeping the remaining left array's values in the resultant array.
+ * @param leftObject - The left object
+ * @param rightObject - The right object
+ * @returns The merged object
+ */
 const mergeDeepRight = <T = Record<string, any>>(
   leftObject: Record<string, any>,
   rightObject: Record<string, any>,

--- a/packages/analytics-js-common/src/v1.1/utils/storage/cookie.js
+++ b/packages/analytics-js-common/src/v1.1/utils/storage/cookie.js
@@ -1,7 +1,7 @@
 import cookie from 'rudder-component-cookie';
-import defaults from '@ndhoule/defaults';
 import topDomain from '@segment/top-domain';
 import { clone } from 'ramda';
+import { mergeDeepRight } from '../../../utilities/object';
 import { logger } from '../logUtil';
 
 /**
@@ -24,13 +24,17 @@ class CookieLocal {
     let domain = `.${topDomain(window.location.href)}`;
     if (domain === '.') domain = null;
 
-    // the default maxage and path
-    this.cOpts = defaults(inOpts, {
-      maxage: 31536000000,
-      path: '/',
-      domain,
-      samesite: 'Lax',
-    });
+    // Override the default options with the provided options
+    this.cOpts = mergeDeepRight(
+      {
+        maxage: 31536000000,
+        path: '/',
+        domain,
+        samesite: 'Lax',
+      },
+      inOpts,
+    );
+
     // configure cookies for exactly same domain
     if (inOpts.sameDomainCookiesOnly) {
       delete this.cOpts.domain;

--- a/packages/analytics-js-common/src/v1.1/utils/storage/store.js
+++ b/packages/analytics-js-common/src/v1.1/utils/storage/store.js
@@ -27,7 +27,6 @@ class StoreLocal {
     );
 
     this.enabled = this.sOpts.enabled && this.enabled;
-    this.sOpts = options;
     return this.sOpts;
   }
 

--- a/packages/analytics-js-common/src/v1.1/utils/storage/store.js
+++ b/packages/analytics-js-common/src/v1.1/utils/storage/store.js
@@ -1,5 +1,5 @@
-import defaults from '@ndhoule/defaults';
 import store from 'storejs';
+import { mergeDeepRight } from '../../../utilities/object';
 
 /**
  * An object utility to persist user and other values in localstorage
@@ -18,9 +18,15 @@ class StoreLocal {
   options(options = {}) {
     if (arguments.length === 0) return this.sOpts;
 
-    defaults(options, { enabled: true });
+    // Override the default options with the provided options
+    this.sOpts = mergeDeepRight(
+      {
+        enabled: true,
+      },
+      options,
+    );
 
-    this.enabled = options.enabled && this.enabled;
+    this.enabled = this.sOpts.enabled && this.enabled;
     this.sOpts = options;
     return this.sOpts;
   }


### PR DESCRIPTION
## PR Description

I've replaced the vulnerable NPM package `@ndhoule/defaults` with custom implementation. This was only used by the legacy SDK.

https://github.com/rudderlabs/rudder-sdk-js/security/dependabot/349

Before:
```
npm audit --recursive --audit-level=high
# npm audit report

@ndhoule/defaults  *
Severity: high
@ndhoule/defaults prototype pollution - https://github.com/advisories/GHSA-79h2-v6hh-wq23
No fix available
node_modules/@ndhoule/defaults

1 high severity vulnerability
```

After:
```
npm audit --recursive --audit-level=high           
found 0 vulnerabilities
```

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2979/fix-vulnerability-dependency-in-legacy-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the way configuration options are merged for cookie and store management, allowing for deeper and more flexible handling of nested settings.
  
- **New Features**
  - Introduced new functions for deep merging of objects and arrays, enhancing the flexibility of configuration management.

These enhancements provide a more robust experience when managing and customizing settings without altering existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->