### PR TITLE
fix: avoid premature execution before sdk initialization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,28 @@
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/" 
     schedule:
-      interval: 'weekly'
+      interval: "daily"
+    target-branch: "develop"
+
+  - package-ecosystem: "npm"
+    directory: "/" 
+    schedule:
+      interval: "daily"
+    target-branch: "develop"
+    groups:
+      npm-prod-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        dependency-type: "production"
+      npm-dev-deps:
+        patterns:
+          - "*"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"

--- a/examples/v3/index.html
+++ b/examples/v3/index.html
@@ -96,7 +96,7 @@
               destSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/js-integrations',
               pluginsSDKBaseURL: sdkBaseUrl + '/' + sdkVersion + '/' + window.rudderAnalyticsBuildType + '/plugins'
             };
-            rudderanalytics.load('2L8Fl7ryPss3Zku133Pj5ox7NeP', 'https://rudderstacpn.dataplane.rudderstack.com', loadOptions);
+            rudderanalytics.load('__WRITE_KEY__', '__DATAPLANE_URL__', loadOptions);
           }
         }
       })();

--- a/packages/analytics-js-common/__mocks__/ErrorHandler.ts
+++ b/packages/analytics-js-common/__mocks__/ErrorHandler.ts
@@ -6,6 +6,7 @@ import { defaultLogger } from './Logger';
 class ErrorHandler implements IErrorHandler {
   onError = jest.fn();
   leaveBreadcrumb = jest.fn();
+  init = jest.fn();
   httpClient = defaultHttpClient;
   logger = defaultLogger;
 }

--- a/packages/analytics-js-common/__mocks__/Store.ts
+++ b/packages/analytics-js-common/__mocks__/Store.ts
@@ -13,7 +13,7 @@ class Store implements IStore {
     this.name = config.name;
     this.isEncrypted = config.isEncrypted ?? false;
     this.validKeys = config.validKeys ?? {};
-    this.engine = engine ?? defaultLocalStorage;
+    this.engine = engine;
     this.originalEngine = this.engine;
     this.errorHandler = config.errorHandler;
     this.logger = config.logger;

--- a/packages/analytics-js-common/src/types/ErrorHandler.ts
+++ b/packages/analytics-js-common/src/types/ErrorHandler.ts
@@ -7,6 +7,7 @@ export type SDKError = unknown | Error | ErrorEvent | Event | PromiseRejectionEv
 export interface IErrorHandler {
   httpClient: IHttpClient;
   logger: ILogger;
+  init(): void;
   onError(error: SDKError, context?: string, customMessage?: string, errorType?: string): void;
   leaveBreadcrumb(breadcrumb: string): void;
 }

--- a/packages/analytics-js-common/src/types/Store.ts
+++ b/packages/analytics-js-common/src/types/Store.ts
@@ -53,7 +53,7 @@ export interface IStore {
 }
 
 export interface IStorage extends Storage {
-  configure?(options: StorageOptions): void;
+  configure?(options?: StorageOptions): void;
   keys(): string[];
   isEnabled?: boolean;
 }

--- a/packages/analytics-js/__tests__/services/ErrorHandler/ErrorHandler.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/ErrorHandler.test.ts
@@ -10,6 +10,7 @@ describe('ErrorHandler', () => {
   beforeEach(() => {
     resetState();
     errorHandlerInstance = new ErrorHandler(defaultHttpClient, defaultLogger);
+    errorHandlerInstance.init();
   });
 
   it('should attach error listeners for unhandled errors', () => {

--- a/packages/analytics-js/__tests__/services/StoreManager/StoreManager.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/StoreManager.test.ts
@@ -77,11 +77,10 @@ describe('StoreManager', () => {
           secure: state.loadOptions.value.secureCookie,
           domain: state.loadOptions.value.setCookieDomain,
           sameDomainCookiesOnly: state.loadOptions.value.sameDomainCookiesOnly,
-          enabled: true,
         },
-        { enabled: true },
-        { enabled: true },
-        { enabled: true },
+        {},
+        {},
+        {},
       );
 
       expect(storeManager.stores).toHaveProperty('clientDataInCookie');

--- a/packages/analytics-js/__tests__/services/StoreManager/storages/CookieStorage.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/storages/CookieStorage.test.ts
@@ -31,6 +31,7 @@ describe('CookieStorage', () => {
     // engine.clear();
     // expect(engine.length).toStrictEqual(0);
   });
+
   it('should not set domain if sameDomainCookiesOnly is set to true', () => {
     expect(typeof engine.options.domain).toBe('string');
     configureCookieStorageEngine({
@@ -42,5 +43,19 @@ describe('CookieStorage', () => {
     });
     const newEngine = getStorageEngine('cookieStorage');
     expect(newEngine.options.domain).toBe(undefined);
+  });
+
+  it('should properly configure cookie attributes', () => {
+    configureCookieStorageEngine({
+      samesite: 'Strict',
+      secure: true,
+      path: '/app',
+      maxage: 3600000,
+    });
+    const newEngine = getStorageEngine('cookieStorage');
+    expect(newEngine.options.samesite).toBe('Strict');
+    expect(newEngine.options.secure).toBe(true);
+    expect(newEngine.options.path).toBe('/app');
+    expect(newEngine.options.maxage).toBe(3600000);
   });
 });

--- a/packages/analytics-js/__tests__/services/StoreManager/storages/CookieStorage.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/storages/CookieStorage.test.ts
@@ -9,6 +9,7 @@ describe('CookieStorage', () => {
 
   beforeEach(() => {
     engine = getStorageEngine('cookieStorage');
+    engine.configure?.();
     engine.clear();
   });
 

--- a/packages/analytics-js/__tests__/services/StoreManager/storages/InMemoryStorage.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/storages/InMemoryStorage.test.ts
@@ -6,6 +6,7 @@ describe('InMemoryStorage', () => {
 
   beforeEach(() => {
     engine = getStorageEngine('memoryStorage');
+    engine.configure?.();
     engine.clear();
   });
 

--- a/packages/analytics-js/__tests__/services/StoreManager/storages/LocalStorage.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/storages/LocalStorage.test.ts
@@ -6,6 +6,7 @@ describe('Localstorage', () => {
 
   beforeEach(() => {
     engine = getStorageEngine('localStorage');
+    engine.configure?.();
     engine.clear();
   });
 

--- a/packages/analytics-js/__tests__/services/StoreManager/storages/defaultOptions.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/storages/defaultOptions.test.ts
@@ -4,6 +4,7 @@ import { getDefaultCookieOptions } from '../../../../src/services/StoreManager/s
 jest.mock('../../../../src/services/StoreManager/top-domain', () => ({
   domain: jest.fn().mockReturnValue('example.com'),
 }));
+
 describe('getDefaultCookieOptions', () => {
   it('should return default cookie options with a valid top domain', () => {
     const result = getDefaultCookieOptions();

--- a/packages/analytics-js/__tests__/services/StoreManager/storages/sessionStorage.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/storages/sessionStorage.test.ts
@@ -6,6 +6,7 @@ describe('SessionStorage', () => {
 
   beforeEach(() => {
     engine = getStorageEngine('sessionStorage');
+    engine.configure?.();
     engine.clear();
   });
 

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -38,6 +38,10 @@ import { defaultLogger } from '../services/Logger/Logger';
 import { PAGE_UNLOAD_ON_BEACON_DISABLED_WARNING } from '../constants/logMessages';
 import { state } from '../state';
 import { defaultErrorHandler } from '../services/ErrorHandler';
+import { defaultCookieStorage } from '../services/StoreManager/storages/CookieStorage';
+import { defaultLocalStorage } from '../services/StoreManager/storages/LocalStorage';
+import { defaultSessionStorage } from '../services/StoreManager/storages/sessionStorage';
+import { defaultInMemoryStorage } from '../services/StoreManager/storages/InMemoryStorage';
 
 // TODO: add analytics restart/reset mechanism
 
@@ -110,6 +114,12 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
   static initializeGlobalResources() {
     // We need to initialize the error handler first to catch any unhandled errors occurring in this module as well
     defaultErrorHandler.init();
+
+    // Initialize the storage engines with default options
+    defaultCookieStorage.configure();
+    defaultLocalStorage.configure();
+    defaultSessionStorage.configure();
+    defaultInMemoryStorage.configure();
   }
 
   /**

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -168,7 +168,6 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
 
       setExposedGlobal(GLOBAL_PRELOAD_BUFFER, clone(preloadedEventsArray));
 
-      this.analyticsInstances[writeKey] = new Analytics();
       this.getAnalyticsInstance(writeKey)?.load(
         writeKey,
         dataPlaneUrl,

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -37,6 +37,7 @@ import { Analytics } from '../components/core/Analytics';
 import { defaultLogger } from '../services/Logger/Logger';
 import { PAGE_UNLOAD_ON_BEACON_DISABLED_WARNING } from '../constants/logMessages';
 import { state } from '../state';
+import { defaultErrorHandler } from '../services/ErrorHandler';
 
 // TODO: add analytics restart/reset mechanism
 
@@ -64,6 +65,8 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
         return RudderAnalytics.globalSingleton;
         // END-NO-SONAR-SCAN
       }
+
+      RudderAnalytics.initializeGlobalResources();
 
       this.setDefaultInstanceKey = this.setDefaultInstanceKey.bind(this);
       this.getAnalyticsInstance = this.getAnalyticsInstance.bind(this);
@@ -102,6 +105,11 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
     } catch (error: any) {
       dispatchErrorEvent(error);
     }
+  }
+
+  static initializeGlobalResources() {
+    // We need to initialize the error handler first to catch any unhandled errors occurring in this module as well
+    defaultErrorHandler.init();
   }
 
   /**

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -33,6 +33,7 @@ import {
 class ErrorHandler implements IErrorHandler {
   httpClient: IHttpClient;
   logger: ILogger;
+  private initialized = false;
 
   // If no logger is passed errors will be thrown as unhandled error
   constructor(httpClient: IHttpClient, logger: ILogger) {
@@ -40,10 +41,22 @@ class ErrorHandler implements IErrorHandler {
     this.logger = logger;
   }
 
+  /**
+   * Initializes the error handler by attaching global error listeners.
+   * This method should be called once after construction.
+   */
   init() {
+    if (this.initialized) {
+      return;
+    }
+
     this.attachErrorListeners();
+    this.initialized = true;
   }
 
+  /**
+   * Attach error listeners to the global window object
+   */
   attachErrorListeners() {
     (globalThis as typeof window).addEventListener('error', (event: ErrorEvent | Event) => {
       this.onError(event, ERROR_HANDLER, undefined, ErrorType.UNHANDLEDEXCEPTION);
@@ -57,6 +70,13 @@ class ErrorHandler implements IErrorHandler {
     );
   }
 
+  /**
+   * Handle errors
+   * @param error - The error to handle
+   * @param context - The context of where the error occurred
+   * @param customMessage - The custom message of the error
+   * @param errorType - The type of the error (handled or unhandled)
+   */
   onError(
     error: SDKError,
     context = '',

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -38,6 +38,9 @@ class ErrorHandler implements IErrorHandler {
   constructor(httpClient: IHttpClient, logger: ILogger) {
     this.httpClient = httpClient;
     this.logger = logger;
+  }
+
+  init() {
     this.attachErrorListeners();
   }
 

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -45,7 +45,7 @@ class ErrorHandler implements IErrorHandler {
    * Initializes the error handler by attaching global error listeners.
    * This method should be called once after construction.
    */
-  init() {
+  public init() {
     if (this.initialized) {
       return;
     }
@@ -158,6 +158,7 @@ class ErrorHandler implements IErrorHandler {
   }
 }
 
+// Note: Remember to call defaultErrorHandler.init() before using it
 const defaultErrorHandler = new ErrorHandler(defaultHttpClient, defaultLogger);
 
 export { ErrorHandler, defaultErrorHandler };

--- a/packages/analytics-js/src/services/StoreManager/Store.ts
+++ b/packages/analytics-js/src/services/StoreManager/Store.ts
@@ -38,7 +38,7 @@ class Store implements IStore {
     this.name = config.name;
     this.isEncrypted = config.isEncrypted ?? false;
     this.validKeys = config.validKeys ?? {};
-    this.engine = engine ?? getStorageEngine(LOCAL_STORAGE);
+    this.engine = engine;
     this.noKeyValidation = Object.keys(this.validKeys).length === 0;
     this.noCompoundKey = config.noCompoundKey;
     this.originalEngine = this.engine;

--- a/packages/analytics-js/src/services/StoreManager/Store.ts
+++ b/packages/analytics-js/src/services/StoreManager/Store.ts
@@ -6,7 +6,7 @@ import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/Error
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { IPluginsManager } from '@rudderstack/analytics-js-common/types/PluginsManager';
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
-import { LOCAL_STORAGE, MEMORY_STORAGE } from '@rudderstack/analytics-js-common/constants/storages';
+import { MEMORY_STORAGE } from '@rudderstack/analytics-js-common/constants/storages';
 import { getMutatedError } from '@rudderstack/analytics-js-common/utilities/errors';
 import { isStorageQuotaExceeded } from '../../components/capabilitiesManager/detection';
 import {

--- a/packages/analytics-js/src/services/StoreManager/StoreManager.ts
+++ b/packages/analytics-js/src/services/StoreManager/StoreManager.ts
@@ -65,11 +65,10 @@ class StoreManager implements IStoreManager {
         secure: loadOptions.secureCookie,
         domain: loadOptions.setCookieDomain,
         sameDomainCookiesOnly: loadOptions.sameDomainCookiesOnly,
-        enabled: true,
       },
-      localStorageOptions: { enabled: true },
-      inMemoryStorageOptions: { enabled: true },
-      sessionStorageOptions: { enabled: true },
+      localStorageOptions: {},
+      inMemoryStorageOptions: {},
+      sessionStorageOptions: {},
     };
 
     configureStorageEngines(

--- a/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
@@ -7,34 +7,26 @@ import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/objec
 import { cookie } from '@rudderstack/analytics-js-common/component-cookie';
 import { isStorageAvailable } from '../../../components/capabilitiesManager/detection';
 import { getDefaultCookieOptions } from './defaultOptions';
+import { defaultLogger } from '../../Logger';
 
 /**
  * A storage utility to persist values in cookies via Storage interface
  */
 class CookieStorage implements IStorage {
-  static globalSingleton: Nullable<CookieStorage> = null;
   logger?: ILogger;
-  options?: ICookieStorageOptions;
+  options: ICookieStorageOptions;
   isSupportAvailable = true;
   isEnabled = true;
   length = 0;
 
-  constructor(options: Partial<ICookieStorageOptions> = {}, logger?: ILogger) {
-    if (CookieStorage.globalSingleton) {
-      // eslint-disable-next-line no-constructor-return
-      return CookieStorage.globalSingleton;
-    }
-
+  constructor(logger?: ILogger) {
     this.options = getDefaultCookieOptions();
     this.logger = logger;
-    this.configure(options);
-
-    CookieStorage.globalSingleton = this;
   }
 
-  configure(options: Partial<ICookieStorageOptions>): ICookieStorageOptions {
-    this.options = mergeDeepRight(this.options ?? {}, options);
-    if (options.sameDomainCookiesOnly) {
+  configure(options?: Partial<ICookieStorageOptions>): ICookieStorageOptions {
+    this.options = mergeDeepRight(this.options, options ?? {});
+    if (this.options.sameDomainCookiesOnly) {
       delete this.options.domain;
     }
     this.isSupportAvailable = isStorageAvailable(COOKIE_STORAGE, this);
@@ -79,4 +71,6 @@ class CookieStorage implements IStorage {
   }
 }
 
-export { CookieStorage };
+const defaultCookieStorage = new CookieStorage(defaultLogger);
+
+export { CookieStorage, defaultCookieStorage };

--- a/packages/analytics-js/src/services/StoreManager/storages/InMemoryStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/InMemoryStorage.ts
@@ -18,14 +18,13 @@ class InMemoryStorage implements IStorage {
   length = 0;
   data: Record<string, any> = {};
 
-  constructor(options?: IInMemoryStorageOptions, logger?: ILogger) {
+  constructor(logger?: ILogger) {
     this.options = getDefaultInMemoryStorageOptions();
     this.logger = logger;
-    this.configure(options ?? {});
   }
 
-  configure(options: Partial<IInMemoryStorageOptions>): IInMemoryStorageOptions {
-    this.options = mergeDeepRight(this.options, options);
+  configure(options?: Partial<IInMemoryStorageOptions>): IInMemoryStorageOptions {
+    this.options = mergeDeepRight(this.options, options ?? {});
     this.isEnabled = Boolean(this.options.enabled);
     return this.options;
   }
@@ -66,6 +65,6 @@ class InMemoryStorage implements IStorage {
   }
 }
 
-const defaultInMemoryStorage = new InMemoryStorage({}, defaultLogger);
+const defaultInMemoryStorage = new InMemoryStorage(defaultLogger);
 
 export { InMemoryStorage, defaultInMemoryStorage };

--- a/packages/analytics-js/src/services/StoreManager/storages/LocalStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/LocalStorage.ts
@@ -23,14 +23,13 @@ class LocalStorage implements IStorage {
   isEnabled = true;
   length = 0;
 
-  constructor(options: ILocalStorageOptions = {}, logger?: ILogger) {
+  constructor(logger?: ILogger) {
     this.options = getDefaultLocalStorageOptions();
     this.logger = logger;
-    this.configure(options);
   }
 
-  configure(options: Partial<ILocalStorageOptions>): ILocalStorageOptions {
-    this.options = mergeDeepRight(this.options, options);
+  configure(options?: Partial<ILocalStorageOptions>): ILocalStorageOptions {
+    this.options = mergeDeepRight(this.options, options ?? {});
     this.isSupportAvailable = isStorageAvailable(LOCAL_STORAGE);
     this.isEnabled = Boolean(this.options.enabled && this.isSupportAvailable);
     return this.options;
@@ -68,6 +67,6 @@ class LocalStorage implements IStorage {
   }
 }
 
-const defaultLocalStorage = new LocalStorage({}, defaultLogger);
+const defaultLocalStorage = new LocalStorage(defaultLogger);
 
 export { LocalStorage, defaultLocalStorage };

--- a/packages/analytics-js/src/services/StoreManager/storages/sessionStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/sessionStorage.ts
@@ -22,14 +22,13 @@ class SessionStorage implements IStorage {
   length = 0;
   store?: Storage;
 
-  constructor(options: ISessionStorageOptions = {}, logger?: ILogger) {
+  constructor(logger?: ILogger) {
     this.options = getDefaultSessionStorageOptions();
     this.logger = logger;
-    this.configure(options);
   }
 
-  configure(options: Partial<ISessionStorageOptions>): ISessionStorageOptions {
-    this.options = mergeDeepRight(this.options, options);
+  configure(options?: Partial<ISessionStorageOptions>): ISessionStorageOptions {
+    this.options = mergeDeepRight(this.options, options ?? {});
     this.isSupportAvailable = isStorageAvailable(SESSION_STORAGE);
     // when storage is blocked by the user, even accessing the property throws an error
     if (this.isSupportAvailable) {
@@ -88,6 +87,6 @@ class SessionStorage implements IStorage {
   }
 }
 
-const defaultSessionStorage = new SessionStorage({}, defaultLogger);
+const defaultSessionStorage = new SessionStorage(defaultLogger);
 
 export { SessionStorage, defaultSessionStorage };

--- a/packages/analytics-js/src/services/StoreManager/storages/storageEngine.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/storageEngine.ts
@@ -13,11 +13,10 @@ import {
 } from '@rudderstack/analytics-js-common/constants/storages';
 import type { StorageType } from '@rudderstack/analytics-js-common/types/Storage';
 import { state } from '../../../state';
-import { defaultLogger } from '../../Logger';
-import { CookieStorage } from './CookieStorage';
 import { defaultInMemoryStorage } from './InMemoryStorage';
 import { defaultLocalStorage } from './LocalStorage';
 import { defaultSessionStorage } from './sessionStorage';
+import { defaultCookieStorage } from './CookieStorage';
 
 /**
  * A utility to retrieve the storage singleton instance by type
@@ -31,7 +30,7 @@ const getStorageEngine = (type?: StorageType): IStorage => {
     case MEMORY_STORAGE:
       return defaultInMemoryStorage;
     case COOKIE_STORAGE:
-      return new CookieStorage({}, defaultLogger);
+      return defaultCookieStorage;
     default:
       return defaultInMemoryStorage;
   }
@@ -41,7 +40,9 @@ const getStorageEngine = (type?: StorageType): IStorage => {
  * Configure cookie storage singleton
  */
 const configureCookieStorageEngine = (options: Partial<ICookieStorageOptions>) => {
-  const cookieStorageOptions = new CookieStorage({}, defaultLogger).configure(options);
+  const cookieStorageOptions = defaultCookieStorage.configure(options);
+
+  // Update the state with the final cookie storage options
   state.storage.cookie.value = {
     maxage: cookieStorageOptions.maxage,
     path: cookieStorageOptions.path,


### PR DESCRIPTION
## PR Description

I've fixed a couple of issues in the core module that would otherwise execute some logic before the SDK initialisation.

We create default instances of some resources so we should be careful in executing some code in their constructors. Otherwise, some code can get executed just by importing the package.

- Attaching error event handlers
- All storage engines default configuration


All the storage engine modules are refactored to create default instances which will be configured only when the SDK instance is created.
The default instances will be used throughout the code.
Now, there is no need for global singletons.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3003/avoid-attaching-error-listeners-by-default

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic configuration for analytics, allowing flexible key and endpoint setup.
  - Added a centralized initialization routine for global resources, enhancing error handling and storage services.

- **Refactor**
  - Streamlined the initialization process and configuration for various storage modules to improve consistency and reliability.
  - Simplified error handling setup to ensure smoother operation during runtime and testing.
  - Updated storage engine configuration to remove explicit enabling, relying on default behavior.
  - Enhanced the `ErrorHandler` class with a new initialization method for improved setup.
  - Modified storage classes to remove unnecessary options parameters, simplifying their constructors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->