### PR TITLE
fix: rename visit duration to time on page

### DIFF
--- a/.github/workflows/security-code-quality-and-bundle-size-checks.yml
+++ b/.github/workflows/security-code-quality-and-bundle-size-checks.yml
@@ -38,7 +38,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           install_script: setup:ci
           build_script: check:size:build
-          clean_script: clean
           script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --exclude=@rudderstack/analytics-js-sanity-suite
           is_monorepo: true
 

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -77,7 +77,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (CJS)',
     path: 'dist/npm/modern/bundled/cjs/index.cjs',
     import: '*',
-    limit: '39.2 KiB',
+    limit: '39.5 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (UMD)',

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -817,7 +817,7 @@ describe('Core - Rudder Analytics Facade', () => {
 
       expect(rudderAnalyticsInstance.track).toHaveBeenCalledWith(
         'Page Unloaded',
-        { visitDuration: expect.any(Number) },
+        { timeOnPage: expect.any(Number) },
         { originalTimestamp: expect.any(String) },
       );
     });

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -276,14 +276,14 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
         onPageLeave((isAccessible: boolean) => {
           if (isAccessible === false && state.lifecycle.loaded.value) {
             const pageUnloadedTimestamp = Date.now();
-            const visitDuration =
+            const timeOnPage =
               pageUnloadedTimestamp -
               (state.autoTrack.pageLifecycle.pageLoadedTimestamp.value as number);
 
             this.track(
               PageLifecycleEvents.UNLOADED,
               {
-                visitDuration,
+                timeOnPage,
               },
               {
                 ...options,


### PR DESCRIPTION
## PR Description

I've renamed the page unloaded event's property from `visitDuration` to `timeOnPage`.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2931/update-visitduration-to-timeonpage-for-time-on-page

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the naming of the page visit duration variable from `visitDuration` to `timeOnPage` for clearer tracking of user engagement.

- **Tests**
  - Adjusted test cases to ensure alignment with the updated tracking metrics.

- **Chores**
  - Increased the size limit for the "Core (Bundled) - Modern - NPM (CJS)" entry from 39.2 KiB to 39.5 KiB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->