### PR TITLE
fix: consider local page urls as dev release stage in error reporting

### DIFF
--- a/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
@@ -69,12 +69,15 @@ describe('Error Reporting utilities', () => {
       ['127.0.0.1', 'development'],
       ['www.test-host.com', 'development'],
       ['[::1]', 'development'],
-      ['', '__RS_BUGSNAG_RELEASE_STAGE__'],
+      ['', 'development'], // for file:// protocol
       ['www.validhost.com', '__RS_BUGSNAG_RELEASE_STAGE__'],
+      [undefined, 'development'],
+      [null, 'development'],
     ];
 
     it.each(testCaseData)(
       'if window host name is "%s" then it should return the release stage as "%s" ',
+      // @ts-expect-error - test case data is not typed
       (hostName, expectedReleaseStage) => {
         locationSpy.mockImplementation(() => ({
           hostname: hostName,

--- a/packages/analytics-js/src/services/ErrorHandler/utils.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/utils.ts
@@ -54,9 +54,15 @@ const createNewBreadcrumb = (message: string): Breadcrumb => ({
   metaData: {},
 });
 
+/**
+ * A function to get the Bugsnag release stage for the current environment
+ * @returns 'development' if the host is empty (for file:// protocol etc.) or a dev host (localhost, 127.0.0.1, etc.), otherwise '__RS_BUGSNAG_RELEASE_STAGE__' (it'll be replaced with the actual release stage during the build)
+ */
 const getReleaseStage = () => {
   const host = globalThis.location.hostname;
-  return host && DEV_HOSTS.includes(host) ? 'development' : '__RS_BUGSNAG_RELEASE_STAGE__';
+  return !host || (host && DEV_HOSTS.includes(host))
+    ? 'development'
+    : '__RS_BUGSNAG_RELEASE_STAGE__';
 };
 
 const getAppStateForMetadata = (state: ApplicationState): Record<string, any> => {


### PR DESCRIPTION
## PR Description

I've fixed an issue in the SDK to treat local file system URLs (file://...) as a development host and thus set the release stage in the error reporting payload as `development`.
Otherwise, errors from such pages spam the errors management tool.

## Linear task (optional)

https://linear.app/rudderstack/issue/2cc0112c-7573-4838-a9d9-8aa80ff8a1cd

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
