### PR TITLE
fix: sdk instrumentation in example apps loading snippet

### DIFF
--- a/examples/v3-beacon/index.html
+++ b/examples/v3-beacon/index.html
@@ -93,8 +93,8 @@
             var loadOptions = {
               logLevel: 'DEBUG',
               configUrl: 'https://api.rudderstack.com',
-              destSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
-              pluginsSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/plugins',
+              destSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
+              pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins',
               useBeacon: true,
               beaconQueueOptions: {
                 flushQueueInterval: 60 * 1000,

--- a/examples/v3-legacy-minimum-plugins/index.html
+++ b/examples/v3-legacy-minimum-plugins/index.html
@@ -93,8 +93,8 @@
             var loadOptions = {
               logLevel: 'DEBUG',
               configUrl: 'https://api.rudderstack.com',
-              destSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
-              pluginsSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/plugins',
+              destSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
+              pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins',
               plugins: [
                 'StorageEncryption',
                 'XhrQueue'

--- a/examples/v3-legacy/index.html
+++ b/examples/v3-legacy/index.html
@@ -93,8 +93,8 @@
             var loadOptions = {
               logLevel: 'DEBUG',
               configUrl: 'https://api.rudderstack.com',
-              destSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
-              pluginsSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/plugins'
+              destSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
+              pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins'
             };
             rudderanalytics.load('__WRITE_KEY__', '__DATAPLANE_URL__', loadOptions);
           }

--- a/examples/v3-minimum-plugins/index.html
+++ b/examples/v3-minimum-plugins/index.html
@@ -93,8 +93,8 @@
             var loadOptions = {
               logLevel: 'DEBUG',
               configUrl: 'https://api.rudderstack.com',
-              destSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
-              pluginsSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/plugins',
+              destSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
+              pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins',
               plugins: [
                 'StorageEncryption',
                 'XhrQueue'

--- a/examples/v3/index.html
+++ b/examples/v3/index.html
@@ -93,10 +93,10 @@
             var loadOptions = {
               logLevel: 'DEBUG',
               configUrl: 'https://api.rudderstack.com',
-              destSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
-              pluginsSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/plugins'
+              destSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
+              pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins'
             };
-            rudderanalytics.load('__WRITE_KEY__', '__DATAPLANE_URL__', loadOptions);
+            rudderanalytics.load('2L8Fl7ryPss3Zku133Pj5ox7NeP', 'https://rudderstacpn.dataplane.rudderstack.com', loadOptions);
           }
         }
       })();

--- a/packages/sanity-suite/public/v3/index-cdn.html
+++ b/packages/sanity-suite/public/v3/index-cdn.html
@@ -133,8 +133,8 @@
               logLevel: 'DEBUG',
               configUrl: '__CONFIG_SERVER_HOST__',
               destSDKBaseURL:
-                sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
-              pluginsSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/plugins',
+                sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
+              pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins',
               consentManagement: {
                 enabled: true,
                 provider: 'oneTrust',

--- a/packages/sanity-suite/public/v3/integrations/index-cdn.html
+++ b/packages/sanity-suite/public/v3/integrations/index-cdn.html
@@ -121,8 +121,8 @@
       var loadOptions = {
         logLevel: 'DEBUG',
         configUrl: '__CONFIG_SERVER_HOST__',
-        destSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
-        pluginsSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/plugins',
+        destSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
+        pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins',
         consentManagement: {
           enabled: true,
           provider: 'oneTrust',

--- a/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
+++ b/packages/sanity-suite/public/v3/manualLoadCall/index-cdn.html
@@ -119,8 +119,8 @@
               logLevel: 'DEBUG',
               configUrl: '__CONFIG_SERVER_HOST__',
               destSDKBaseURL:
-                sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
-              pluginsSDKBaseURL: sdkBaseUrl + '/' + window.rudderAnalyticsBuildType + '/plugins',
+                sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
+              pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins',
               consentManagement: {
                 enabled: true,
                 provider: 'oneTrust',


### PR DESCRIPTION
## PR Description

I've added the missing `sdkVersion` variable in the example apps and sanity suite HTML files.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2942/update-sdk-loading-snippet-to-decouple-the-sdk-major-version-and

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced analytics integration by incorporating explicit versioning in resource paths to ensure more reliable and accurate loading of SDK components.
  - Updated initialization settings now utilize production-ready configuration values and improved event tracking, resulting in more precise data capture and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->