### PR TITLE
chore: implement concurrency in github workflows

### DIFF
--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -5,6 +5,10 @@ on:
     branches: ['main', 'develop', 'hotfix/*']
     types: ['opened', 'reopened', 'edited', 'synchronize']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   check_pr_title:
     name: Check PR title

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -3,6 +3,10 @@ name: Deploy BETA/BugBash Feature
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write # allows the JWT to be requested from GitHub's OIDC provider
   contents: read # This is required for actions/checkout

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -7,6 +7,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy to Development Environment

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -28,6 +28,10 @@ on:
       SLACK_RELEASE_CHANNEL_ID:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write # allows the JWT to be requested from GitHub's OIDC provider
   contents: read # This is required for actions/checkout

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,6 +9,10 @@ on:
       - synchronize
       - reopened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy to staging environment

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -6,7 +6,11 @@ on:
       release_ticket_id:
         description: Release ticket ID (Ex:- SDK-1234)
         required: true
-
+        
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true       
+        
 env:
   NODE_OPTIONS: '--no-warnings'
 

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '1 0 * * *' # every day at 00:01
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   prs:
     name: Clean up stale PRs

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -3,6 +3,10 @@ name: Rollback Production Deployment
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   validate-actor:
     # Only allow to be deployed from tags and main branch

--- a/.github/workflows/security-code-quality-and-bundle-size-checks.yml
+++ b/.github/workflows/security-code-quality-and-bundle-size-checks.yml
@@ -5,6 +5,10 @@ on:
     branches: ['develop', 'main', 'hotfix/*']
     types: ['opened', 'reopened', 'synchronize']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 env:
   NODE_OPTIONS: '--no-warnings'
   BASE_REF: ${{ github.event.pull_request.base.sha || 'HEAD' }}

--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -7,6 +7,10 @@ on:
     branches: ['main', 'develop', 'hotfix/*']
     types: ['opened', 'reopened', 'synchronize']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 env:
   NODE_OPTIONS: '--no-warnings'
   BASE_REF: ${{ github.event.pull_request.base.sha || 'HEAD' }}


### PR DESCRIPTION
## PR Description

I've implemented the concurrency group for all the applicable workflows to cancel any inprogress runs that will be superseded by newer events.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-1717/implement-concurrency-group-cancel-in-progress-for-js-repo

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
