### PR TITLE
feat: pre-consent event buffering works now for anonymousId pre-consent storage strategy

### DIFF
--- a/packages/analytics-js/__tests__/components/eventRepository/EventRepository.test.ts
+++ b/packages/analytics-js/__tests__/components/eventRepository/EventRepository.test.ts
@@ -341,7 +341,7 @@ describe('EventRepository', () => {
     );
 
     eventRepository.init();
-    
+
     const mockEventCallback = jest.fn(() => {
       throw new Error('test error');
     });
@@ -354,29 +354,32 @@ describe('EventRepository', () => {
     );
   });
 
-  it('should buffer the data plane events if the pre-consent event delivery strategy is set to buffer', () => {
-    const eventRepository = new EventRepository(
-      mockPluginsManager,
-      defaultStoreManager,
-      defaultHttpClient,
-      defaultErrorHandler,
-      defaultLogger,
-    );
+  it.each(['session', 'anonymousId', 'none'] as const)(
+    'should buffer the data plane events if the pre-consent event delivery strategy is set to buffer with storage strategy "%s"',
+    strategy => {
+      const eventRepository = new EventRepository(
+        mockPluginsManager,
+        defaultStoreManager,
+        defaultHttpClient,
+        defaultErrorHandler,
+        defaultLogger,
+      );
 
-    state.consents.preConsent.value = {
-      enabled: true,
-      events: {
-        delivery: 'buffer',
-      },
-      storage: {
-        strategy: 'session', // the value should be either 'session' or 'anonymousId'
-      },
-    };
+      state.consents.preConsent.value = {
+        enabled: true,
+        events: {
+          delivery: 'buffer',
+        },
+        storage: {
+          strategy,
+        },
+      };
 
-    eventRepository.init();
+      eventRepository.init();
 
-    expect(mockDataplaneEventsQueue.start).not.toHaveBeenCalled();
-  });
+      expect(mockDataplaneEventsQueue.start).not.toHaveBeenCalled();
+    },
+  );
 
   describe('resume', () => {
     it('should resume events processing on resume', () => {

--- a/packages/analytics-js/src/components/eventRepository/utils.ts
+++ b/packages/analytics-js/src/components/eventRepository/utils.ts
@@ -44,8 +44,6 @@ const getFinalEvent = (event: RudderEvent, state: ApplicationState) => {
 
 const shouldBufferEventsForPreConsent = (state: ApplicationState): boolean =>
   state.consents.preConsent.value.enabled &&
-  state.consents.preConsent.value.events?.delivery === 'buffer' &&
-  (state.consents.preConsent.value.storage?.strategy === 'session' ||
-    state.consents.preConsent.value.storage?.strategy === 'none');
+  state.consents.preConsent.value.events?.delivery === 'buffer';
 
 export { getOverriddenIntegrationOptions, getFinalEvent, shouldBufferEventsForPreConsent };


### PR DESCRIPTION
## PR Description

This PR enables pre-consent event buffering (as raised in https://github.com/rudderlabs/rudder-sdk-js/issues/2092), so I don't need to create my own event queue.

## Linear task (optional)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [X] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [X] All sanity suite test cases pass locally

## Security

- [X] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced test coverage by parameterizing event buffering scenarios, ensuring robust evaluation across multiple storage strategies.
- **Refactor**
	- Simplified event buffering logic for pre-consent conditions, streamlining internal processing for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->