### PR TITLE
fix: allow handled errors to be processed

### DIFF
--- a/packages/analytics-js/__tests__/services/ErrorHandler/ErrorHandler.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/ErrorHandler.test.ts
@@ -117,12 +117,18 @@ describe('ErrorHandler', () => {
       expect(defaultLogger.error).toHaveBeenCalledTimes(0);
     });
 
-    it('should skip handled errors if they are not originated from the sdk', () => {
+    it('should not skip handled errors even if they are not originated from the sdk', () => {
+      // Enable error reporting
+      state.reporting.isErrorReportingEnabled.value = true;
+
       // For this error, the stacktrace would not contain the sdk file names
       errorHandlerInstance.onError(new Error('dummy error'));
 
-      // It should not be logged to the console
-      expect(defaultLogger.error).toHaveBeenCalledTimes(0);
+      // It should be reported to the metrics service
+      expect(defaultHttpClient.getAsyncData).toHaveBeenCalledTimes(1);
+
+      // It should be logged to the console
+      expect(defaultLogger.error).toHaveBeenCalledTimes(1);
     });
 
     it('should not log unhandled errors to the console', () => {

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -75,9 +75,13 @@ class ErrorHandler implements IErrorHandler {
       const isSdkDispatched = stacktrace.includes(MANUAL_ERROR_IDENTIFIER);
 
       // Filter errors that are not originated in the SDK.
-      // In case of NPM installations, the errors from the SDK cannot be identified
+      // In case of NPM installations, the unhandled errors from the SDK cannot be identified
       // and will NOT be reported unless they occur in plugins or integrations.
-      if (!isSdkDispatched && !isSDKError(bsException)) {
+      if (
+        !isSdkDispatched &&
+        !isSDKError(bsException) &&
+        errorType !== ErrorType.HANDLEDEXCEPTION
+      ) {
         return;
       }
 


### PR DESCRIPTION
## PR Description

I've allowed handled errors to be processed even if they do not seem to be originated from the SDK. Especially, this is helpful for reporting and logging handled errors from the core SDK in the case of NPM installations.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3011/unsuppress-handled-errors-for-npm-installations

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling to ensure that errors are consistently logged and reported for improved diagnostic tracking and system stability.
- **Tests**
	- Updated test coverage to confirm that all handled errors, regardless of origin, are now correctly captured and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->