### PR TITLE
fix: add validation for non array products

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/utils.js
@@ -285,8 +285,10 @@ const getProductContentAndId = (prodId, quantity, price) => {
  * @returns
  */
 const getProductListViewedEventParams = properties => {
-  const { products, category, quantity, price } = properties;
-
+  let { products, category, quantity, price } = properties;
+  if (!Array.isArray(products)) {
+    products = [products];
+  }
   const { contents, contentIds } = getProductsContentsAndContentIds(products, quantity, price);
 
   let contentType;

--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/utils.test.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/utils.test.js
@@ -1,0 +1,101 @@
+import { getProductListViewedEventParams } from './utils';
+
+describe('Facebook Pixel utils', () => {
+  describe('getProductListViewedEventParams', () => {
+    // When products is an array, it should extract contentIds and contents correctly
+    it('should extract contentIds and contents correctly when products is an array', () => {
+      const mockContents = [
+        { id: 'prod1', quantity: 2 },
+        { id: 'prod2', quantity: 1 },
+      ];
+      const mockContentIds = ['prod1', 'prod2'];
+
+      // Test data
+      const properties = {
+        products: [
+          { product_id: 'prod1', quantity: 2 },
+          { product_id: 'prod2', quantity: 1 },
+        ],
+      };
+
+      // Execute the function
+      const result = getProductListViewedEventParams(properties);
+
+      // Assertions
+      expect(result).toEqual({
+        contentIds: mockContentIds,
+        contentType: 'product',
+        contents: mockContents,
+      });
+    });
+
+    // When products array is empty
+    it('should return empty arrays when products array is empty', () => {
+      const properties = {
+        products: [],
+      };
+
+      const result = getProductListViewedEventParams(properties);
+
+      expect(result).toEqual({
+        contentIds: [],
+        contents: [],
+      });
+    });
+
+    // When products is undefined
+    it('should return empty arrays when products is undefined', () => {
+      const properties = {};
+
+      const result = getProductListViewedEventParams(properties);
+
+      expect(result).toEqual({
+        contentIds: [],
+        contents: [],
+      });
+    });
+
+    // When product_id is missing in some products
+    it('should handle missing product_id in products array', () => {
+      const properties = {
+        products: [
+          { product_id: 'prod1', quantity: 2 },
+          { quantity: 1 }, // Missing product_id
+          { product_id: 'prod3', quantity: 3 },
+        ],
+      };
+
+      const result = getProductListViewedEventParams(properties);
+
+      expect(result).toEqual({
+        contentIds: ['prod1', 'prod3'],
+        contentType: 'product',
+        contents: [
+          { id: 'prod1', quantity: 2 },
+          { id: 'prod3', quantity: 3 },
+        ],
+      });
+    });
+
+    // When quantity is missing in some products
+    it('should default to quantity 1 when quantity is missing', () => {
+      const properties = {
+        products: [
+          { product_id: 'prod1' }, // Missing quantity
+          { product_id: 'prod2', quantity: 2 },
+        ],
+      };
+
+      const result = getProductListViewedEventParams(properties);
+
+      expect(result).toEqual({
+        contentIds: ['prod1', 'prod2'],
+        contentType: 'product',
+        contents: [
+          { id: 'prod1', quantity: 1 }, // Default quantity
+          { id: 'prod2', quantity: 2 },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## PR Description

Added validation to verify product is an array or not and then converting that to an array if not.

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-3455/fix-error-in-nativedestinationqueueplugin-for-facebook-pixel

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of product lists in Facebook Pixel integration to ensure consistent processing, even when the products property is not an array.

- **Tests**
  - Added comprehensive tests for product-related event parameter extraction, covering various input scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->