### PR TITLE
fix: sdk loading snippet to reduce ambiguity in updating url

### DIFF
--- a/examples/angular/sample-app/src/index.html
+++ b/examples/angular/sample-app/src/index.html
@@ -9,7 +9,7 @@
   <script>
     (function() {
       "use strict";
-      window.RudderSnippetVersion = "3.0.59";
+      window.RudderSnippetVersion = "3.0.60";
       var identifier = "rudderanalytics";
       if (!window[identifier]) {
         window[identifier] = [];

--- a/examples/angular/sample-app/src/index.html
+++ b/examples/angular/sample-app/src/index.html
@@ -9,7 +9,7 @@
   <script>
     (function() {
       "use strict";
-      window.RudderSnippetVersion = "3.0.58";
+      window.RudderSnippetVersion = "3.0.59";
       var identifier = "rudderanalytics";
       if (!window[identifier]) {
         window[identifier] = [];
@@ -20,7 +20,11 @@
           console.error("RudderStack JavaScript SDK snippet included more than once.");
         } else {
           rudderanalytics.snippetExecuted = true;
-
+          window.rudderAnalyticsBuildType = "legacy";
+          var sdkBaseUrl = "https://cdn.rudderlabs.com";
+          var sdkVersion = "v3";
+          var sdkFileName = "rsa.min.js";
+          var scriptLoadingMode = "async";
           var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
           for (var i = 0; i < methods.length; i++) {
             var method = methods[i];
@@ -30,7 +34,7 @@
                   rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                 } else {
                   var _methodName;
-                  (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                  (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                 }
               };
             }(method);

--- a/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/public/index.html
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/public/index.html
@@ -26,26 +26,26 @@
     -->
     <title>React App</title>
     <script type="text/javascript">
-      !function(){"use strict";window.RudderSnippetVersion="3.0.58";var e="rudderanalytics";window[e]||(window[e]=[])
+      !function(){"use strict";window.RudderSnippetVersion="3.0.59";var e="rudderanalytics";window[e]||(window[e]=[])
       ;var rudderanalytics=window[e];if(Array.isArray(rudderanalytics)){
       if(true===rudderanalytics.snippetExecuted&&window.console&&console.error){
       console.error("RudderStack JavaScript SDK snippet included more than once.")}else{rudderanalytics.snippetExecuted=true,
-      window.rudderAnalyticsBuildType="legacy";var sdkBaseUrl="https://cdn.rudderlabs.com/v3";var sdkName="rsa.min.js"
-      ;var scriptLoadingMode="async"
+      window.rudderAnalyticsBuildType="legacy";var sdkBaseUrl="https://cdn.rudderlabs.com";var sdkVersion="v3"
+      ;var sdkFileName="rsa.min.js";var scriptLoadingMode="async"
       ;var r=["setDefaultInstanceKey","load","ready","page","track","identify","alias","group","reset","setAnonymousId","startSession","endSession","consent"]
       ;for(var n=0;n<r.length;n++){var t=r[n];rudderanalytics[t]=function(r){return function(){var n
       ;Array.isArray(window[e])?rudderanalytics.push([r].concat(Array.prototype.slice.call(arguments))):null===(n=window[e][r])||void 0===n||n.apply(window[e],arguments)
       }}(t)}try{
       new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}'),
-      window.rudderAnalyticsBuildType="modern"}catch(o){}var d=document.head||document.getElementsByTagName("head")[0]
-      ;var i=document.body||document.getElementsByTagName("body")[0];window.rudderAnalyticsAddScript=function(e,r,n){
+      window.rudderAnalyticsBuildType="modern"}catch(i){}var d=document.head||document.getElementsByTagName("head")[0]
+      ;var o=document.body||document.getElementsByTagName("body")[0];window.rudderAnalyticsAddScript=function(e,r,n){
       var t=document.createElement("script");t.src=e,t.setAttribute("data-loader","RS_JS_SDK"),r&&n&&t.setAttribute(r,n),
       "async"===scriptLoadingMode?t.async=true:"defer"===scriptLoadingMode&&(t.defer=true),
-      d?d.insertBefore(t,d.firstChild):i.insertBefore(t,i.firstChild)},window.rudderAnalyticsMount=function(){!function(){
+      d?d.insertBefore(t,d.firstChild):o.insertBefore(t,o.firstChild)},window.rudderAnalyticsMount=function(){!function(){
       if("undefined"==typeof globalThis){var e;var r=function getGlobal(){
       return"undefined"!=typeof self?self:"undefined"!=typeof window?window:null}();r&&Object.defineProperty(r,"globalThis",{
       value:r,configurable:true})}
-      }(),window.rudderAnalyticsAddScript("".concat(sdkBaseUrl,"/").concat(window.rudderAnalyticsBuildType,"/").concat(sdkName),"data-rsa-write-key","dummyWriteKey")
+      }(),window.rudderAnalyticsAddScript("".concat(sdkBaseUrl,"/").concat(sdkVersion,"/").concat(window.rudderAnalyticsBuildType,"/").concat(sdkFileName),"data-rsa-write-key","dummyWriteKey")
       },
       "undefined"==typeof Promise||"undefined"==typeof globalThis?window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount"):window.rudderAnalyticsMount()
       ;}}}();

--- a/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/public/index.html
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/public/index.html
@@ -26,7 +26,7 @@
     -->
     <title>React App</title>
     <script type="text/javascript">
-      !function(){"use strict";window.RudderSnippetVersion="3.0.59";var e="rudderanalytics";window[e]||(window[e]=[])
+      !function(){"use strict";window.RudderSnippetVersion="3.0.60";var e="rudderanalytics";window[e]||(window[e]=[])
       ;var rudderanalytics=window[e];if(Array.isArray(rudderanalytics)){
       if(true===rudderanalytics.snippetExecuted&&window.console&&console.error){
       console.error("RudderStack JavaScript SDK snippet included more than once.")}else{rudderanalytics.snippetExecuted=true,

--- a/examples/nextjs/hooks/sample-app/src/app/layout.tsx
+++ b/examples/nextjs/hooks/sample-app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.59";
+              window.RudderSnippetVersion = "3.0.60";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];

--- a/examples/nextjs/hooks/sample-app/src/app/layout.tsx
+++ b/examples/nextjs/hooks/sample-app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.58";
+              window.RudderSnippetVersion = "3.0.59";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];
@@ -29,7 +29,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   console.error("RudderStack JavaScript SDK snippet included more than once.");
                 } else {
                   rudderanalytics.snippetExecuted = true;
-
+                  window.rudderAnalyticsBuildType = "legacy";
+                  var sdkBaseUrl = "https://cdn.rudderlabs.com";
+                  var sdkVersion = "v3";
+                  var sdkFileName = "rsa.min.js";
+                  var scriptLoadingMode = "async";
                   var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
                   for (var i = 0; i < methods.length; i++) {
                     var method = methods[i];
@@ -39,7 +43,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                           rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                         } else {
                           var _methodName;
-                          (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                          (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                         }
                       };
                     }(method);

--- a/examples/nextjs/js/sample-app/src/app/layout.js
+++ b/examples/nextjs/js/sample-app/src/app/layout.js
@@ -17,7 +17,7 @@ export default function RootLayout({ children }) {
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.59";
+              window.RudderSnippetVersion = "3.0.60";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];

--- a/examples/nextjs/js/sample-app/src/app/layout.js
+++ b/examples/nextjs/js/sample-app/src/app/layout.js
@@ -17,7 +17,7 @@ export default function RootLayout({ children }) {
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.58";
+              window.RudderSnippetVersion = "3.0.59";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];
@@ -28,7 +28,11 @@ export default function RootLayout({ children }) {
                   console.error("RudderStack JavaScript SDK snippet included more than once.");
                 } else {
                   rudderanalytics.snippetExecuted = true;
-
+                  window.rudderAnalyticsBuildType = "legacy";
+                  var sdkBaseUrl = "https://cdn.rudderlabs.com";
+                  var sdkVersion = "v3";
+                  var sdkFileName = "rsa.min.js";
+                  var scriptLoadingMode = "async";
                   var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
                   for (var i = 0; i < methods.length; i++) {
                     var method = methods[i];
@@ -38,7 +42,7 @@ export default function RootLayout({ children }) {
                           rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                         } else {
                           var _methodName;
-                          (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                          (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                         }
                       };
                     }(method);

--- a/examples/nextjs/page-router/sample-app/src/pages/_document.tsx
+++ b/examples/nextjs/page-router/sample-app/src/pages/_document.tsx
@@ -9,7 +9,7 @@ export default function Document() {
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.58";
+              window.RudderSnippetVersion = "3.0.59";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];
@@ -20,7 +20,11 @@ export default function Document() {
                   console.error("RudderStack JavaScript SDK snippet included more than once.");
                 } else {
                   rudderanalytics.snippetExecuted = true;
-
+                  window.rudderAnalyticsBuildType = "legacy";
+                  var sdkBaseUrl = "https://cdn.rudderlabs.com";
+                  var sdkVersion = "v3";
+                  var sdkFileName = "rsa.min.js";
+                  var scriptLoadingMode = "async";
                   var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
                   for (var i = 0; i < methods.length; i++) {
                     var method = methods[i];
@@ -30,7 +34,7 @@ export default function Document() {
                           rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                         } else {
                           var _methodName;
-                          (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                          (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                         }
                       };
                     }(method);

--- a/examples/nextjs/page-router/sample-app/src/pages/_document.tsx
+++ b/examples/nextjs/page-router/sample-app/src/pages/_document.tsx
@@ -9,7 +9,7 @@ export default function Document() {
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.59";
+              window.RudderSnippetVersion = "3.0.60";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];

--- a/examples/nextjs/ts/sample-app/src/app/layout.tsx
+++ b/examples/nextjs/ts/sample-app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.59";
+              window.RudderSnippetVersion = "3.0.60";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];

--- a/examples/nextjs/ts/sample-app/src/app/layout.tsx
+++ b/examples/nextjs/ts/sample-app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {`
             (function() {
               "use strict";
-              window.RudderSnippetVersion = "3.0.58";
+              window.RudderSnippetVersion = "3.0.59";
               var identifier = "rudderanalytics";
               if (!window[identifier]) {
                 window[identifier] = [];
@@ -29,7 +29,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   console.error("RudderStack JavaScript SDK snippet included more than once.");
                 } else {
                   rudderanalytics.snippetExecuted = true;
-
+                  window.rudderAnalyticsBuildType = "legacy";
+                  var sdkBaseUrl = "https://cdn.rudderlabs.com";
+                  var sdkVersion = "v3";
+                  var sdkFileName = "rsa.min.js";
+                  var scriptLoadingMode = "async";
                   var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
                   for (var i = 0; i < methods.length; i++) {
                     var method = methods[i];
@@ -39,7 +43,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                           rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                         } else {
                           var _methodName;
-                          (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                          (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                         }
                       };
                     }(method);

--- a/examples/reactjs/hooks/sample-app/public/index.html
+++ b/examples/reactjs/hooks/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/reactjs/hooks/sample-app/public/index.html
+++ b/examples/reactjs/hooks/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -39,7 +39,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -49,7 +53,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/examples/reactjs/js/sample-app/public/index.html
+++ b/examples/reactjs/js/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/reactjs/js/sample-app/public/index.html
+++ b/examples/reactjs/js/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -39,7 +39,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -49,7 +53,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/examples/reactjs/ts/sample-app/public/index.html
+++ b/examples/reactjs/ts/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/reactjs/ts/sample-app/public/index.html
+++ b/examples/reactjs/ts/sample-app/public/index.html
@@ -28,7 +28,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -39,7 +39,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -49,7 +53,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/examples/reactjs/vite/sample-app/index.html
+++ b/examples/reactjs/vite/sample-app/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/reactjs/vite/sample-app/index.html
+++ b/examples/reactjs/vite/sample-app/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -19,7 +19,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -29,7 +33,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/examples/v3-beacon/index.html
+++ b/examples/v3-beacon/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -20,8 +20,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -32,7 +33,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -82,7 +83,7 @@
                   }
                 }
               })();
-              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/examples/v3-beacon/index.html
+++ b/examples/v3-beacon/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/v3-legacy-minimum-plugins/index.html
+++ b/examples/v3-legacy-minimum-plugins/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -20,8 +20,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -32,7 +33,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -82,7 +83,7 @@
                   }
                 }
               })();
-              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/examples/v3-legacy-minimum-plugins/index.html
+++ b/examples/v3-legacy-minimum-plugins/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/v3-legacy/index.html
+++ b/examples/v3-legacy/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -20,8 +20,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -32,7 +33,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -82,7 +83,7 @@
                   }
                 }
               })();
-              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/examples/v3-legacy/index.html
+++ b/examples/v3-legacy/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/v3-minimum-plugins/index.html
+++ b/examples/v3-minimum-plugins/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -20,8 +20,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -32,7 +33,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -82,7 +83,7 @@
                   }
                 }
               })();
-              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/examples/v3-minimum-plugins/index.html
+++ b/examples/v3-minimum-plugins/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/examples/v3/index.html
+++ b/examples/v3/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -20,8 +20,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -32,7 +33,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -82,7 +83,7 @@
                   }
                 }
               })();
-              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/examples/v3/index.html
+++ b/examples/v3/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/analytics-js/__fixtures__/msw.handlers.ts
+++ b/packages/analytics-js/__fixtures__/msw.handlers.ts
@@ -111,7 +111,7 @@ const handlers = [
       },
     });
   }),
-  http.get(`${dummyCDNHost}/modern/${SDK_FILE_NAME}`, () => {
+  http.get(`${dummyCDNHost}/v3/modern/${SDK_FILE_NAME}`, () => {
     const scriptContent = fs.readFileSync(
       path.join(path.resolve(__dirname, SDK_FILE_BASE_PATH), SDK_FILE_NAME),
       'utf-8',

--- a/packages/analytics-js/__tests__/nativeSdkLoader.js
+++ b/packages/analytics-js/__tests__/nativeSdkLoader.js
@@ -1,7 +1,7 @@
 function loadingSnippet(basePath, fileName, writeKey, dpUrl, options = {}) {
   (function() {
     "use strict";
-    window.RudderSnippetVersion = "3.0.59";
+    window.RudderSnippetVersion = "3.0.60";
     var identifier = "rudderanalytics";
     if (!window[identifier]) {
       window[identifier] = [];

--- a/packages/analytics-js/__tests__/nativeSdkLoader.js
+++ b/packages/analytics-js/__tests__/nativeSdkLoader.js
@@ -1,7 +1,7 @@
 function loadingSnippet(basePath, fileName, writeKey, dpUrl, options = {}) {
   (function() {
     "use strict";
-    window.RudderSnippetVersion = "3.0.32";
+    window.RudderSnippetVersion = "3.0.59";
     var identifier = "rudderanalytics";
     if (!window[identifier]) {
       window[identifier] = [];
@@ -14,7 +14,8 @@ function loadingSnippet(basePath, fileName, writeKey, dpUrl, options = {}) {
         rudderanalytics.snippetExecuted = true;
         window.rudderAnalyticsBuildType = "legacy";
         var sdkBaseUrl = basePath;
-        var sdkName = fileName;
+        var sdkVersion = "v3";
+        var sdkFileName = fileName;
         var scriptLoadingMode = "async";
         var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
         for (var i = 0; i < methods.length; i++) {
@@ -25,7 +26,7 @@ function loadingSnippet(basePath, fileName, writeKey, dpUrl, options = {}) {
                 rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
               } else {
                 var _methodName;
-                (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
               }
             };
           }(method);
@@ -75,7 +76,7 @@ function loadingSnippet(basePath, fileName, writeKey, dpUrl, options = {}) {
               }
             }
           })();
-            window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", writeKey);
+          window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", writeKey);
         };
         if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
           window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -10,7 +10,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -22,8 +22,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -34,7 +35,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -66,20 +67,18 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
-                    if (typeof self !== "undefined") { 
-                      return self; 
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
                     }
-                    if (typeof window !== "undefined") { 
-                      return window; 
+                    if (typeof window !== "undefined") {
+                      return window;
                     }
                     return null;
                   };
-                  
                   var global = getGlobal();
-                  
                   if (global) {
-                    Object.defineProperty(global, 'globalThis', {
+                    Object.defineProperty(global, "globalThis", {
                       value: global,
                       configurable: true
                     });
@@ -89,7 +88,7 @@
 
               // Commented out SDK script addition
               // as the build process automatically adds the script
-              // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -10,7 +10,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/loading-scripts/rollup.config.mjs
+++ b/packages/loading-scripts/rollup.config.mjs
@@ -78,7 +78,8 @@ export function getDefaultConfig(distName) {
               unused: false,
               top_retain: [
                 'sdkBaseUrl',
-                'sdkName',
+                'sdkVersion',
+                'sdkFileName',
                 'loadOptions',
                 'scriptLoadingMode',
                 'rudderanalytics',
@@ -92,7 +93,8 @@ export function getDefaultConfig(distName) {
               keep_fnames: true,
               reserved: [
                 'sdkBaseUrl',
-                'sdkName',
+                'sdkVersion',
+                'sdkFileName',
                 'loadOptions',
                 'scriptLoadingMode',
                 'rudderanalytics',

--- a/packages/loading-scripts/src/index.ts
+++ b/packages/loading-scripts/src/index.ts
@@ -21,8 +21,9 @@ if (Array.isArray(rudderanalytics)) {
     (rudderanalytics as any).snippetExecuted = true;
     window.rudderAnalyticsBuildType = 'legacy';
 
-    const sdkBaseUrl = 'https://cdn.rudderlabs.com/v3';
-    const sdkName = 'rsa.min.js';
+    const sdkBaseUrl = 'https://cdn.rudderlabs.com';
+    const sdkVersion = 'v3';
+    const sdkFileName = 'rsa.min.js';
     const scriptLoadingMode = 'async'; // Options: 'async', 'defer', 'none'/'' (empty string)
 
     const methods: string[] = [
@@ -126,7 +127,7 @@ if (Array.isArray(rudderanalytics)) {
       /* eslint-enable */
 
       window.rudderAnalyticsAddScript(
-        `${sdkBaseUrl}/${window.rudderAnalyticsBuildType}/${sdkName}`,
+        `${sdkBaseUrl}/${sdkVersion}/${window.rudderAnalyticsBuildType}/${sdkFileName}`,
         'data-rsa-write-key',
         '__WRITE_KEY__',
       );

--- a/packages/sanity-suite/public/v3/index-cdn.html
+++ b/packages/sanity-suite/public/v3/index-cdn.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/index-cdn.html
+++ b/packages/sanity-suite/public/v3/index-cdn.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -44,8 +44,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/__CDN_VERSION_PATH__";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "__CDN_VERSION_PATH__";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -56,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -64,8 +65,7 @@
             try {
               new Function('class Test{field=()=>{};test({prop=[]}={}){return prop?(prop?.property??[...prop]):import("");}}');
               window.rudderAnalyticsBuildType = "modern";
-            } catch (e) {
-            }
+            } catch (e) {}
             var head = document.head || document.getElementsByTagName("head")[0];
             var body = document.body || document.getElementsByTagName("body")[0];
             window.rudderAnalyticsAddScript = function(url, extraAttributeKey, extraAttributeVal) {
@@ -89,27 +89,25 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
-                    if (typeof self !== "undefined") { 
-                      return self; 
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
                     }
-                    if (typeof window !== "undefined") { 
-                      return window; 
+                    if (typeof window !== "undefined") {
+                      return window;
                     }
                     return null;
                   };
-                  
                   var global = getGlobal();
-                  
                   if (global) {
-                    Object.defineProperty(global, 'globalThis', {
+                    Object.defineProperty(global, "globalThis", {
                       value: global,
                       configurable: true
                     });
                   }
                 }
               })();
-              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/packages/sanity-suite/public/v3/index-local.html
+++ b/packages/sanity-suite/public/v3/index-local.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -44,8 +44,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/v3";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -56,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -88,27 +89,25 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
-                    if (typeof self !== "undefined") { 
-                      return self; 
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
                     }
-                    if (typeof window !== "undefined") { 
-                      return window; 
+                    if (typeof window !== "undefined") {
+                      return window;
                     }
                     return null;
                   };
-                  
                   var global = getGlobal();
-                  
                   if (global) {
-                    Object.defineProperty(global, 'globalThis', {
+                    Object.defineProperty(global, "globalThis", {
                       value: global,
                       configurable: true
                     });
                   }
                 }
               })();
-              // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/packages/sanity-suite/public/v3/index-local.html
+++ b/packages/sanity-suite/public/v3/index-local.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/index-npm-bundled.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/index-npm-bundled.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -43,7 +43,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -53,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/packages/sanity-suite/public/v3/index-npm.html
+++ b/packages/sanity-suite/public/v3/index-npm.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/index-npm.html
+++ b/packages/sanity-suite/public/v3/index-npm.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -43,7 +43,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -53,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/packages/sanity-suite/public/v3/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v3/integrations/index-cdn.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v3/integrations/index-cdn.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -44,8 +44,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/__CDN_VERSION_PATH__";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "__CDN_VERSION_PATH__";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -56,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -88,27 +89,25 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
-                    if (typeof self !== "undefined") { 
-                      return self; 
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
                     }
-                    if (typeof window !== "undefined") { 
-                      return window; 
+                    if (typeof window !== "undefined") {
+                      return window;
                     }
                     return null;
                   };
-                  
                   var global = getGlobal();
-                  
                   if (global) {
-                    Object.defineProperty(global, 'globalThis', {
+                    Object.defineProperty(global, "globalThis", {
                       value: global,
                       configurable: true
                     });
                   }
                 }
               })();
-              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/packages/sanity-suite/public/v3/integrations/index-local.html
+++ b/packages/sanity-suite/public/v3/integrations/index-local.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/integrations/index-local.html
+++ b/packages/sanity-suite/public/v3/integrations/index-local.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -44,8 +44,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/__CDN_VERSION_PATH__";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "__CDN_VERSION_PATH__";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -56,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -88,27 +89,25 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
-                    if (typeof self !== "undefined") { 
-                      return self; 
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
                     }
-                    if (typeof window !== "undefined") { 
-                      return window; 
+                    if (typeof window !== "undefined") {
+                      return window;
                     }
                     return null;
                   };
-                  
                   var global = getGlobal();
-                  
                   if (global) {
-                    Object.defineProperty(global, 'globalThis', {
+                    Object.defineProperty(global, "globalThis", {
                       value: global,
                       configurable: true
                     });
                   }
                 }
               })();
-              // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm-bundled.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -43,7 +43,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -53,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/packages/sanity-suite/public/v3/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/integrations/index-npm.html
+++ b/packages/sanity-suite/public/v3/integrations/index-npm.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -43,7 +43,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -53,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -44,8 +44,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/__CDN_VERSION_PATH__";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "__CDN_VERSION_PATH__";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -56,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -88,27 +89,25 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
-                    if (typeof self !== "undefined") { 
-                      return self; 
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
                     }
-                    if (typeof window !== "undefined") { 
-                      return window; 
+                    if (typeof window !== "undefined") {
+                      return window;
                     }
                     return null;
                   };
-                  
                   var global = getGlobal();
-                  
                   if (global) {
-                    Object.defineProperty(global, 'globalThis', {
+                    Object.defineProperty(global, "globalThis", {
                       value: global,
                       configurable: true
                     });
                   }
                 }
               })();
-              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-local.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -44,8 +44,9 @@
           } else {
             rudderanalytics.snippetExecuted = true;
             window.rudderAnalyticsBuildType = "legacy";
-            var sdkBaseUrl = "https://cdn.rudderlabs.com/__CDN_VERSION_PATH__";
-            var sdkName = "rsa.min.js";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "__CDN_VERSION_PATH__";
+            var sdkFileName = "rsa.min.js";
             var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
@@ -56,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);
@@ -88,27 +89,25 @@
             window.rudderAnalyticsMount = function() {
               (function() {
                 if (typeof globalThis === "undefined") {
-                  var getGlobal = function() {
-                    if (typeof self !== "undefined") { 
-                      return self; 
+                  var getGlobal = function getGlobal() {
+                    if (typeof self !== "undefined") {
+                      return self;
                     }
-                    if (typeof window !== "undefined") { 
-                      return window; 
+                    if (typeof window !== "undefined") {
+                      return window;
                     }
                     return null;
                   };
-                  
                   var global = getGlobal();
-                  
                   if (global) {
-                    Object.defineProperty(global, 'globalThis', {
+                    Object.defineProperty(global, "globalThis", {
                       value: global,
                       configurable: true
                     });
                   }
                 }
               })();
-              // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkName), "data-rsa-write-key", "__WRITE_KEY__");
+              // window.rudderAnalyticsAddScript("".concat(sdkBaseUrl, "/").concat(sdkVersion, "/").concat(window.rudderAnalyticsBuildType, "/").concat(sdkFileName), "data-rsa-write-key", "__WRITE_KEY__");
             };
             if (typeof Promise === "undefined" || typeof globalThis === "undefined") {
               window.rudderAnalyticsAddScript("https://polyfill-fastly.io/v3/polyfill.min.js?version=3.111.0&features=Symbol%2CPromise&callback=rudderAnalyticsMount");

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm-bundled.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -43,7 +43,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -53,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.59";
+        window.RudderSnippetVersion = "3.0.60";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-npm.html
@@ -32,7 +32,7 @@
       // prettier-ignore
       (function() {
         "use strict";
-        window.RudderSnippetVersion = "3.0.58";
+        window.RudderSnippetVersion = "3.0.59";
         var identifier = "rudderanalytics";
         if (!window[identifier]) {
           window[identifier] = [];
@@ -43,7 +43,11 @@
             console.error("RudderStack JavaScript SDK snippet included more than once.");
           } else {
             rudderanalytics.snippetExecuted = true;
-
+            window.rudderAnalyticsBuildType = "legacy";
+            var sdkBaseUrl = "https://cdn.rudderlabs.com";
+            var sdkVersion = "v3";
+            var sdkFileName = "rsa.min.js";
+            var scriptLoadingMode = "async";
             var methods = [ "setDefaultInstanceKey", "load", "ready", "page", "track", "identify", "alias", "group", "reset", "setAnonymousId", "startSession", "endSession", "consent" ];
             for (var i = 0; i < methods.length; i++) {
               var method = methods[i];
@@ -53,7 +57,7 @@
                     rudderanalytics.push([ methodName ].concat(Array.prototype.slice.call(arguments)));
                   } else {
                     var _methodName;
-                    (_methodName = window[identifier][methodName]) === null || _methodName === void 0 || _methodName.apply(window[identifier], arguments);
+                    (_methodName = window[identifier][methodName]) === null || _methodName === undefined || _methodName.apply(window[identifier], arguments);
                   }
                 };
               }(method);


### PR DESCRIPTION
## PR Description

I've updated the SDK loading snippet to split the variables that form the final URL of the core SDK.
`sdkBaseUrl` - refers to the CDN URL without the version
`sdkVersion` - refers to the SDK version
`sdkFileName` - refers to the SDK file name on the CDN

This will be helpful for the customers who setup custom domains and have to update the snippet to just replace RS CDN URL with theirs, leaving aside the version and the file name.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2942/update-sdk-loading-snippet-to-decouple-the-sdk-major-version-and

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Incremented the RudderSnippet version from "3.0.58" to "3.0.60".
  - Introduced new configuration variables: `window.rudderAnalyticsBuildType`, `sdkBaseUrl`, `sdkVersion`, `sdkFileName`, and `scriptLoadingMode`.

- **Refactor**
  - Streamlined the SDK loading process to include explicit version details in the URL, ensuring more predictable asset retrieval.
  - Enhanced the clarity and maintainability of the code by separating the SDK version and file name into distinct variables.

- **Bug Fixes**
  - Updated error handling logic to check for `undefined` directly instead of using `void 0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->