### PR TITLE
fix: prevent cookie storage engine options init by default

### DIFF
--- a/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
@@ -14,17 +14,20 @@ import { defaultLogger } from '../../Logger';
  */
 class CookieStorage implements IStorage {
   logger?: ILogger;
-  options: ICookieStorageOptions;
+  options?: ICookieStorageOptions;
   isSupportAvailable = true;
   isEnabled = true;
   length = 0;
 
   constructor(logger?: ILogger) {
-    this.options = getDefaultCookieOptions();
     this.logger = logger;
   }
 
   configure(options?: Partial<ICookieStorageOptions>): ICookieStorageOptions {
+    if (!this.options) {
+      this.options = getDefaultCookieOptions();
+    }
+
     this.options = mergeDeepRight(this.options, options ?? {});
     if (this.options.sameDomainCookiesOnly) {
       delete this.options.domain;


### PR DESCRIPTION
## PR Description

I have fixed an issue with the cookie storage engine where options are initialised by default causing crashes on Next.js server-side imports.

The default cookie storage options are set once it is configured in `RudderAnalytics` class's constructor.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3071/prevent-initialising-cookie-module-by-default

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
