### PR TITLE
chore: update nextjs hooks sample app to buffer preload events

### DIFF
--- a/examples/nextjs/hooks/sample-app/src/app/layout.tsx
+++ b/examples/nextjs/hooks/sample-app/src/app/layout.tsx
@@ -14,7 +14,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang='en'>
       <head>
-        <Script id='bufferEvents'>
+        <Script 
+          id='bufferEvents'
+          strategy="beforeInteractive"
+        >
           {`
             (function() {
               "use strict";

--- a/examples/nextjs/hooks/sample-app/src/app/page.tsx
+++ b/examples/nextjs/hooks/sample-app/src/app/page.tsx
@@ -69,7 +69,10 @@ export default function Home() {
   };
 
   useEffect(() => {
-    if (analytics) {
+    // Instrument a page event when RudderStack analytics is available to accept events.
+    // It is first available as an array and then as an object when the SDK is instantiated.
+    // So, enqueue the event as early as possible.
+    if (analytics && Array.isArray(analytics)) {
       analytics.page('Auto track');
     }
   }, [analytics]);

--- a/examples/nextjs/hooks/sample-app/src/app/useRudderAnalytics.ts
+++ b/examples/nextjs/hooks/sample-app/src/app/useRudderAnalytics.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import type { RudderAnalytics } from '@rudderstack/analytics-js';
+import type { RudderAnalytics, RudderAnalyticsPreloader } from '@rudderstack/analytics-js';
 
-const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
-  const [analytics, setAnalytics] = useState<RudderAnalytics>();
+const useRudderStackAnalytics = (): RudderAnalytics | RudderAnalyticsPreloader | undefined => {
+  const [analytics, setAnalytics] = useState<RudderAnalytics | RudderAnalyticsPreloader>();
 
   useEffect(() => {
     if (!analytics) {
@@ -23,7 +23,12 @@ const useRudderStackAnalytics = (): RudderAnalytics | undefined => {
     }
   }, [analytics]);
 
-  return analytics;
+  // Return initialized instance if available, otherwise fallback to window.rudderanalytics
+  if (analytics) {
+    return analytics;
+  }
+
+  return typeof window !== 'undefined' ? window.rudderanalytics : undefined;
 };
 
 export default useRudderStackAnalytics;


### PR DESCRIPTION
## PR Description

I've updated the Next.js hooks based sample application to buffer the SDK pre-load events effectively.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Updated script execution timing so that critical scripts run earlier, promoting smoother page interactivity.
  - Enhanced analytics tracking with refined initialization and fallback handling, ensuring more reliable event reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->