### PR TITLE
feat: turn sdk deprecation warnings into errors

### DIFF
--- a/packages/analytics-v1.1/src/core/analytics.js
+++ b/packages/analytics-v1.1/src/core/analytics.js
@@ -1660,11 +1660,11 @@ const setAuthToken = instance.setAuthToken.bind(instance);
 
 // eslint-disable-next-line no-constant-condition
 if ('__MODULE_TYPE__' === 'npm') {
-  logger.warn(
+  logger.error(
     'This RudderStack JavaScript SDK package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest [@rudderstack/analytics-js](https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
   );
 } else {
-  logger.warn(
+  logger.error(
     'This version of the RudderStack JavaScript SDK is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest version (v3) for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/.',
   );
 }


### PR DESCRIPTION
## PR Description

I've converted the [legacy SDK deprecation warnings](https://github.com/rudderlabs/rudder-sdk-js/pull/2038) into errors.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-2950/add-deprecation-errors-in-legacy-sdk)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deprecation notifications to display as critical errors instead of warnings. This enhancement ensures that users and monitoring systems are more clearly alerted when deprecated features are in use, helping you remain aware of changes regarding support and maintenance. The overall functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->