### PR TITLE
fix: update clevertap loading js to https

### DIFF
--- a/packages/analytics-js-integrations/.size-limit.js
+++ b/packages/analytics-js-integrations/.size-limit.js
@@ -6,7 +6,7 @@ module.exports = [
   {
     name: 'All Integrations - Legacy - CDN',
     path: 'dist/cdn/legacy/js-integrations/*.min.js',
-    limit: '96.5 KiB',
+    limit: '97 KiB',
   },
   {
     name: 'All Integrations - Modern - CDN',

--- a/packages/analytics-js-integrations/src/integrations/Clevertap/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Clevertap/browser.js
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import get from 'get-value';
 import { ScriptLoader } from '@rudderstack/analytics-js-common/v1.1/utils/ScriptLoader';
 import {
@@ -55,10 +54,7 @@ class Clevertap {
   }
 
   init() {
-    const sourceUrl =
-      document.location.protocol === 'https:'
-        ? 'https://d2r1yp2w7bby2u.cloudfront.net/js/clevertap.min.js'
-        : 'https://static.clevertap.com/js/clevertap.min.js';
+    const sourceUrl = 'https://static.clevertap.com/js/clevertap.min.js';
 
     window.clevertap = {
       event: [],

--- a/packages/analytics-js-integrations/src/integrations/Clevertap/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Clevertap/browser.js
@@ -58,7 +58,7 @@ class Clevertap {
     const sourceUrl =
       document.location.protocol === 'https:'
         ? 'https://d2r1yp2w7bby2u.cloudfront.net/js/clevertap.min.js'
-        : 'http://static.clevertap.com/js/clevertap.min.js';
+        : 'https://static.clevertap.com/js/clevertap.min.js';
 
     window.clevertap = {
       event: [],


### PR DESCRIPTION
## PR Description

This pull request includes changes to update the file size limit for legacy integrations and to ensure secure loading of the Clevertap script. The most important changes are:

File size limit update:
* [`packages/analytics-js-integrations/.size-limit.js`](diffhunk://#diff-7d80ecb545265933240ceca76dd053cc8e78dfea9a356cd98b91a2700b433d3bL9-R9): Increased the file size limit for 'All Integrations - Legacy - CDN' from 96.5 KiB to 97 KiB.

Security improvement:
* [`packages/analytics-js-integrations/src/integrations/Clevertap/browser.js`](diffhunk://#diff-8eba6adb67611bee450c703c85d4aeac2a254aa6a88c3b78fa985e8f37b62e2dL61-R61): Changed the URL for loading the Clevertap script to always use HTTPS, ensuring secure loading regardless of the protocol used.

## Linear task (optional)

Resolves INT-3484

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Increased the allowed size limit for a legacy integration to better accommodate performance.

- **Bug Fixes**
  - Updated the third-party integration to load its SDK using a secure HTTPS URL, ensuring enhanced security and consistent delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->