### PR TITLE
fix: rename view id to visit id

### DIFF
--- a/.github/workflows/security-code-quality-and-bundle-size-checks.yml
+++ b/.github/workflows/security-code-quality-and-bundle-size-checks.yml
@@ -38,7 +38,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           install_script: setup:ci
           build_script: check:size:build
-          clean_script: clean
           script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --exclude=@rudderstack/analytics-js-sanity-suite
           is_monorepo: true
 

--- a/packages/analytics-js-common/src/types/ApplicationState.ts
+++ b/packages/analytics-js-common/src/types/ApplicationState.ts
@@ -90,7 +90,7 @@ export type AutoTrackState = {
 
 export type PageLifecycleState = {
   enabled: Signal<boolean>;
-  visitId: Signal<string | undefined>;
+  pageViewId: Signal<string | undefined>;
   pageLoadedTimestamp: Signal<number | undefined>;
 };
 

--- a/packages/analytics-js-common/src/types/Event.ts
+++ b/packages/analytics-js-common/src/types/Event.ts
@@ -9,7 +9,7 @@ import type { ApiObject } from './ApiObject';
 export type BufferedEvent = any[];
 
 export type PageLifecycle = {
-  visitId: string; // UUID
+  pageViewId: string; // UUID
 };
 
 export type AutoTrack = {

--- a/packages/analytics-js-plugins/__mocks__/state.ts
+++ b/packages/analytics-js-plugins/__mocks__/state.ts
@@ -175,7 +175,7 @@ const defaultStateValues: ApplicationState = {
     enabled: signal(false),
     pageLifecycle: {
       enabled: signal(false),
-      visitId: signal(undefined),
+      pageViewId: signal(undefined),
       pageLoadedTimestamp: signal(undefined),
     },
   },

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -250,7 +250,7 @@ describe('Event Manager - Utilities', () => {
 
         state.autoTrack.enabled.value = true;
         state.autoTrack.pageLifecycle.enabled.value = true;
-        state.autoTrack.pageLifecycle.visitId.value = 'visit_id';
+        state.autoTrack.pageLifecycle.pageViewId.value = 'view_id';
       });
 
       // @ts-expect-error Omitted other fields for brevity
@@ -329,7 +329,7 @@ describe('Event Manager - Utilities', () => {
           userId: 'overridden_user_id',
           autoTrack: {
             page: {
-              visitId: 'visit_id',
+              pageViewId: 'view_id',
             },
           },
         },

--- a/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
@@ -278,7 +278,7 @@ describe('Error Reporting utilities', () => {
       state.session.sessionInfo.value = { id: 123 };
       // @ts-expect-error setting the value for testing
       state.context.app.value.installType = 'cdn';
-      state.autoTrack.pageLifecycle.visitId.value = 'test-visit-id';
+      state.autoTrack.pageLifecycle.pageViewId.value = 'test-view-id';
       // @ts-expect-error setting the value for testing
       state.context.library.value.snippetVersion = 'sample_snippet_version';
       state.context.locale.value = 'en-US';
@@ -408,7 +408,7 @@ describe('Error Reporting utilities', () => {
                 enabled: false,
                 pageLifecycle: {
                   enabled: false,
-                  visitId: 'test-visit-id',
+                  pageViewId: 'test-view-id',
                 },
               },
               capabilities: {
@@ -576,7 +576,7 @@ describe('Error Reporting utilities', () => {
               },
             },
             user: {
-              id: 'dummy-source-id..123..test-visit-id',
+              id: 'dummy-source-id..123..test-view-id',
               name: 'dummy-source-name',
             },
           },
@@ -698,7 +698,7 @@ describe('Error Reporting utilities', () => {
         workspaceId: 'dummy-workspace-id',
       };
       state.session.sessionInfo.value = { id: 123 };
-      state.autoTrack.pageLifecycle.visitId.value = 'test-visit-id';
+      state.autoTrack.pageLifecycle.pageViewId.value = 'test-view-id';
 
       const userDetails = getUserDetails(
         state.source,
@@ -707,7 +707,7 @@ describe('Error Reporting utilities', () => {
         state.autoTrack,
       );
       expect(userDetails).toEqual({
-        id: 'dummy-source-id..123..test-visit-id',
+        id: 'dummy-source-id..123..test-view-id',
         name: 'dummy-source-name',
       });
     });

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -97,7 +97,7 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
 
       RudderAnalytics.globalSingleton = this;
 
-      state.autoTrack.pageLifecycle.visitId.value = generateUUID();
+      state.autoTrack.pageLifecycle.pageViewId.value = generateUUID();
       state.autoTrack.pageLifecycle.pageLoadedTimestamp.value = Date.now();
 
       // start loading if a load event was buffered or wait for explicit load call

--- a/packages/analytics-js/src/components/eventManager/utilities.ts
+++ b/packages/analytics-js/src/components/eventManager/utilities.ts
@@ -268,7 +268,7 @@ const getEnrichedEvent = (
         autoTrack: {
           ...(state.autoTrack.pageLifecycle.enabled.value && {
             page: {
-              visitId: state.autoTrack.pageLifecycle.visitId.value,
+              pageViewId: state.autoTrack.pageLifecycle.pageViewId.value,
             },
           }),
         },

--- a/packages/analytics-js/src/services/ErrorHandler/utils.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/utils.ts
@@ -75,7 +75,7 @@ const getUserDetails = (
   lifecycle: ApplicationState['lifecycle'],
   autoTrack: ApplicationState['autoTrack'],
 ) => ({
-  id: `${source.value?.id ?? (lifecycle.writeKey.value as string)}..${session.sessionInfo.value.id ?? 'NA'}..${autoTrack.pageLifecycle.visitId.value ?? 'NA'}`,
+  id: `${source.value?.id ?? (lifecycle.writeKey.value as string)}..${session.sessionInfo.value.id ?? 'NA'}..${autoTrack.pageLifecycle.pageViewId.value ?? 'NA'}`,
   name: source.value?.name ?? 'NA',
 });
 

--- a/packages/analytics-js/src/state/slices/autoTrack.ts
+++ b/packages/analytics-js/src/state/slices/autoTrack.ts
@@ -5,7 +5,7 @@ const autoTrackState: AutoTrackState = {
   enabled: signal(false),
   pageLifecycle: {
     enabled: signal(false),
-    visitId: signal(undefined),
+    pageViewId: signal(undefined),
     pageLoadedTimestamp: signal(undefined),
   },
 };


### PR DESCRIPTION
## PR Description

I've renamed `visitId` to `pageViewId` in `context.autoTrack.page` object.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2932/update-visitid-to-pageviewid-for-time-on-page

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the analytics tracking identifier for page views from `visitId` to `pageViewId` to improve clarity and consistency.

- **Tests**
  - Adjusted related test cases to ensure reliable functionality with the updated tracking terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->