### PR TITLE
fix: handle edge cases in retry queue

### DIFF
--- a/packages/analytics-js-common/__mocks__/StoreManager.ts
+++ b/packages/analytics-js-common/__mocks__/StoreManager.ts
@@ -2,7 +2,8 @@ import type { IStoreConfig, IStoreManager } from '../src/types/Store';
 import { defaultPluginsManager } from './PluginsManager';
 import { defaultCookieStorage, defaultInMemoryStorage, defaultLocalStorage } from './Storage';
 import { defaultStore, Store } from './Store';
-
+import { defaultLogger } from './Logger';
+import { defaultErrorHandler } from './ErrorHandler';
 // Mock all the methods of the StoreManager class
 
 class StoreManager implements IStoreManager {
@@ -26,6 +27,8 @@ class StoreManager implements IStoreManager {
   };
   getStore = jest.fn(() => defaultStore);
   initializeStorageState = jest.fn();
+  logger = defaultLogger;
+  errorHandler = defaultErrorHandler;
 }
 
 const defaultStoreManager = new StoreManager();

--- a/packages/analytics-js-plugins/.size-limit.mjs
+++ b/packages/analytics-js-plugins/.size-limit.mjs
@@ -16,7 +16,7 @@ export default [
   {
     name: 'Plugins - Legacy - CDN',
     path: 'dist/cdn/legacy/plugins/rsa-plugins-*.min.js',
-    limit: '14.1 KiB',
+    limit: '14.5 KiB',
   },
   {
     name: 'Plugins - Modern - CDN',

--- a/packages/analytics-js-plugins/src/utilities/retryQueue/RetryQueue.ts
+++ b/packages/analytics-js-plugins/src/utilities/retryQueue/RetryQueue.ts
@@ -375,7 +375,12 @@ class RetryQueue implements IQueue<QueueItemData> {
     let queue =
       (this.getStorageEntry(QueueStatuses.QUEUE) as Nullable<QueueItem<QueueItemData>[]>) ?? [];
 
+    if (this.maxItems > 1) {
     queue = queue.slice(-(this.maxItems - 1));
+    } else {
+      queue = [];
+    }
+
     queue.push(curEntry);
     queue = queue.sort(sortByTime);
 

--- a/packages/analytics-js-plugins/src/utilities/retryQueue/logMessages.ts
+++ b/packages/analytics-js-plugins/src/utilities/retryQueue/logMessages.ts
@@ -1,7 +1,7 @@
 import { LOG_CONTEXT_SEPARATOR } from '../../shared-chunks/common';
 
-const RETRY_QUEUE_PROCESS_ERROR = (context: string): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}Process function threw an error.`;
+const RETRY_QUEUE_PROCESS_ERROR = (context: string, errMsg: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}An unknown error occurred while processing the queue item. ${errMsg}`;
 
 const RETRY_QUEUE_ENTRY_REMOVE_ERROR = (context: string, entry: string, attempt: number): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}Failed to remove local storage entry "${entry}" (attempt: ${attempt}.`;

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -13,7 +13,7 @@ export default [
     name: 'Core - Legacy - NPM (CJS)',
     path: 'dist/npm/legacy/cjs/index.cjs',
     import: '*',
-    limit: '48 KiB',
+    limit: '48.2 KiB',
   },
   {
     name: 'Core - Legacy - NPM (UMD)',
@@ -59,7 +59,7 @@ export default [
     name: 'Core (Bundled) - Legacy - NPM (CJS)',
     path: 'dist/npm/legacy/bundled/cjs/index.cjs',
     import: '*',
-    limit: '48 KiB',
+    limit: '48.2 KiB',
   },
   {
     name: 'Core (Bundled) - Legacy - NPM (UMD)',


### PR DESCRIPTION
## PR Description

I've fixed the following issues in the retry queue module:
- When max items is 1, handle exactly 1 item. Earlier, it was accumulating all the items.
- For cases where queue item processor errors out, retry the item before giving up on it.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3066/event-processing-queue-issues

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling in the retry queue for clearer feedback on item processing.
  - Added logging and error handling capabilities to the StoreManager.

- **Bug Fixes**
  - Resolved issues with item reprocessing to prevent unpredictable behavior under certain conditions.

- **Refactor**
  - Improved the retry processing system with enhanced error feedback and clearer notifications to support easier troubleshooting and increased overall reliability.
  - Updated size limits for plugin configurations to accommodate larger file sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->