### PR TITLE
feat: add events processing and retry headers

### DIFF
--- a/packages/analytics-js-plugins/.size-limit.mjs
+++ b/packages/analytics-js-plugins/.size-limit.mjs
@@ -16,7 +16,7 @@ export default [
   {
     name: 'Plugins - Legacy - CDN',
     path: 'dist/cdn/legacy/plugins/rsa-plugins-*.min.js',
-    limit: '14 KiB',
+    limit: '14.1 KiB',
   },
   {
     name: 'Plugins - Modern - CDN',

--- a/packages/analytics-js-plugins/__tests__/deviceModeTransformation/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeTransformation/index.test.ts
@@ -172,9 +172,14 @@ describe('Device mode transformation plugin', () => {
         event,
       },
       expect.any(Function),
-      0,
-      3,
-      true,
+      {
+        willBeRetried: true,
+        retryAttemptNumber: 0,
+        maxRetryAttempts: 3,
+        reclaimed: false,
+        timeSinceFirstAttempt: expect.any(Number),
+        timeSinceLastAttempt: expect.any(Number),
+      },
     );
 
     // Item is successfully processed and removed from queue
@@ -289,6 +294,9 @@ describe('Device mode transformation plugin', () => {
           event,
         },
         attemptNumber: 1,
+        firstAttemptedAt: expect.any(Number),
+        lastAttemptedAt: expect.any(Number),
+        reclaimed: undefined,
         id: 'sample_uuid',
         time: expect.any(Number),
         // time: 1 + 500 * 2 ** 1, // this is the delay calculation in RetryQueue

--- a/packages/analytics-js-plugins/__tests__/utilities/retryQueue/RetryQueue.test.ts
+++ b/packages/analytics-js-plugins/__tests__/utilities/retryQueue/RetryQueue.test.ts
@@ -198,7 +198,14 @@ describe('Queue', () => {
 
     queue.addItem('a');
 
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 0, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: false,
+    });
   });
 
   it('should retry a task if it fails', () => {
@@ -214,7 +221,14 @@ describe('Queue', () => {
     queue.addItem('a');
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 0, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: false,
+    });
 
     // Delay for the first retry
     mockProcessItemCb.mockReset();
@@ -222,7 +236,14 @@ describe('Queue', () => {
     jest.advanceTimersByTime(nextTickDelay);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 1, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 1,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: false,
+    });
   });
 
   it('should delay retries', () => {
@@ -238,7 +259,14 @@ describe('Queue', () => {
     queue.addItem('a');
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 0, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: false,
+    });
 
     // Delay for the retry
     mockProcessItemCb.mockReset();
@@ -246,7 +274,14 @@ describe('Queue', () => {
     jest.advanceTimersByTime(nextTickDelay);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('b', expect.any(Function), 1, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('b', expect.any(Function), {
+      retryAttemptNumber: 1,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: false,
+    });
   });
 
   it('should respect shouldRetry', () => {
@@ -347,38 +382,38 @@ describe('Queue', () => {
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(4);
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      1,
-      'a',
-      expect.any(Function),
-      0,
-      Infinity,
-      true,
-    );
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      2,
-      ['b', 'c'],
-      expect.any(Function),
-      0,
-      Infinity,
-      true,
-    );
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      3,
-      ['d', 'e'],
-      expect.any(Function),
-      0,
-      Infinity,
-      true,
-    );
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      4,
-      'f',
-      expect.any(Function),
-      0,
-      Infinity,
-      true,
-    );
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(1, 'a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(2, ['b', 'c'], expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(3, ['d', 'e'], expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(4, 'f', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should take over an in-progress task if a queue is abandoned', () => {
@@ -426,38 +461,38 @@ describe('Queue', () => {
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(4);
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      1,
-      'a',
-      expect.any(Function),
-      1,
-      Infinity,
-      true,
-    );
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      2,
-      ['b', 'c'],
-      expect.any(Function),
-      1,
-      Infinity,
-      true,
-    );
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      3,
-      ['d', 'e'],
-      expect.any(Function),
-      1,
-      Infinity,
-      true,
-    );
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      4,
-      'f',
-      expect.any(Function),
-      1,
-      Infinity,
-      true,
-    );
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(1, 'a', expect.any(Function), {
+      retryAttemptNumber: 1,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(2, ['b', 'c'], expect.any(Function), {
+      retryAttemptNumber: 1,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(3, ['d', 'e'], expect.any(Function), {
+      retryAttemptNumber: 1,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(4, 'f', expect.any(Function), {
+      retryAttemptNumber: 1,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should take over a batch queued task if a queue is abandoned', () => {
@@ -502,13 +537,14 @@ describe('Queue', () => {
       batchQueue.timeouts.reclaimTimer + batchQueue.timeouts.reclaimWait * 2,
     );
 
-    expect(batchQueue.processQueueCb).toHaveBeenCalledWith(
-      ['a', 'b'],
-      expect.any(Function),
-      0,
-      Infinity,
-      true,
-    );
+    expect(batchQueue.processQueueCb).toHaveBeenCalledWith(['a', 'b'], expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should take over a batch queued task to main queue if a queue is abandoned', () => {
@@ -544,22 +580,22 @@ describe('Queue', () => {
     // wait long enough for the other queue to expire and be reclaimed
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      1,
-      'a',
-      expect.any(Function),
-      0,
-      Infinity,
-      true,
-    );
-    expect(queue.processQueueCb).toHaveBeenNthCalledWith(
-      2,
-      'b',
-      expect.any(Function),
-      0,
-      Infinity,
-      true,
-    );
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(1, 'a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenNthCalledWith(2, 'b', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should deduplicate ids when reclaiming abandoned queue tasks', () => {
@@ -597,7 +633,14 @@ describe('Queue', () => {
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 0, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should deduplicate ids when reclaiming abandoned in-progress tasks', () => {
@@ -635,7 +678,14 @@ describe('Queue', () => {
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 1, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 1,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should deduplicate ids when reclaiming abandoned batch queue tasks', () => {
@@ -673,7 +723,14 @@ describe('Queue', () => {
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 0, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should deduplicate ids when reclaiming abandoned batch, in-progress and queue tasks', () => {
@@ -741,9 +798,30 @@ describe('Queue', () => {
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(3);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('c', expect.any(Function), 0, Infinity, true);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 0, Infinity, true);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('b', expect.any(Function), 0, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('c', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenCalledWith('b', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should not deduplicate tasks when ids are not set during reclaim', () => {
@@ -792,7 +870,14 @@ describe('Queue', () => {
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(4);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 0, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   it('should take over multiple tasks if a queue is abandoned', () => {
@@ -837,9 +922,30 @@ describe('Queue', () => {
     jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
     expect(queue.processQueueCb).toHaveBeenCalledTimes(3);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), 0, Infinity, true);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('b', expect.any(Function), 1, Infinity, true);
-    expect(queue.processQueueCb).toHaveBeenCalledWith('c', expect.any(Function), 0, Infinity, true);
+    expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenCalledWith('b', expect.any(Function), {
+      retryAttemptNumber: 1,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
+    expect(queue.processQueueCb).toHaveBeenCalledWith('c', expect.any(Function), {
+      retryAttemptNumber: 0,
+      maxRetryAttempts: Infinity,
+      willBeRetried: true,
+      timeSinceFirstAttempt: expect.any(Number),
+      timeSinceLastAttempt: expect.any(Number),
+      reclaimed: true,
+    });
   });
 
   describe('while using in memory engine', () => {
@@ -875,13 +981,14 @@ describe('Queue', () => {
       jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
       expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-      expect(queue.processQueueCb).toHaveBeenCalledWith(
-        'a',
-        expect.any(Function),
-        0,
-        Infinity,
-        true,
-      );
+      expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+        retryAttemptNumber: 0,
+        maxRetryAttempts: Infinity,
+        willBeRetried: true,
+        timeSinceFirstAttempt: expect.any(Number),
+        timeSinceLastAttempt: expect.any(Number),
+        reclaimed: true,
+      });
     });
 
     it('should take over an in-progress task if a queue is abandoned', () => {
@@ -912,13 +1019,14 @@ describe('Queue', () => {
       jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
       expect(queue.processQueueCb).toHaveBeenCalledTimes(1);
-      expect(queue.processQueueCb).toHaveBeenCalledWith(
-        'a',
-        expect.any(Function),
-        1,
-        Infinity,
-        true,
-      );
+      expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+        retryAttemptNumber: 1,
+        maxRetryAttempts: Infinity,
+        willBeRetried: true,
+        timeSinceFirstAttempt: expect.any(Number),
+        timeSinceLastAttempt: expect.any(Number),
+        reclaimed: true,
+      });
     });
 
     it('should take over multiple tasks if a queue is abandoned', () => {
@@ -956,20 +1064,22 @@ describe('Queue', () => {
       jest.advanceTimersByTime(queue.timeouts.reclaimTimer + queue.timeouts.reclaimWait * 2);
 
       expect(queue.processQueueCb).toHaveBeenCalledTimes(2);
-      expect(queue.processQueueCb).toHaveBeenCalledWith(
-        'a',
-        expect.any(Function),
-        0,
-        Infinity,
-        true,
-      );
-      expect(queue.processQueueCb).toHaveBeenCalledWith(
-        'b',
-        expect.any(Function),
-        1,
-        Infinity,
-        true,
-      );
+      expect(queue.processQueueCb).toHaveBeenCalledWith('a', expect.any(Function), {
+        retryAttemptNumber: 0,
+        maxRetryAttempts: Infinity,
+        willBeRetried: true,
+        timeSinceFirstAttempt: expect.any(Number),
+        timeSinceLastAttempt: expect.any(Number),
+        reclaimed: true,
+      });
+      expect(queue.processQueueCb).toHaveBeenCalledWith('b', expect.any(Function), {
+        retryAttemptNumber: 1,
+        maxRetryAttempts: Infinity,
+        willBeRetried: true,
+        timeSinceFirstAttempt: expect.any(Number),
+        timeSinceLastAttempt: expect.any(Number),
+        reclaimed: true,
+      });
     });
   });
 

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
@@ -133,9 +133,14 @@ describe('XhrQueue', () => {
         event: mergeDeepRight(event, { sentAt: 'sample_timestamp' }),
       },
       expect.any(Function),
-      0,
-      10,
-      true,
+      {
+        retryAttemptNumber: 0,
+        maxRetryAttempts: 10,
+        willBeRetried: true,
+        timeSinceFirstAttempt: expect.any(Number),
+        timeSinceLastAttempt: expect.any(Number),
+        reclaimed: false,
+      },
     );
 
     // Item is successfully processed and removed from queue
@@ -197,6 +202,8 @@ describe('XhrQueue', () => {
           event: mergeDeepRight(event, { sentAt: 'sample_timestamp' }),
         },
         attemptNumber: 1,
+        lastAttemptedAt: expect.any(Number),
+        firstAttemptedAt: expect.any(Number),
         id: 'sample_uuid',
         time: 1 + 1000 * 2 ** 1, // this is the delay calculation in RetryQueue
         type: 'Single',
@@ -284,9 +291,14 @@ describe('XhrQueue', () => {
         },
       ],
       expect.any(Function),
-      0,
-      10,
-      true,
+      {
+        retryAttemptNumber: 0,
+        maxRetryAttempts: 10,
+        willBeRetried: true,
+        timeSinceFirstAttempt: expect.any(Number),
+        timeSinceLastAttempt: expect.any(Number),
+        reclaimed: false,
+      },
     );
 
     expect(defaultHttpClient.getAsyncData).toHaveBeenCalledWith({
@@ -295,6 +307,7 @@ describe('XhrQueue', () => {
         method: 'POST',
         headers: {
           AnonymousId: 'c2FtcGxlQW5vbklk', // Base64 encoded anonymousId
+          SentAt: 'sample_timestamp',
         },
         sendRawData: true,
         data: '{"batch":[{"type":"track","event":"test","userId":"test","properties":{"test":"test"},"anonymousId":"sampleAnonId","messageId":"test","originalTimestamp":"test","sentAt":"sample_timestamp"},{"type":"track","event":"test2","userId":"test2","properties":{"test2":"test2"},"anonymousId":"sampleAnonId","messageId":"test2","originalTimestamp":"test2","sentAt":"sample_timestamp"}],"sentAt":"sample_timestamp"}',

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
@@ -319,6 +319,45 @@ describe('xhrQueue Plugin Utilities', () => {
       });
     });
 
+    it('should return request info for single event queue item that is reclaimed and retried', () => {
+      const queueItemData = {
+        event: {
+          type: 'track',
+        } as unknown as RudderEvent,
+        url: 'https://test.com/v1/track',
+        headers: {
+          AnonymousId: 'anonymous-id',
+        },
+      };
+
+      const requestInfo = getRequestInfo(
+        queueItemData,
+        state,
+        {
+          retryAttemptNumber: 2,
+          maxRetryAttempts: 10,
+          willBeRetried: true,
+          timeSinceFirstAttempt: 4,
+          timeSinceLastAttempt: 2,
+          reclaimed: true,
+        },
+        defaultLogger,
+      );
+
+      expect(requestInfo).toEqual({
+        url: 'https://test.com/v1/track',
+        headers: {
+          AnonymousId: 'anonymous-id',
+          SentAt: '2021-01-01T00:00:00.000Z',
+          'Retry-Attempt': '2',
+          'Retried-After': '2',
+          'Retried-After-First': '4',
+          Reclaimed: 'true',
+        },
+        data: '{"type":"track","sentAt":"2021-01-01T00:00:00.000Z"}',
+      });
+    });
+
     it('should return request info for batch queue item', () => {
       const queueItemData = [
         {

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
@@ -120,7 +120,19 @@ describe('xhrQueue Plugin Utilities', () => {
         error: { message: 'Unauthorized' },
       } as ResponseDetails;
 
-      logErrorOnFailure(details, false, false, 1, 10, defaultLogger);
+      logErrorOnFailure(
+        details,
+        false,
+        {
+          retryAttemptNumber: 1,
+          maxRetryAttempts: 10,
+          willBeRetried: false,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
 
       expect(defaultLogger.error).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Unauthorized. The event(s) will be dropped.',
@@ -135,7 +147,19 @@ describe('xhrQueue Plugin Utilities', () => {
         },
       } as ResponseDetails;
 
-      logErrorOnFailure(details, true, true, 1, 10, defaultLogger);
+      logErrorOnFailure(
+        details,
+        true,
+        {
+          retryAttemptNumber: 1,
+          maxRetryAttempts: 10,
+          willBeRetried: true,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
 
       expect(defaultLogger.error).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried. Retry attempt 1 of 10.',
@@ -145,8 +169,19 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 429;
 
-      logErrorOnFailure(details, true, true, 0, 10, defaultLogger);
-
+      logErrorOnFailure(
+        details,
+        true,
+        {
+          retryAttemptNumber: 0,
+          maxRetryAttempts: 10,
+          willBeRetried: true,
+          timeSinceFirstAttempt: 10,
+          timeSinceLastAttempt: 10,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
       expect(defaultLogger.error).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried.',
       );
@@ -155,7 +190,19 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 500;
 
-      logErrorOnFailure(details, true, true, 1, 10, defaultLogger);
+      logErrorOnFailure(
+        details,
+        true,
+        {
+          retryAttemptNumber: 1,
+          maxRetryAttempts: 10,
+          willBeRetried: true,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
 
       expect(defaultLogger.error).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried. Retry attempt 1 of 10.',
@@ -165,7 +212,19 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 501;
 
-      logErrorOnFailure(details, true, true, 1, 10, defaultLogger);
+      logErrorOnFailure(
+        details,
+        true,
+        {
+          retryAttemptNumber: 1,
+          maxRetryAttempts: 10,
+          willBeRetried: true,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
 
       expect(defaultLogger.error).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried. Retry attempt 1 of 10.',
@@ -175,7 +234,19 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 600;
 
-      logErrorOnFailure(details, true, true, 1, 10, defaultLogger);
+      logErrorOnFailure(
+        details,
+        true,
+        {
+          retryAttemptNumber: 1,
+          maxRetryAttempts: 10,
+          willBeRetried: true,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
 
       expect(defaultLogger.error).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried. Retry attempt 1 of 10.',
@@ -185,7 +256,19 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 520;
 
-      logErrorOnFailure(details, true, false, 10, 10, defaultLogger);
+      logErrorOnFailure(
+        details,
+        true,
+        {
+          retryAttemptNumber: 10,
+          maxRetryAttempts: 10,
+          willBeRetried: false,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
 
       expect(defaultLogger.error).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. Retries exhausted (10). The event(s) will be dropped.',
@@ -212,12 +295,25 @@ describe('xhrQueue Plugin Utilities', () => {
         },
       };
 
-      const requestInfo = getRequestInfo(queueItemData, state, defaultLogger);
+      const requestInfo = getRequestInfo(
+        queueItemData,
+        state,
+        {
+          retryAttemptNumber: 0,
+          maxRetryAttempts: 10,
+          willBeRetried: true,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
 
       expect(requestInfo).toEqual({
         url: 'https://test.com/v1/track',
         headers: {
           AnonymousId: 'anonymous-id',
+          SentAt: '2021-01-01T00:00:00.000Z',
         },
         data: '{"type":"track","properties":{"prop1":"value1"},"sentAt":"2021-01-01T00:00:00.000Z"}',
       });
@@ -253,12 +349,25 @@ describe('xhrQueue Plugin Utilities', () => {
 
       state.lifecycle.activeDataplaneUrl.value = 'https://test.dataplaneurl.com/';
 
-      const requestInfo = getRequestInfo(queueItemData, state, defaultLogger);
+      const requestInfo = getRequestInfo(
+        queueItemData,
+        state,
+        {
+          retryAttemptNumber: 0,
+          maxRetryAttempts: 10,
+          willBeRetried: true,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
 
       expect(requestInfo).toEqual({
         url: 'https://test.dataplaneurl.com/v1/batch',
         headers: {
           AnonymousId: 'anonymous-id1',
+          SentAt: '2021-01-01T00:00:00.000Z',
         },
         data: '{"batch":[{"type":"track","properties":{"prop1":"value1"},"sentAt":"2021-01-01T00:00:00.000Z"},{"type":"track","properties":{"prop2":"value2"},"sentAt":"2021-01-01T00:00:00.000Z"}],"sentAt":"2021-01-01T00:00:00.000Z"}',
       });

--- a/packages/analytics-js-plugins/src/deviceModeTransformation/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeTransformation/index.ts
@@ -16,7 +16,7 @@ import { createPayload, sendTransformedEventToDestinations } from './utilities';
 import { getDMTDeliveryPayload } from '../utilities/eventsDelivery';
 import { DEFAULT_TRANSFORMATION_QUEUE_OPTIONS, QUEUE_NAME, REQUEST_TIMEOUT_MS } from './constants';
 import { RetryQueue } from '../utilities/retryQueue/RetryQueue';
-import type { DoneCallback, IQueue } from '../types/plugins';
+import type { DoneCallback, IQueue, QueueProcessCallbackInfo } from '../types/plugins';
 import type { TransformationQueueItemData } from './types';
 import { isErrRetryable, isUndefined, MEMORY_STORAGE } from '../shared-chunks/common';
 
@@ -47,8 +47,7 @@ const DeviceModeTransformation = (): ExtensionPlugin => ({
         (
           item: TransformationQueueItemData,
           done: DoneCallback,
-          attemptNumber?: number,
-          maxRetryAttempts?: number,
+          qItemProcessInfo: QueueProcessCallbackInfo,
         ) => {
           const payload = createPayload(item.event, item.destinationIds, item.token);
 
@@ -68,7 +67,7 @@ const DeviceModeTransformation = (): ExtensionPlugin => ({
               if (
                 isUndefined(details?.error) ||
                 !isRetryable ||
-                attemptNumber === maxRetryAttempts
+                qItemProcessInfo.retryAttemptNumber === qItemProcessInfo.maxRetryAttempts
               ) {
                 sendTransformedEventToDestinations(
                   state,

--- a/packages/analytics-js-plugins/src/types/plugins.ts
+++ b/packages/analytics-js-plugins/src/types/plugins.ts
@@ -52,8 +52,9 @@ export type QueueProcessCallbackInfo = {
  *   - retryAttemptNumber: The number of times this item has been attempted to retry
  *   - maxRetryAttempts: The maximum number of times this item should be attempted to retry
  *   - willBeRetried: A boolean indicating if the item will be retried later
- *   - lastAttemptedAt: The timestamp of the last attempt
  *   - timeSinceLastAttempt: The number of seconds since the last attempt
+ *   - timeSinceFirstAttempt: The number of seconds since the first attempt
+ *   - reclaimed: A boolean indicating if the item has been reclaimed
  */
 export type QueueProcessCallback<T = any> = (
   item: T,

--- a/packages/analytics-js-plugins/src/types/plugins.ts
+++ b/packages/analytics-js-plugins/src/types/plugins.ts
@@ -13,6 +13,9 @@ export type QueueItem<T = QueueItemData> = {
   time: number;
   id: string;
   type: QueueItemType;
+  lastAttemptedAt?: number;
+  firstAttemptedAt?: number;
+  reclaimed?: boolean;
 };
 
 export type QueueItemData =
@@ -24,19 +27,38 @@ export type QueueItemData =
   | number[];
 
 /**
+ * @typedef {Object} QueueProcessCallbackInfo
+ * @property {number} retryAttemptNumber The number of times this item has been attempted to retry
+ * @property {number} maxRetryAttempts The maximum number of times this item should be attempted to retry
+ * @property {boolean} willBeRetried A boolean indicating if the item will be retried later
+ * @property {number} timeSinceFirstAttempt The number of seconds since the first attempt
+ * @property {number} timeSinceLastAttempt The number of seconds since the last attempt
+ * @property {boolean} reclaimed A boolean indicating if the item has been reclaimed
+ */
+export type QueueProcessCallbackInfo = {
+  retryAttemptNumber: number;
+  maxRetryAttempts: number;
+  willBeRetried: boolean;
+  timeSinceLastAttempt: number;
+  timeSinceFirstAttempt: number;
+  reclaimed: boolean;
+};
+
+/**
  * @callback QueueProcessCallback
  * @param {any} item The item added to the queue to process
  * @param {Function} done A function to call when processing is completed.
- * @param {Number} retryAttemptNumber The number of times this item has been attempted to retry
- * @param {Number} maxRetryAttempts The maximum number of times this item should be attempted to retry
- * @param {Number} willBeRetried A boolean indicating if the item will be retried later
+ * @param {Object} info An object containing the following properties:
+ *   - retryAttemptNumber: The number of times this item has been attempted to retry
+ *   - maxRetryAttempts: The maximum number of times this item should be attempted to retry
+ *   - willBeRetried: A boolean indicating if the item will be retried later
+ *   - lastAttemptedAt: The timestamp of the last attempt
+ *   - timeSinceLastAttempt: The number of seconds since the last attempt
  */
 export type QueueProcessCallback<T = any> = (
   item: T,
   done: DoneCallback,
-  retryAttemptNumber?: number,
-  maxRetryAttempts?: number,
-  willBeRetried?: boolean,
+  info: QueueProcessCallbackInfo,
 ) => void;
 
 export type QueueBatchItemsSizeCalculatorCallback<T = any> = (item: T) => number;

--- a/packages/analytics-js-plugins/src/utilities/retryQueue/RetryQueue.ts
+++ b/packages/analytics-js-plugins/src/utilities/retryQueue/RetryQueue.ts
@@ -569,13 +569,18 @@ class RetryQueue implements IQueue<QueueItemData> {
         const firstAttemptedAt = inProgressItem?.firstAttemptedAt ?? now;
         const lastAttemptedAt = inProgressItem?.lastAttemptedAt ?? now;
 
-        // A decimal integer representing the seconds since the last attempt
+        // A decimal integer representing the seconds since the first attempt
         const timeSinceFirstAttempt = Math.round((now - firstAttemptedAt) / 1000);
+
+        // A decimal integer representing the seconds since the last attempt
         const timeSinceLastAttempt = Math.round((now - lastAttemptedAt) / 1000);
+
+        // Indicates if the item has been reclaimed from local storage
         const reclaimed = inProgressItem?.reclaimed ?? false;
 
-        // Update the last attempted at timestamp for the in progress item
+        // Update the first attempted at timestamp for the in progress item
         inProgressItem.firstAttemptedAt = firstAttemptedAt;
+        // Update the last attempted at to current timestamp for the in progress item
         inProgressItem.lastAttemptedAt = now;
 
         inProgress[el.id] = inProgressItem;
@@ -669,6 +674,7 @@ class RetryQueue implements IQueue<QueueItemData> {
             type: el.type ?? type,
             firstAttemptedAt: el.firstAttemptedAt,
             lastAttemptedAt: el.lastAttemptedAt,
+            // Mark the item as reclaimed from local storage
             reclaimed: true,
           });
           trackMessageIds.push(id);
@@ -695,6 +701,7 @@ class RetryQueue implements IQueue<QueueItemData> {
           this.enqueue({
             ...el,
             id,
+            // Mark the item as reclaimed from local storage
             reclaimed: true,
             type: el.type ?? SINGLE_QUEUE_ITEM_TYPE,
             time: this.schedule.now(),

--- a/packages/analytics-js-plugins/src/utilities/retryQueue/RetryQueue.ts
+++ b/packages/analytics-js-plugins/src/utilities/retryQueue/RetryQueue.ts
@@ -432,9 +432,9 @@ class RetryQueue implements IQueue<QueueItemData> {
         time: this.schedule.now() + this.getDelay(attemptNumberToUse),
         id: id ?? generateUUID(),
         type,
-        firstAttemptedAt: firstAttemptedAt,
-        lastAttemptedAt: lastAttemptedAt,
-        reclaimed: reclaimed,
+        firstAttemptedAt,
+        lastAttemptedAt,
+        reclaimed,
       });
     } else {
       // Discard item

--- a/packages/analytics-js-plugins/src/utilities/retryQueue/types.ts
+++ b/packages/analytics-js-plugins/src/utilities/retryQueue/types.ts
@@ -15,6 +15,7 @@ export type QueueTimeouts = {
 };
 
 export type InProgressQueueItem = {
+  id: string;
   item: Record<string, any> | string | number | Record<string, any>[] | string[] | number[];
   done: DoneCallback;
   attemptNumber: number;

--- a/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
@@ -16,6 +16,7 @@ import {
   removeDuplicateSlashes,
   stringifyWithoutCircular,
 } from '../shared-chunks/common';
+import type { QueueProcessCallbackInfo } from '../types/plugins';
 
 const getBatchDeliveryPayload = (
   events: RudderEvent[],
@@ -42,9 +43,7 @@ const getBatchDeliveryUrl = (dataplaneUrl: string): string => getDeliveryUrl(dat
 const logErrorOnFailure = (
   details: ResponseDetails | undefined,
   isRetryable: boolean,
-  willBeRetried?: boolean,
-  attemptNumber?: number,
-  maxRetryAttempts?: number,
+  qItemProcessInfo: QueueProcessCallbackInfo,
   logger?: ILogger,
 ) => {
   let errMsg = EVENT_DELIVERY_FAILURE_ERROR_PREFIX(
@@ -53,13 +52,13 @@ const logErrorOnFailure = (
   );
   const dropMsg = `The event(s) will be dropped.`;
   if (isRetryable) {
-    if (willBeRetried) {
+    if (qItemProcessInfo.willBeRetried) {
       errMsg = `${errMsg} The event(s) will be retried.`;
-      if ((attemptNumber as number) > 0) {
-        errMsg = `${errMsg} Retry attempt ${attemptNumber} of ${maxRetryAttempts}.`;
+      if (qItemProcessInfo.retryAttemptNumber > 0) {
+        errMsg = `${errMsg} Retry attempt ${qItemProcessInfo.retryAttemptNumber} of ${qItemProcessInfo.maxRetryAttempts}.`;
       }
     } else {
-      errMsg = `${errMsg} Retries exhausted (${maxRetryAttempts}). ${dropMsg}`;
+      errMsg = `${errMsg} Retries exhausted (${qItemProcessInfo.maxRetryAttempts}). ${dropMsg}`;
     }
   } else {
     errMsg = `${errMsg} ${dropMsg}`;
@@ -71,6 +70,7 @@ const logErrorOnFailure = (
 const getRequestInfo = (
   itemData: XHRRetryQueueItemData,
   state: ApplicationState,
+  qItemProcessInfo: QueueProcessCallbackInfo,
   logger?: ILogger,
 ) => {
   let data;
@@ -92,6 +92,20 @@ const getRequestInfo = (
     headers = clone(eventHeaders);
     url = eventUrl;
   }
+
+  // Add sentAt header
+  headers.SentAt = currentTime;
+  if (qItemProcessInfo.reclaimed) {
+    headers.Reclaimed = qItemProcessInfo.reclaimed.toString();
+  }
+
+  // Add retry headers if the item is being retried
+  if (qItemProcessInfo.retryAttemptNumber > 0) {
+    headers['Retry-Attempt'] = qItemProcessInfo.retryAttemptNumber.toString();
+    headers['Retried-After'] = qItemProcessInfo.timeSinceLastAttempt.toString();
+    headers['Retried-After-First'] = qItemProcessInfo.timeSinceFirstAttempt.toString();
+  }
+
   return { data, headers, url };
 };
 

--- a/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
@@ -93,16 +93,25 @@ const getRequestInfo = (
     url = eventUrl;
   }
 
-  // Add sentAt header
+  // Add current timestamp as sentAt header
+  // The same value is added in the event payload as well
   headers.SentAt = currentTime;
+
+  // Add a header to indicate if the item has been reclaimed from
+  // local storage
   if (qItemProcessInfo.reclaimed) {
     headers.Reclaimed = 'true';
   }
 
-  // Add retry headers if the item is being retried
+  // Add retry headers if the item is being retried for delivery
   if (qItemProcessInfo.retryAttemptNumber > 0) {
+    // The number of times this item has been attempted to retry
     headers['Retry-Attempt'] = qItemProcessInfo.retryAttemptNumber.toString();
+
+    // The number of seconds since the last attempt
     headers['Retried-After'] = qItemProcessInfo.timeSinceLastAttempt.toString();
+
+    // The number of seconds since the first attempt
     headers['Retried-After-First'] = qItemProcessInfo.timeSinceFirstAttempt.toString();
   }
 

--- a/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
@@ -96,7 +96,7 @@ const getRequestInfo = (
   // Add sentAt header
   headers.SentAt = currentTime;
   if (qItemProcessInfo.reclaimed) {
-    headers.Reclaimed = qItemProcessInfo.reclaimed.toString();
+    headers.Reclaimed = 'true';
   }
 
   // Add retry headers if the item is being retried

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -113,7 +113,7 @@ export default [
     name: 'Core (Content Script) - Modern - NPM (CJS)',
     path: 'dist/npm/modern/content-script/cjs/index.cjs',
     import: '*',
-    limit: '39.1 KiB',
+    limit: '39.2 KiB',
   },
   {
     name: 'Core (Content Script) - Modern - NPM (UMD)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -24,7 +24,7 @@ export default [
   {
     name: 'Core - Legacy - CDN',
     path: 'dist/cdn/legacy/iife/rsa.min.js',
-    limit: '47.6 KiB',
+    limit: '48 KiB',
   },
   {
     name: 'Core - Modern - NPM (ESM)',
@@ -77,7 +77,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (CJS)',
     path: 'dist/npm/modern/bundled/cjs/index.cjs',
     import: '*',
-    limit: '39 KiB',
+    limit: '39.2 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (UMD)',
@@ -113,7 +113,7 @@ export default [
     name: 'Core (Content Script) - Modern - NPM (CJS)',
     path: 'dist/npm/modern/content-script/cjs/index.cjs',
     import: '*',
-    limit: '39 KiB',
+    limit: '39.1 KiB',
   },
   {
     name: 'Core (Content Script) - Modern - NPM (UMD)',


### PR DESCRIPTION
## PR Description

I've added retry headers and also the missing "sent at" header for all the requests to the data plane.

`Retried-After` - Time in seconds since the previous attempt to send the event(s)
`Retry-Attempt` - The retry attempt number
`Retried-After-First` - Time in seconds since the very first attempt to send the event(s)
`Reclaimed` - Boolean to indicate if the events were reclaimed from the storage

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2996/js-sdk-implementation-retry-headers

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Adjusted module size thresholds for key modules to better align with updated performance parameters.
- **Refactor**
	- Streamlined event processing by unifying retry metrics and error handling, enhancing the tracking of processing attempts and overall consistency.
	- Improved batch processing capabilities and item state tracking within the analytics framework.

These improvements aim to boost reliability and maintain smoother analytics operations without altering end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->