### PR TITLE
fix: retry status code logic and error messages

### DIFF
--- a/packages/analytics-js-common/__tests__/utilities/http.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/http.test.ts
@@ -1,0 +1,44 @@
+import { isErrRetryable } from '../../src/utilities/http';
+
+describe('utilities - http', () => {
+  describe('isErrRetryable', () => {
+    const testCases: [number, boolean][] = [
+      // 2xx status codes - should be retryable
+      [200, true],
+      [201, true],
+      [204, true],
+
+      // 3xx status codes - should be retryable
+      [301, true],
+      [302, true],
+      [304, true],
+
+      // 4xx status codes - should NOT be retryable (except 429)
+      [400, false],
+      [401, false],
+      [403, false],
+      [404, false],
+      [422, false],
+      [429, true], // Too Many Requests - should be retryable
+      [451, false],
+
+      // 5xx status codes - should be retryable
+      [500, true],
+      [501, true],
+      [502, true],
+      [503, true],
+      [504, true],
+    ];
+
+    it.each(testCases)('should return %p when status code is %p', (statusCode, expected) => {
+      expect(isErrRetryable(statusCode)).toBe(expected);
+    });
+
+    it('should handle edge cases', () => {
+      // Invalid status codes should follow the same logic
+      expect(isErrRetryable(0)).toBe(true);
+      expect(isErrRetryable(-1)).toBe(true);
+      expect(isErrRetryable(600)).toBe(true);
+    });
+  });
+});

--- a/packages/analytics-js-common/src/utilities/http.ts
+++ b/packages/analytics-js-common/src/utilities/http.ts
@@ -1,13 +1,14 @@
-import type { ResponseDetails } from '../types/HttpClient';
-
-const isErrRetryable = (details?: ResponseDetails) => {
-  let isRetryableNWFailure = false;
-  if (details?.error && details?.xhr) {
-    const xhrStatus = details.xhr.status;
-    // same as in v1.1
-    isRetryableNWFailure = xhrStatus === 429 || (xhrStatus >= 500 && xhrStatus < 600);
+/**
+ * This function is used to determine if the input status code is retryable.
+ * @param status - The status code.
+ * @returns True if the status code is not 4xx (except 429), false otherwise.
+ */
+const isErrRetryable = (status: number) => {
+  if (status === 429) {
+    return true;
   }
-  return isRetryableNWFailure;
+
+  return !(status >= 400 && status < 500);
 };
 
 export { isErrRetryable };

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
@@ -148,7 +148,7 @@ describe('XhrQueue', () => {
     // Mock getAsyncData to return a retryable failure
 
     defaultHttpClient.getAsyncData.mockImplementation(({ callback }) => {
-      callback?.(false, { error: 'some error', xhr: { status: 429 } });
+      callback?.(false, { error: { message: 'Too many requests' }, xhr: { status: 429 } });
     });
     const queue = (XhrQueue()?.dataplaneEventsQueue as ExtensionPoint).init?.(
       state,
@@ -183,7 +183,7 @@ describe('XhrQueue', () => {
     queue.start();
 
     expect(defaultLogger.error).toHaveBeenCalledWith(
-      'XhrQueuePlugin:: Failed to deliver event(s) to https://sampleurl.com/v1/track. It/they will be retried.',
+      'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried.',
     );
 
     // The element is requeued

--- a/packages/analytics-js-plugins/src/xhrQueue/logMessages.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/logMessages.ts
@@ -1,6 +1,6 @@
 import { LOG_CONTEXT_SEPARATOR } from '../shared-chunks/common';
 
-const EVENT_DELIVERY_FAILURE_ERROR_PREFIX = (context: string, url: string): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}Failed to deliver event(s) to ${url}.`;
+const EVENT_DELIVERY_FAILURE_ERROR_PREFIX = (context: string, originalErrorMsg: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}Failed to deliver event(s). Cause: ${originalErrorMsg}.`;
 
 export { EVENT_DELIVERY_FAILURE_ERROR_PREFIX };

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -24,7 +24,7 @@ export default [
   {
     name: 'Core - Legacy - CDN',
     path: 'dist/cdn/legacy/iife/rsa.min.js',
-    limit: '47.5 KiB',
+    limit: '47.6 KiB',
   },
   {
     name: 'Core - Modern - NPM (ESM)',

--- a/packages/analytics-js/__fixtures__/msw.handlers.ts
+++ b/packages/analytics-js/__fixtures__/msw.handlers.ts
@@ -40,17 +40,17 @@ const handlers = [
     });
   }),
   http.get(`${dummyDataplaneHost}/404ErrorSample`, () => {
-    return new HttpResponse(null, {
+    return new HttpResponse('Not Found', {
       status: 404,
     });
   }),
   http.get(`${dummyDataplaneHost}/429ErrorSample`, () => {
-    return new HttpResponse(null, {
+    return new HttpResponse('Too Many Requests', {
       status: 429,
     });
   }),
   http.get(`${dummyDataplaneHost}/500ErrorSample`, () => {
-    return new HttpResponse(null, {
+    return new HttpResponse('Internal Server Error', {
       status: 500,
     });
   }),

--- a/packages/analytics-js/__tests__/services/HttpClient/HttpClient.test.ts
+++ b/packages/analytics-js/__tests__/services/HttpClient/HttpClient.test.ts
@@ -102,7 +102,7 @@ describe('HttpClient', () => {
   it('should handle 400 range errors in getAsyncData requests', done => {
     const callback = (data: any, details: ResponseDetails) => {
       const errResult = new Error(
-        'The request failed with status: 404, Not Found for URL: https://dummy.dataplane.host.com/404ErrorSample.',
+        'The request failed with status 404 (Not Found) for URL: https://dummy.dataplane.host.com/404ErrorSample. Response: Not Found',
       );
       expect(details.error).toEqual(errResult);
       done();
@@ -120,7 +120,7 @@ describe('HttpClient', () => {
     expect(response.data).toBeUndefined();
     expect(response.details?.error).toEqual(
       new Error(
-        'The request failed with status: 404, Not Found for URL: https://dummy.dataplane.host.com/404ErrorSample.',
+        'The request failed with status 404 (Not Found) for URL: https://dummy.dataplane.host.com/404ErrorSample. Response: Not Found',
       ),
     );
   });
@@ -128,7 +128,7 @@ describe('HttpClient', () => {
   it('should handle 500 range errors in getAsyncData requests', done => {
     const callback = (response: any, reject: ResponseDetails) => {
       const errResult = new Error(
-        'The request failed with status: 500, Internal Server Error for URL: https://dummy.dataplane.host.com/500ErrorSample.',
+        'The request failed with status 500 (Internal Server Error) for URL: https://dummy.dataplane.host.com/500ErrorSample. Response: Internal Server Error',
       );
       expect(reject.error).toEqual(errResult);
       done();
@@ -146,7 +146,7 @@ describe('HttpClient', () => {
     expect(response.data).toBeUndefined();
     expect(response.details?.error).toEqual(
       new Error(
-        'The request failed with status: 500, Internal Server Error for URL: https://dummy.dataplane.host.com/500ErrorSample.',
+        'The request failed with status 500 (Internal Server Error) for URL: https://dummy.dataplane.host.com/500ErrorSample. Response: Internal Server Error',
       ),
     );
   });
@@ -158,7 +158,7 @@ describe('HttpClient', () => {
     expect(response.data).toBeUndefined();
     expect(response.details?.error).toEqual(
       new Error(
-        'The request failed due to timeout or no connection (error) for URL: https://dummy.dataplane.host.com/noConnectionSample.',
+        'The request failed due to timeout or no connection (error) at the client side for URL: https://dummy.dataplane.host.com/noConnectionSample',
       ),
     );
   });

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -98,9 +98,9 @@
             }
             var loadOptions = {
               logLevel: 'DEBUG',
-              // integrations: {
-              //   All: false
-              // },
+              integrations: {
+                All: false
+              },
               // useGlobalIntegrationsConfigInEvents: true,
               // useServerSideCookies:true,
               // queueOptions: {

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -98,9 +98,9 @@
             }
             var loadOptions = {
               logLevel: 'DEBUG',
-              integrations: {
-                All: false
-              },
+              // integrations: {
+              //   All: false
+              // },
               // useGlobalIntegrationsConfigInEvents: true,
               // useServerSideCookies:true,
               // queueOptions: {

--- a/packages/analytics-js/rollup.config.mjs
+++ b/packages/analytics-js/rollup.config.mjs
@@ -24,6 +24,7 @@ import pkg from './package.json' assert { type: 'json' };
 
 dotenv.config();
 const isLegacyBuild = process.env.BROWSERSLIST_ENV !== 'modern';
+const additionalWatchPaths = isLegacyBuild ? ['../analytics-js-plugins/src/**', '../analytics-js-common/src/**'] : [];
 const variantSubfolder = isLegacyBuild ? '/legacy' : '/modern';
 const bundledPluginsList = process.env.BUNDLED_PLUGINS;
 const isDynamicCustomBuild = Boolean(bundledPluginsList);
@@ -165,7 +166,7 @@ export function getDefaultConfig(distName) {
 
   return {
     watch: {
-      include: ['src/**'],
+      include: ['src/**', ...additionalWatchPaths],
     },
     external: [/rudderAnalyticsRemotePlugins\/.*/, ...Object.keys(pkg.peerDependencies || {})],
     onwarn(warning, warn) {

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -85,10 +85,12 @@ const XHR_DELIVERY_ERROR = (
   status: number,
   statusText: string,
   url: string,
-): string => `${prefix} with status: ${status}, ${statusText} for URL: ${url}.`;
+  response: string,
+): string =>
+  `${prefix} with status ${status} (${statusText}) for URL: ${url}. Response: ${response.trim()}`;
 
 const XHR_REQUEST_ERROR = (prefix: string, e: ProgressEvent | undefined, url: string): string =>
-  `${prefix} due to timeout or no connection (${e ? e.type : ''}) for URL: ${url}.`;
+  `${prefix} due to timeout or no connection (${e ? e.type : ''}) at the client side for URL: ${url}`;
 
 const XHR_SEND_ERROR = (prefix: string, url: string): string => `${prefix} for URL: ${url}`;
 

--- a/packages/analytics-js/src/services/HttpClient/xhr/xhrRequestHandler.ts
+++ b/packages/analytics-js/src/services/HttpClient/xhr/xhrRequestHandler.ts
@@ -86,6 +86,7 @@ const xhrRequest = (
             xhr.status,
             xhr.statusText,
             options.url,
+            xhr.responseText,
           ),
         ),
         xhr,


### PR DESCRIPTION
## PR Description

I've updated the events retryability logic to drop events strictly only for 4xx (excluding 429) status codes.
Client-side errors like no-connection, slow network or broken connections or ad-blockers are now retried.

Additionally, I've updated the error messages logged in case of event delivery failures to also include the raw error message from the HttpClient which includes status code and response text information.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2997/fix-retry-mechanism-and-improve-error-messaging-for-data-plane-events

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced batch processing in event queuing to increase processing efficiency.
  
- **Bug Fixes**
  - Enhanced error messages for failed requests, now clearly displaying status details and descriptive responses.
  - Improved simulated error responses for clarity during failure scenarios.

- **Refactor**
  - Streamlined error handling and event processing logic for greater reliability and easier troubleshooting.
  - Simplified the logic for determining retryable errors based on HTTP status codes.

- **Tests**
  - Expanded test coverage to validate comprehensive error handling and response behavior.
  - Updated tests to reflect changes in error handling and logging mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->