### PR TITLE
fix: consent api to refresh consent data every time

### DIFF
--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -260,7 +260,9 @@ describe('Core - Analytics', () => {
       analytics.onInitialized();
 
       expect(errorSpy).toHaveBeenCalledTimes(1);
-      expect(errorSpy).toHaveBeenCalledWith('LoadAPI:: The provided callback parameter is not a function.');
+      expect(errorSpy).toHaveBeenCalledWith(
+        'LoadAPI:: The provided callback parameter is not a function.',
+      );
     });
 
     it('should log an error if the onLoaded callback throws an error', () => {
@@ -378,7 +380,9 @@ describe('Core - Analytics', () => {
       analytics.ready(true);
 
       expect(errorSpy).toHaveBeenCalledTimes(1);
-      expect(errorSpy).toHaveBeenCalledWith('ReadyAPI:: The provided callback parameter is not a function.');
+      expect(errorSpy).toHaveBeenCalledWith(
+        'ReadyAPI:: The provided callback parameter is not a function.',
+      );
     });
 
     it('should log an error if the provided callback throws an error', () => {
@@ -802,6 +806,42 @@ describe('Core - Analytics', () => {
           },
         ],
       ]);
+    });
+
+    it('should refresh consents data when the API is invoked multiple times', () => {
+      analytics.prepareInternalServices();
+
+      state.consents.enabled.value = true;
+      state.lifecycle.loaded.value = true;
+      state.consents.initialized.value = false;
+      state.storage.type.value = 'localStorage';
+      state.storage.entries.value = entriesWithMixStorage;
+
+      const invokeSingleSpy = jest.spyOn(
+        analytics.pluginsManager as IPluginsManager,
+        'invokeSingle',
+      );
+
+      analytics.consent();
+
+      expect(invokeSingleSpy).toHaveBeenCalledTimes(2);
+
+      // Update consents data to simulate the plugin populating the data
+      state.consents.data.value = {
+        allowedConsentIds: ['allowed_consent_id'],
+        deniedConsentIds: ['denied_consent_id'],
+      };
+      state.consents.initialized.value = true;
+
+      // Set the state to simulate destinations being ready
+      state.nativeDestinations.clientDestinationsReady.value = true;
+
+      invokeSingleSpy.mockClear();
+
+      // Invoke the API again to refresh the consents data
+      analytics.consent();
+
+      expect(invokeSingleSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -761,7 +761,7 @@ class Analytics implements IAnalytics {
         this.logger,
       );
 
-      state.consents.initialized.value = initialized || state.consents.initialized.value;
+      state.consents.initialized.value = initialized;
       state.consents.data.value = consentsData;
     });
 


### PR DESCRIPTION
## PR Description

When consent API is invoked more than once, the `initialized` state is not cleared from the first invocation. Therefore, if the consent preferences are updated, they are not fetched again when the API is invoked again.

I've fixed it by setting the state to the current value.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3000/fix-consent-api-bug-that-was-not-refreshing-the-data-from-second

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
