### PR TITLE
fix: consent api race condition to load integrations

### DIFF
--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -385,8 +385,8 @@ class Analytics implements IAnalytics {
    * Load device mode destinations
    */
   loadDestinations() {
+    // If the destinations load is already triggered or completed, do not anything
     if (
-      state.nativeDestinations.clientDestinationsReady.value ||
       state.lifecycle.status.value === 'destinationsLoading' ||
       state.lifecycle.status.value === 'destinationsReady'
     ) {

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -385,7 +385,7 @@ class Analytics implements IAnalytics {
    * Load device mode destinations
    */
   loadDestinations() {
-    // If the destinations load is already triggered or completed, do not anything
+    // If the integrations load is already triggered or completed, skip the rest of the logic
     if (
       state.lifecycle.status.value === 'destinationsLoading' ||
       state.lifecycle.status.value === 'destinationsReady'

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -385,7 +385,11 @@ class Analytics implements IAnalytics {
    * Load device mode destinations
    */
   loadDestinations() {
-    if (state.nativeDestinations.clientDestinationsReady.value) {
+    if (
+      state.nativeDestinations.clientDestinationsReady.value ||
+      state.lifecycle.status.value === 'destinationsLoading' ||
+      state.lifecycle.status.value === 'destinationsReady'
+    ) {
       return;
     }
 


### PR DESCRIPTION
## PR Description

I've updated the validation in integrations load function to check for both loading and ready states.
This way if consent API and SDK life cycle will only attempt to load the integrations once.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3224/fix-consent-api-race-condition-for-loading-integrations-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of destination loading to prevent redundant or unnecessary loading processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->