### PR TITLE
feat: remove page loaded event

### DIFF
--- a/packages/analytics-js-common/src/types/LoadOptions.ts
+++ b/packages/analytics-js-common/src/types/LoadOptions.ts
@@ -109,7 +109,6 @@ export type PreConsentOptions = {
 };
 
 export enum PageLifecycleEvents {
-  LOADED = 'Page Loaded',
   UNLOADED = 'Page Unloaded',
 }
 

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -800,7 +800,7 @@ describe('Core - Rudder Analytics Facade', () => {
 
       expect(rudderAnalyticsInstance.track).toHaveBeenCalledWith(
         'Page Unloaded',
-        { visitDuration: expect.any(Number) },
+        { timeOnPage: expect.any(Number) },
         { originalTimestamp: expect.any(String), key: 'value2' },
       );
 
@@ -832,7 +832,7 @@ describe('Core - Rudder Analytics Facade', () => {
 
       expect(rudderAnalyticsInstance.track).toHaveBeenCalledWith(
         'Page Unloaded',
-        { visitDuration: 1500 },
+        { timeOnPage: 1500 },
         { originalTimestamp: '1970-01-01T00:00:01.500Z', key: 'value' },
       );
 

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -174,12 +174,13 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
       }
 
       this.setDefaultInstanceKey(writeKey);
+
+      // Track page loaded lifecycle event if enabled
+      this.trackPageLifecycleEvents(loadOptions);
+
       // Get the preloaded events array from global buffer instead of window.rudderanalytics
       // as the constructor must have already pushed the events to the global buffer
       const preloadedEventsArray = getExposedGlobal(GLOBAL_PRELOAD_BUFFER) as PreloadedEventCall[];
-
-      // Track page loaded lifecycle event if enabled
-      this.trackPageLifecycleEvents(preloadedEventsArray, loadOptions);
 
       // The array will be mutated in the below method
       promotePreloadedConsentEventsToTop(preloadedEventsArray);
@@ -198,14 +199,10 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
 
   /**
    * A function to track page lifecycle events like page loaded and page unloaded
-   * @param preloadedEventsArray
    * @param loadOptions
    * @returns
    */
-  trackPageLifecycleEvents(
-    preloadedEventsArray: PreloadedEventCall[],
-    loadOptions?: Partial<LoadOptions>,
-  ) {
+  trackPageLifecycleEvents(loadOptions?: Partial<LoadOptions>) {
     const { autoTrack, useBeacon } = loadOptions ?? {};
     const {
       enabled: autoTrackEnabled = false,
@@ -214,7 +211,7 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
     } = autoTrack ?? {};
 
     const {
-      events = [PageLifecycleEvents.LOADED, PageLifecycleEvents.UNLOADED],
+      events = [PageLifecycleEvents.UNLOADED],
       enabled: pageLifecycleEnabled = autoTrackEnabled,
       options = autoTrackOptions,
     } = pageLifecycle ?? {};
@@ -229,35 +226,8 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
     if (!pageLifecycleEnabled) {
       return;
     }
-    this.trackPageLoadedEvent(events, options, preloadedEventsArray);
-    this.setupPageUnloadTracking(events, useBeacon, options);
-  }
 
-  /**
-   * Buffer the page loaded event in the preloaded events array
-   * @param events
-   * @param options
-   * @param preloadedEventsArray
-   */
-  // eslint-disable-next-line class-methods-use-this
-  trackPageLoadedEvent(
-    events: PageLifecycleEvents[],
-    options: ApiOptions,
-    preloadedEventsArray: PreloadedEventCall[],
-  ) {
-    if (events.length === 0 || events.includes(PageLifecycleEvents.LOADED)) {
-      preloadedEventsArray.unshift([
-        'track',
-        PageLifecycleEvents.LOADED,
-        {},
-        {
-          ...options,
-          originalTimestamp: getFormattedTimestamp(
-            new Date(state.autoTrack.pageLifecycle.pageLoadedTimestamp.value as number),
-          ),
-        },
-      ]);
-    }
+    this.setupPageUnloadTracking(events, useBeacon, options);
   }
 
   /**


### PR DESCRIPTION
## PR Description

I've updated the page lifecycle auto-tracking feature to only send `Page Unloaded` event. This is to prevent duplicate events if users already have a default `page` event.

The page view ID and time spent on the current page parameters are both path of the `Page Unloaded` event. So, no information is truly lost.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-2933/remove-page-loaded-option

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined analytics event tracking to focus exclusively on page unload events by removing previous page load tracking.
  - Removed the `LOADED` enum value from page lifecycle events.

- **Tests**
  - Expanded test coverage and improved state management to validate correct lifecycle event tracking and behavior under various conditions.
  - Introduced new tests for simulating page unload events and verifying event tracking based on the `useBeacon` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->