### PR TITLE
feat: speed up rollback process

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -9,7 +9,6 @@ on:
         type: choice
         options:
           - development
-          - staging
           - production
         default: 'development'
 
@@ -47,13 +46,35 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
 
     steps:
+      - name: Configure environment variables
+        run: |
+          echo "DATE=$(date)" >> $GITHUB_ENV
+
+          # TODO: Remove the below once the dev testing is done
+          if [ "${{ inputs.environment }}" == "production" ]; then
+            AWS_ACCOUNT_ID="${{ secrets.AWS_PROD_ACCOUNT_ID }}"
+            AWS_S3_SYNC_ROLE="${{ secrets.AWS_PROD_S3_SYNC_ROLE }}"
+            AWS_S3_BUCKET_NAME="${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
+            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}"
+          elif [ "${{ inputs.environment }}" == "development" ]; then
+            AWS_ACCOUNT_ID="${{ secrets.AWS_DEV_ACCOUNT_ID_TEMP }}"
+            AWS_S3_SYNC_ROLE="${{ secrets.AWS_DEV_S3_SYNC_ROLE_TEMP }}"
+            AWS_S3_BUCKET_NAME="${{ secrets.AWS_DEV_S3_BUCKET_NAME_TEMP }}"
+            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_DEV_CF_DISTRIBUTION_ID_TEMP }}"
+          fi
+
+          echo "AWS_S3_BUCKET_NAME=$AWS_S3_BUCKET_NAME" >> $GITHUB_ENV
+          echo "AWS_CF_DISTRIBUTION_ID=$AWS_CF_DISTRIBUTION_ID" >> $GITHUB_ENV
+          echo "AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID" >> $GITHUB_ENV
+          echo "AWS_S3_SYNC_ROLE=$AWS_S3_SYNC_ROLE" >> $GITHUB_ENV
+
       - name: Install AWS CLI
         uses: unfor19/install-aws-cli-action@master
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_PROD_ACCOUNT_ID }}:role/${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.AWS_S3_SYNC_ROLE }}
           aws-region: us-east-1
 
       - name: Checkout source code
@@ -68,25 +89,6 @@ jobs:
 
           legacy_sdk_rollback_version=$(jq -r .version packages/analytics-v1.1/package.json)
           echo "LEGACY_SDK_ROLLBACK_VERSION_VALUE=$legacy_sdk_rollback_version" >> $GITHUB_ENV
-
-      - name: Configure environment variables
-        run: |
-          echo "DATE=$(date)" >> $GITHUB_ENV
-
-          # TODO: Remove the below once the dev testing is done
-          if [ "${{ inputs.environment }}" == "production" ]; then
-            AWS_S3_BUCKET_NAME="${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
-            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}"
-          elif [ "${{ inputs.environment }}" == "staging" ]; then
-            AWS_S3_BUCKET_NAME="${{ secrets.AWS_STAGING_S3_BUCKET_NAME_TEMP }}"
-            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_STAGING_CF_DISTRIBUTION_ID_TEMP }}"
-          elif [ "${{ inputs.environment }}" == "development" ]; then
-            AWS_S3_BUCKET_NAME="${{ secrets.AWS_DEV_S3_BUCKET_NAME_TEMP }}"
-            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_DEV_CF_DISTRIBUTION_ID_TEMP }}"
-          fi
-
-          echo "AWS_S3_BUCKET_NAME=$AWS_S3_BUCKET_NAME" >> $GITHUB_ENV
-          echo "AWS_CF_DISTRIBUTION_ID=$AWS_CF_DISTRIBUTION_ID" >> $GITHUB_ENV
 
       - name: Copy the core SDK artifacts from the previous version to the latest version directory
         run: |

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -102,11 +102,6 @@ jobs:
 
       - name: Copy the core SDK artifacts from the previous version to the latest version directory
         run: |
-          integrations_modern_path_prefix="${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/${{ env.INTEGRATIONS_DIR_NAME }}"
-          integrations_legacy_path_prefix="${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/${{ env.INTEGRATIONS_DIR_NAME }}"
-
-          plugins_modern_path_prefix="${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/${{ env.PLUGINS_DIR_NAME }}"
-
           s3_path_prefix="s3://${{ env.AWS_S3_BUCKET_NAME }}"
 
           # Copy from S3 bucket versioned directory to the same S3 bucket in the latest version directory
@@ -114,10 +109,10 @@ jobs:
 
           echo "Copying core SDK legacy artifacts from $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ to $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/"
 
-          aws s3 cp $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/ --recursive --exclude "$integrations_legacy_path_prefix/*" --exclude "$integrations_legacy_path_prefix/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
+          aws s3 cp $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/ --recursive --exclude "${{ env.INTEGRATIONS_DIR_NAME }}/*" --exclude "${{ env.INTEGRATIONS_DIR_NAME }}/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
 
           echo "Copying core SDK modern artifacts from $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ to $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/"
-          aws s3 cp $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/ --recursive --exclude "$plugins_modern_path_prefix/*" --exclude "$plugins_modern_path_prefix/**" --exclude "$integrations_modern_path_prefix/*" --exclude "$integrations_modern_path_prefix/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
+          aws s3 cp $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/ --recursive --exclude "${{ env.PLUGINS_DIR_NAME }}/*" --exclude "${{ env.PLUGINS_DIR_NAME }}/**" --exclude "${{ env.INTEGRATIONS_DIR_NAME }}/*" --exclude "${{ env.INTEGRATIONS_DIR_NAME }}/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
 
       - name: Invalidate CloudFront cache for the latest version directory
         run: |

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -7,6 +7,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write # allows the JWT to be requested from GitHub's OIDC provider
+  contents: read # This is required for actions/checkout
+
+env:
+  NODE_OPTIONS: "--no-warnings"
+  CACHE_CONTROL_NO_STORE: "\"no-store\""
+  CACHE_CONTROL_MAX_AGE: "\"max-age=3600\""
+  LEGACY_DIR_NAME: "legacy"
+  MODERN_DIR_NAME: "modern"
+  INTEGRATIONS_DIR_NAME: "js-integrations"
+  PLUGINS_DIR_NAME: "plugins"
+  MAJOR_VERSION_DIR_NAME: "v3"
+  LEGACY_MAJOR_VERSION_DIR_NAME: "v1.1"
+
 jobs:
   validate-actor:
     # Only allow to be deployed from tags and main branch
@@ -17,21 +32,62 @@ jobs:
     secrets:
       PAT: ${{ secrets.PAT }}
 
-  deploy:
-    needs: validate-actor
+  rollback:
     name: Rollback production deployment
-    uses: ./.github/workflows/deploy.yml
-    with:
-      environment: 'production'
-      bugsnag_release_stage: 'production'
-      s3_dir_path: 'v3'
-      s3_dir_path_legacy: 'v1.1'
-      action_type: ' Rollback'
-    secrets:
-      AWS_ACCOUNT_ID: ${{ secrets.AWS_PROD_ACCOUNT_ID }}
-      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_PROD_S3_BUCKET_NAME }}
-      AWS_S3_SYNC_ROLE: ${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
-      AWS_CF_DISTRIBUTION_ID: ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}
-      BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+    runs-on: [self-hosted, Linux, X64]
+
+    steps:
+      - name: Install AWS CLI
+        uses: unfor19/install-aws-cli-action@master
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_PROD_ACCOUNT_ID }}:role/${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
+          aws-region: us-east-1
+
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Get new versions
+        run: |
+          current_version_v1=$(jq -r .version packages/analytics-v1.1/package.json)
+          current_version=$(jq -r .version packages/analytics-js/package.json)
+          echo "CURRENT_VERSION_V1_VALUE=$current_version_v1" >> $GITHUB_ENV
+          echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
+
+      - name: Copy the core SDK artifacts from the previous version to the latest version directory
+        run: |
+          integrations_modern_path_prefix="${{ env.CURRENT_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/${{ env.INTEGRATIONS_DIR_NAME }}"
+          integrations_legacy_path_prefix="${{ env.CURRENT_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/${{ env.INTEGRATIONS_DIR_NAME }}"
+          plugins_modern_path_prefix="${{ env.CURRENT_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/${{ env.PLUGINS_DIR_NAME }}"
+          s3_path_prefix="s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
+
+          # Copy from S3 bucket versioned directory to the same S3 bucket in the latest version directory
+          # Exclude the plugins and js-integrations directories
+
+          aws s3 cp $s3_path_prefix/${{ env.CURRENT_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ $s3_path_prefix/${{ env.MAJOR_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/ --recursive --exclude "$integrations_legacy_path_prefix/*" --exclude "$integrations_legacy_path_prefix/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
+
+          aws s3 cp $s3_path_prefix/${{ env.CURRENT_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ $s3_path_prefix/${{ env.MAJOR_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/ --recursive --exclude "$plugins_modern_path_prefix/*" --exclude "$plugins_modern_path_prefix/**" --exclude "$integrations_modern_path_prefix/*" --exclude "$integrations_modern_path_prefix/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
+
+      - name: Invalidate CloudFront cache for the latest version directory
+        run: |
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ env.MAJOR_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
+
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
+
+      # Repeat the above steps for the legacy SDK artifacts
+      - name: Copy the legacy core SDK artifacts from the previous version to the latest version directory
+        run: |
+          s3_path_prefix="s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
+
+          # Copy from S3 bucket versioned directory to the same S3 bucket in the latest version directory
+          aws s3 cp $s3_path_prefix/${{ env.CURRENT_VERSION_V1_VALUE }}/ $s3_path_prefix/${{ env.LEGACY_MAJOR_VERSION_DIR_NAME }}/ --recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
+
+      - name: Invalidate CloudFront cache for the latest version directory (legacy SDK artifacts)
+        run: |
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ env.LEGACY_MAJOR_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
+
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --id "$invalidation_id"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -11,6 +11,9 @@ on:
           - development
           - production
         default: 'development'
+      tag:
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -34,7 +37,7 @@ env:
 jobs:
   validate-actor:
     # Only allow to be deployed from tags and main branch
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    # if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
@@ -78,17 +81,23 @@ jobs:
           aws-region: us-east-1
 
       - name: Checkout source code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
+        # uses: actions/checkout@v4
+        # with:
+        #   ref: ${{ github.sha }}
+        run: |
+          git clone https://github.com/rudderlabs/rudder-sdk-js.git
+          cd rudder-sdk-js
+          git checkout ${{ inputs.tag }}
 
       - name: Get rollback sdk versions
         run: |
           rollback_version=$(jq -r .version packages/analytics-js/package.json)
           echo "ROLLBACK_VERSION_VALUE=$rollback_version" >> $GITHUB_ENV
+          echo "Rollback version: $rollback_version"
 
           legacy_sdk_rollback_version=$(jq -r .version packages/analytics-v1.1/package.json)
           echo "LEGACY_SDK_ROLLBACK_VERSION_VALUE=$legacy_sdk_rollback_version" >> $GITHUB_ENV
+          echo "Legacy SDK rollback version: $legacy_sdk_rollback_version"
 
       - name: Copy the core SDK artifacts from the previous version to the latest version directory
         run: |
@@ -132,6 +141,7 @@ jobs:
 
       - name: Send message to Slack channel
         id: slack
+        if: false
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.27.0
         env:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -2,6 +2,16 @@ name: Rollback Production Deployment
 
 on:
   workflow_dispatch:
+    # TODO: Remove the inputs once the dev testing is done
+    inputs:
+      environment:
+        required: true
+        type: choice
+        options:
+          - development
+          - staging
+          - production
+        default: 'development'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -19,8 +29,8 @@ env:
   MODERN_DIR_NAME: "modern"
   INTEGRATIONS_DIR_NAME: "js-integrations"
   PLUGINS_DIR_NAME: "plugins"
-  MAJOR_VERSION_DIR_NAME: "v3"
-  LEGACY_MAJOR_VERSION_DIR_NAME: "v1.1"
+  LATEST_VERSION_DIR_NAME: "v3"
+  LEGACY_SDK_LATEST_VERSION_DIR_NAME: "v1.1"
 
 jobs:
   validate-actor:
@@ -51,43 +61,111 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Get new versions
+      - name: Get rollback sdk versions
         run: |
-          current_version_v1=$(jq -r .version packages/analytics-v1.1/package.json)
-          current_version=$(jq -r .version packages/analytics-js/package.json)
-          echo "CURRENT_VERSION_V1_VALUE=$current_version_v1" >> $GITHUB_ENV
-          echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
+          rollback_version=$(jq -r .version packages/analytics-js/package.json)
+          echo "ROLLBACK_VERSION_VALUE=$rollback_version" >> $GITHUB_ENV
+
+          legacy_sdk_rollback_version=$(jq -r .version packages/analytics-v1.1/package.json)
+          echo "LEGACY_SDK_ROLLBACK_VERSION_VALUE=$legacy_sdk_rollback_version" >> $GITHUB_ENV
+
+      - name: Configure environment variables
+        run: |
+          echo "DATE=$(date)" >> $GITHUB_ENV
+
+          # TODO: Remove the below once the dev testing is done
+          if [ "${{ inputs.environment }}" == "production" ]; then
+            AWS_S3_BUCKET_NAME="${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
+            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}"
+          elif [ "${{ inputs.environment }}" == "staging" ]; then
+            AWS_S3_BUCKET_NAME="${{ secrets.AWS_STAGING_S3_BUCKET_NAME_TEMP }}"
+            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_STAGING_CF_DISTRIBUTION_ID_TEMP }}"
+          elif [ "${{ inputs.environment }}" == "development" ]; then
+            AWS_S3_BUCKET_NAME="${{ secrets.AWS_DEV_S3_BUCKET_NAME_TEMP }}"
+            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_DEV_CF_DISTRIBUTION_ID_TEMP }}"
+          fi
+
+          echo "AWS_S3_BUCKET_NAME=$AWS_S3_BUCKET_NAME" >> $GITHUB_ENV
+          echo "AWS_CF_DISTRIBUTION_ID=$AWS_CF_DISTRIBUTION_ID" >> $GITHUB_ENV
 
       - name: Copy the core SDK artifacts from the previous version to the latest version directory
         run: |
-          integrations_modern_path_prefix="${{ env.CURRENT_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/${{ env.INTEGRATIONS_DIR_NAME }}"
-          integrations_legacy_path_prefix="${{ env.CURRENT_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/${{ env.INTEGRATIONS_DIR_NAME }}"
-          plugins_modern_path_prefix="${{ env.CURRENT_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/${{ env.PLUGINS_DIR_NAME }}"
-          s3_path_prefix="s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
+          integrations_modern_path_prefix="${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/${{ env.INTEGRATIONS_DIR_NAME }}"
+          integrations_legacy_path_prefix="${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/${{ env.INTEGRATIONS_DIR_NAME }}"
+
+          plugins_modern_path_prefix="${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/${{ env.PLUGINS_DIR_NAME }}"
+
+          s3_path_prefix="s3://${{ env.AWS_S3_BUCKET_NAME }}"
 
           # Copy from S3 bucket versioned directory to the same S3 bucket in the latest version directory
-          # Exclude the plugins and js-integrations directories
+          # excluding the plugins and js-integrations directories
 
-          aws s3 cp $s3_path_prefix/${{ env.CURRENT_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ $s3_path_prefix/${{ env.MAJOR_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/ --recursive --exclude "$integrations_legacy_path_prefix/*" --exclude "$integrations_legacy_path_prefix/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
+          echo "Copying core SDK legacy artifacts from $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ to $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/"
 
-          aws s3 cp $s3_path_prefix/${{ env.CURRENT_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ $s3_path_prefix/${{ env.MAJOR_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/ --recursive --exclude "$plugins_modern_path_prefix/*" --exclude "$plugins_modern_path_prefix/**" --exclude "$integrations_modern_path_prefix/*" --exclude "$integrations_modern_path_prefix/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}"
+          aws s3 cp $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/ --recursive --exclude "$integrations_legacy_path_prefix/*" --exclude "$integrations_legacy_path_prefix/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
+
+          echo "Copying core SDK modern artifacts from $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ to $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/"
+          aws s3 cp $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/ --recursive --exclude "$plugins_modern_path_prefix/*" --exclude "$plugins_modern_path_prefix/**" --exclude "$integrations_modern_path_prefix/*" --exclude "$integrations_modern_path_prefix/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
 
       - name: Invalidate CloudFront cache for the latest version directory
         run: |
-          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ env.MAJOR_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ env.LATEST_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
 
-          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
+          aws cloudfront wait invalidation-completed --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
       # Repeat the above steps for the legacy SDK artifacts
-      - name: Copy the legacy core SDK artifacts from the previous version to the latest version directory
+      - name: Copy the legacy SDK artifacts from the previous version to the latest version directory
         run: |
-          s3_path_prefix="s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
+          s3_path_prefix="s3://${{ env.AWS_S3_BUCKET_NAME }}"
 
           # Copy from S3 bucket versioned directory to the same S3 bucket in the latest version directory
-          aws s3 cp $s3_path_prefix/${{ env.CURRENT_VERSION_V1_VALUE }}/ $s3_path_prefix/${{ env.LEGACY_MAJOR_VERSION_DIR_NAME }}/ --recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
+          echo "Copying legacy SDK artifacts from $s3_path_prefix/${{ env.LEGACY_SDK_ROLLBACK_VERSION_VALUE }}/ to $s3_path_prefix/${{ env.LEGACY_SDK_LATEST_VERSION_DIR_NAME }}/"
+          aws s3 cp $s3_path_prefix/${{ env.LEGACY_SDK_ROLLBACK_VERSION_VALUE }}/ $s3_path_prefix/${{ env.LEGACY_SDK_LATEST_VERSION_DIR_NAME }}/ --recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
 
       - name: Invalidate CloudFront cache for the latest version directory (legacy SDK artifacts)
         run: |
-          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ env.LEGACY_MAJOR_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ env.LEGACY_SDK_LATEST_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
 
-          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
+          aws cloudfront wait invalidation-completed --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
+
+      - name: Send message to Slack channel
+        id: slack
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          PROJECT_NAME: 'JS SDK Browser Package - Rollback - Production'
+          CDN_URL: ${{ format('https://cdn.rudderlabs.com/{0}/modern/rsa.min.js', env.LATEST_VERSION_DIR_NAME) }}
+          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js@'
+          LINK_TEXT: ${{ format('v{0}', env.ROLLBACK_VERSION_VALUE) }}
+        with:
+          channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D> <!subteam^S03SHJ20350>",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "New release: ${{ env.PROJECT_NAME }}"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*<${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D> <!subteam^S03SHJ20350>"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://cdn.jsdelivr.net/npm/programming-languages-logos/src/javascript/javascript.png",
+                    "alt_text": "JavaScript Icon"
+                  }
+                }
+                ${{ format(',{{"type": "context", "elements": [{{"type": "mrkdwn", "text": "For more details, check the full release notes <{0}{1}|here>."}}]}}', env.RELEASES_URL, env.ROLLBACK_VERSION_VALUE) || ''  }}
+              ]
+            }

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -33,6 +33,7 @@ jobs:
       PAT: ${{ secrets.PAT }}
 
   rollback:
+    needs: validate-actor
     name: Rollback production deployment
     runs-on: [self-hosted, Linux, X64]
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Get rollback sdk versions
         run: |
+          cd rudder-sdk-js
           rollback_version=$(jq -r .version packages/analytics-js/package.json)
           echo "ROLLBACK_VERSION_VALUE=$rollback_version" >> $GITHUB_ENV
           echo "Rollback version: $rollback_version"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -2,18 +2,6 @@ name: Rollback Production Deployment
 
 on:
   workflow_dispatch:
-    # TODO: Remove the inputs once the dev testing is done
-    inputs:
-      environment:
-        required: true
-        type: choice
-        options:
-          - development
-          - production
-        default: 'development'
-      tag:
-        required: true
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -37,7 +25,7 @@ env:
 jobs:
   validate-actor:
     # Only allow to be deployed from tags and main branch
-    # if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
@@ -49,95 +37,66 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
 
     steps:
-      - name: Configure environment variables
-        run: |
-          echo "DATE=$(date)" >> $GITHUB_ENV
-
-          # TODO: Remove the below once the dev testing is done
-          if [ "${{ inputs.environment }}" == "production" ]; then
-            AWS_ACCOUNT_ID="${{ secrets.AWS_PROD_ACCOUNT_ID }}"
-            AWS_S3_SYNC_ROLE="${{ secrets.AWS_PROD_S3_SYNC_ROLE }}"
-            AWS_S3_BUCKET_NAME="${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
-            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}"
-          elif [ "${{ inputs.environment }}" == "development" ]; then
-            AWS_ACCOUNT_ID="${{ secrets.AWS_DEV_ACCOUNT_ID_TEMP }}"
-            AWS_S3_SYNC_ROLE="${{ secrets.AWS_DEV_S3_SYNC_ROLE_TEMP }}"
-            AWS_S3_BUCKET_NAME="${{ secrets.AWS_DEV_S3_BUCKET_NAME_TEMP }}"
-            AWS_CF_DISTRIBUTION_ID="${{ secrets.AWS_DEV_CF_DISTRIBUTION_ID_TEMP }}"
-          fi
-
-          echo "AWS_S3_BUCKET_NAME=$AWS_S3_BUCKET_NAME" >> $GITHUB_ENV
-          echo "AWS_CF_DISTRIBUTION_ID=$AWS_CF_DISTRIBUTION_ID" >> $GITHUB_ENV
-          echo "AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID" >> $GITHUB_ENV
-          echo "AWS_S3_SYNC_ROLE=$AWS_S3_SYNC_ROLE" >> $GITHUB_ENV
-
       - name: Install AWS CLI
         uses: unfor19/install-aws-cli-action@master
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.AWS_S3_SYNC_ROLE }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_PROD_ACCOUNT_ID }}:role/${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
           aws-region: us-east-1
 
       - name: Checkout source code
-        # uses: actions/checkout@v4
-        # with:
-        #   ref: ${{ github.sha }}
-        run: |
-          git clone https://github.com/rudderlabs/rudder-sdk-js.git
-          cd rudder-sdk-js
-          git checkout ${{ inputs.tag }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
       - name: Get rollback sdk versions
         run: |
-          cd rudder-sdk-js
           rollback_version=$(jq -r .version packages/analytics-js/package.json)
           echo "ROLLBACK_VERSION_VALUE=$rollback_version" >> $GITHUB_ENV
-          echo "Rollback version: $rollback_version"
+          echo "SDK rollback version: $rollback_version"
 
           legacy_sdk_rollback_version=$(jq -r .version packages/analytics-v1.1/package.json)
           echo "LEGACY_SDK_ROLLBACK_VERSION_VALUE=$legacy_sdk_rollback_version" >> $GITHUB_ENV
           echo "Legacy SDK rollback version: $legacy_sdk_rollback_version"
 
+          echo "DATE=$(date)" >> $GITHUB_ENV
+
       - name: Copy the core SDK artifacts from the previous version to the latest version directory
         run: |
-          s3_path_prefix="s3://${{ env.AWS_S3_BUCKET_NAME }}"
+          s3_path_prefix="s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
 
           # Copy from S3 bucket versioned directory to the same S3 bucket in the latest version directory
           # excluding the plugins and js-integrations directories
-
-          echo "Copying core SDK legacy artifacts from $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ to $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/"
+          # as the core SDK automatically refers to the plugins and js-integrations files from the versioned directory
 
           aws s3 cp $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.LEGACY_DIR_NAME }}/ $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.LEGACY_DIR_NAME }}/ --recursive --exclude "${{ env.INTEGRATIONS_DIR_NAME }}/*" --exclude "${{ env.INTEGRATIONS_DIR_NAME }}/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
 
-          echo "Copying core SDK modern artifacts from $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ to $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/"
           aws s3 cp $s3_path_prefix/${{ env.ROLLBACK_VERSION_VALUE }}/${{ env.MODERN_DIR_NAME }}/ $s3_path_prefix/${{ env.LATEST_VERSION_DIR_NAME }}/${{ env.MODERN_DIR_NAME }}/ --recursive --exclude "${{ env.PLUGINS_DIR_NAME }}/*" --exclude "${{ env.PLUGINS_DIR_NAME }}/**" --exclude "${{ env.INTEGRATIONS_DIR_NAME }}/*" --exclude "${{ env.INTEGRATIONS_DIR_NAME }}/**" --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
 
       - name: Invalidate CloudFront cache for the latest version directory
         run: |
-          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ env.LATEST_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ env.LATEST_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
 
-          aws cloudfront wait invalidation-completed --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
       # Repeat the above steps for the legacy SDK artifacts
       - name: Copy the legacy SDK artifacts from the previous version to the latest version directory
         run: |
-          s3_path_prefix="s3://${{ env.AWS_S3_BUCKET_NAME }}"
+          s3_path_prefix="s3://${{ secrets.AWS_PROD_S3_BUCKET_NAME }}"
 
           # Copy from S3 bucket versioned directory to the same S3 bucket in the latest version directory
-          echo "Copying legacy SDK artifacts from $s3_path_prefix/${{ env.LEGACY_SDK_ROLLBACK_VERSION_VALUE }}/ to $s3_path_prefix/${{ env.LEGACY_SDK_LATEST_VERSION_DIR_NAME }}/"
           aws s3 cp $s3_path_prefix/${{ env.LEGACY_SDK_ROLLBACK_VERSION_VALUE }}/ $s3_path_prefix/${{ env.LEGACY_SDK_LATEST_VERSION_DIR_NAME }}/ --recursive --cache-control ${{ env.CACHE_CONTROL_NO_STORE }}
 
       - name: Invalidate CloudFront cache for the latest version directory (legacy SDK artifacts)
         run: |
-          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --paths "/${{ env.LEGACY_SDK_LATEST_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
+          invalidation_id=$(AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --paths "/${{ env.LEGACY_SDK_LATEST_VERSION_DIR_NAME }}*" --query "Invalidation.Id" --output text)
 
-          aws cloudfront wait invalidation-completed --distribution-id ${{ env.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
+          aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
       - name: Send message to Slack channel
         id: slack
-        if: false
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.27.0
         env:
@@ -150,7 +109,7 @@ jobs:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D> <!subteam^S03SHJ20350>",
+              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D> <!subteam^S03SW7DM8P3> <!subteam^S03SHJ20350>",
               "blocks": [
                 {
                   "type": "header",
@@ -166,7 +125,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*<${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D> <!subteam^S03SHJ20350>"
+                    "text": "*<${{ env.CDN_URL }}|${{ env.LINK_TEXT }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D> <!subteam^S03SW7DM8P3> <!subteam^S03SHJ20350>"
                   },
                   "accessory": {
                     "type": "image",


### PR DESCRIPTION
## PR Description

I've revamped the SDK version rollback workflow to copy artifacts directly from AWS S3 -> S3 to speed up the process.

Now, as we're not re-building the SDK artifacts at all, it should be really fast.

In case of the latest SDK, we're just copying the core SDK artifacts as it'll refer to the plugins and integrations from the versioned directories automatically.

For legacy SDK, all the artifacts are copied from the source.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2732/speed-up-the-sdk-rollback-process

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the analytics integration to load from new, validated endpoints and credentials.
  - Enhanced configuration settings to improve consistency in how analytics components manage their versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->