### PR TITLE
fix: recursively migrate persisted entries

### DIFF
--- a/packages/analytics-js-common/src/v1.1/utils/storage/storage.js
+++ b/packages/analytics-js-common/src/v1.1/utils/storage/storage.js
@@ -199,23 +199,21 @@ class Storage {
     try {
       let currentValue = this.storage.get(key);
 
+      let decryptedValue = decryptValue(currentValue);
+      currentValue = decryptedValue ? JSON.parse(decryptedValue) : null;
+
       // Recursively decrypt the value until we reach a point where the value
       // is not encrypted anymore
-      while (true) {
-        const decryptedValue = decryptValue(currentValue);
+      while (typeof currentValue === 'string') {
+        decryptedValue = decryptValue(currentValue);
 
         // If the decrypted value is the same as the current value,
-        // we have reached the end of the migration
+        // then it's not encrypted anymore
         if (decryptedValue === currentValue) {
           break;
         }
 
         currentValue = JSON.parse(decryptedValue);
-
-        // If the parsed value is not a string, we have reached the end of the migration
-        if (typeof currentValue !== 'string') {
-          break;
-        }
       }
 
       return currentValue;

--- a/packages/analytics-js-plugins/__tests__/storageMigrator/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/storageMigrator/index.test.ts
@@ -44,7 +44,7 @@ describe('Plugin - Storage Migrator', () => {
     expect(migratedVal).toBe('test-data');
   });
 
-  it('should return null if the stored value is undefined', () => {
+  it('should return "undefined" if the stored value is undefined', () => {
     defaultLocalStorage.setItem('key', undefined);
 
     const migratedVal = (storageMigrator.storage as ExtensionPoint).migrate?.(
@@ -53,7 +53,7 @@ describe('Plugin - Storage Migrator', () => {
       defaultErrorHandler,
       defaultLogger,
     );
-    expect(migratedVal).toBe(null);
+    expect(migratedVal).toEqual('undefined');
   });
 
   it('should return null if the stored value is null', () => {

--- a/packages/analytics-js-plugins/__tests__/storageMigrator/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/storageMigrator/index.test.ts
@@ -44,7 +44,7 @@ describe('Plugin - Storage Migrator', () => {
     expect(migratedVal).toBe('test-data');
   });
 
-  it('should return "undefined" if the stored value is undefined', () => {
+  it('should return null if the stored value is undefined', () => {
     defaultLocalStorage.setItem('key', undefined);
 
     const migratedVal = (storageMigrator.storage as ExtensionPoint).migrate?.(
@@ -53,7 +53,7 @@ describe('Plugin - Storage Migrator', () => {
       defaultErrorHandler,
       defaultLogger,
     );
-    expect(migratedVal).toEqual('undefined');
+    expect(migratedVal).toBe(null);
   });
 
   it('should return null if the stored value is null', () => {

--- a/packages/analytics-js-plugins/__tests__/storageMigrator/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/storageMigrator/index.test.ts
@@ -68,7 +68,7 @@ describe('Plugin - Storage Migrator', () => {
     expect(migratedVal).toBe(null);
   });
 
-  it('should return null if the legacy decrypted value is undefined', () => {
+  it('should return null if the legacy decrypted value is not JSON parsable string', () => {
     defaultLocalStorage.setItem(
       'key',
       'RudderEncrypt:U2FsdGVkX195kUN9L968e0E/eu8CtnDHWt6ALf6bm8E=',
@@ -83,22 +83,7 @@ describe('Plugin - Storage Migrator', () => {
     expect(migratedVal).toBe(null);
   });
 
-  it('should return null if the legacy decrypted value is null', () => {
-    defaultLocalStorage.setItem(
-      'key',
-      'RudderEncrypt:U2FsdGVkX1+SMQ+LKcuk7w/nQ9DEjgU9EUmmBgb/Pfo=',
-    );
-
-    const migratedVal = (storageMigrator.storage as ExtensionPoint).migrate?.(
-      null,
-      defaultLocalStorage,
-      defaultErrorHandler,
-      defaultLogger,
-    );
-    expect(migratedVal).toBe(null);
-  });
-
-  it('should return null if the v3 decrypted value is undefined', () => {
+  it('should return null if the v3 decrypted value is not a JSON parsable string', () => {
     defaultLocalStorage.setItem('key', 'RS_ENC_v3_dW5kZWZpbmVk');
 
     const migratedVal = (storageMigrator.storage as ExtensionPoint).migrate?.(
@@ -140,5 +125,38 @@ describe('Plugin - Storage Migrator', () => {
       'StorageMigratorPlugin',
       'Failed to retrieve or parse data for key from storage.',
     );
+  });
+
+  it('should recursively decrypt the value until it is not encrypted', () => {
+    // The cookie value is encrypted over and over multiple times
+    // using the v3 encryption method
+    defaultLocalStorage.setItem(
+      'key',
+      'RS_ENC_v3_IlJTX0VOQ192M19JbEpUWDBWT1ExOTJNMTlKYkVwVVdEQldUMUV4T1RKTk1UbEtZa1Z3VlZkRVFsZFVNVVY0VDFSS1RrMVViRXRaYTFaM1ZsWmtSVkZzWkZWTlZWWTBWREZTUzFSck1WVmlSWFJhWVRGYU0xWnNXbXRTVmtaeldrWldUbFpXV1RCV1JFWlRVekZTY2sxV1ZtbFNXRkpoV1ZSR1lVMHhXbk5YYlhSVFZtdGFlbGRyV2xkVWJGcFhWMVJDVjFKRldsUlZla1pUWTJzeFYxWnRiRk5YUmtwb1YxWlNSMWxWTUhoWGJrNVlZbGhTVkZadGRHRmxiR1J5VjJ4a1ZXSkdjRmhXTVZKRFZqRktSbGRzVWxabGExcFVXVEp6ZUZZeFduUmlSazVZVW10d2IxWXhXbE5TTVd4V1RVaG9XR0pyTlZsWmJHaFRWa1phZEdSSFJteGlSMUo1VmpKNGExWlhTa2RqUm1oWFRWWktSRlpxUmt0U2JHUnpWV3hhYkdFeGNGVlhWRXA2WlVaWmVGZHVVbWxTYXpWWlZXMTBkMkl4V1hoWGJFNVRUVmQ0VjFSVmFHOVhSMHB5VGxac1dtSkhhRlJXYTFwaFpFZFNTRkp0ZUdsU01VbzFWbXBLTkdFeFdsaFRhMlJxVW0xb1dGUldXa3RTUmxweFVtdDBVMkpIVW5wV1YzaGhZa2RGZUdOR1ZsaFdSWEEyV2xWYVdtVkdaSFZWYld4VFlYcFdXbFpYTVRCa01rbDRWMWhvV0dKRk5WUlVWbVEwVmpGU1ZtRkhPVmhTTUhCNVZHeGFjMWR0U2toaFJsSlhZVEZ3YUZwRlpGTlRSa3AwWlVkc1UwMVZiekZXYlhCTFRrZEZlRmRzYUZSaE1sSnhWVzB4YjFkR1VsZFhhM1JUVW14d2VGVnRkREJWTWtwSVZXNXdWMVl6YUdoWmEyUkdaVWRPUjFac2FGZFNXRUV5VjJ4V1lWZHRWa2RhU0ZaV1lsZDRWRmxZY0ZkWGJGcFlUVlJDYTAxcmJEUldNalZUVkd4a1NGVnNXbFZXYkhCWVZHdGFXbVZIUmtoUFZtUnBWbGhDU1ZkVVFtRmpNV1IwVWxob1YxZEhhRmhVVmxwM1lVWnJlRmRyWkZkV2EzQjZWa2R6TVZkR1NsWmpSV3hYWVd0dmQxbFhjekZXTVdSellVWlNhRTFZUW5oV1YzaHJZakZrUjFWc2FFOVdhelZ4V1d0YWQyVkdWWGxrUkVKV1RVUkdlVlJzVm05V01WbDZZVWRvV21FeVVrZGFWV1JQVWpGYWMxcEhiRmhTVlhCS1ZqRmFVMU14VVhsVmEyUlVZbXR3YUZWdE1XOWpSbHB4VkcwNWEySkdjRWhXTWpBMVZXc3hXR1ZHYUZkTlYyaDJWMVphUzFKc1RuUlNiR1JwVjBVME1GWkhkR0ZXYlZaSVVtdG9VRll5YUhCVmJHaERWMVprVlZGdFJtbE5WbXcxVld4b2IxZEhTbGhoUm1oYVZrVmFNMWxWV25kU2JIQkhXa1pTVjJKclNrbFdNblJyWXpGVmVWTnVTbFJoTTFKWVZGWmFTMVZHY0VWU2EzQnNVbTFTTVZaWGVGTmhWa2w0VTJ4d1dGWjZRalJVYTFwclVqRldjMkZIY0ZOaVZrcDRWMWQwWVdReVZrZFdibEpyVTBkU2NGVnFRbmRTTVZsNVRsaE9XbFpzY0ZoWk1HaExWakZhUmxkcmVGZE5WbkJJV1RJeFIxSXlSa2hoUlRWWFYwVktUMVp0TUhoa01VbDRWRzVTVjJKSFVsVlpiWFIzWVVaV2RFMVhPV3BTYkZwNFZXMTBNRll4V25SVmJHeGhVbGROTVZaWGMzaFdNV1J6WVVaa1RsWXlhRFpYVjNSaFUyMVdjMVp1VGxKaVJuQndWbXRXVm1ReFduRlNiVVphVm1zMVNWWnRkRzloTVVwMVVXeG9XbGRJUWxoVk1GcGhVMGRXU0ZKdGFFNVdNVW8yVm1wS01GbFdVWGhYYkdSVVlrZG9WMWxVUm1GaFJteFdWMjVrVTJKR2NGcFpWVnByVmpKS1IyTkVXbGROYmxKeVdYcEdWbVZXVG5KaVJrcFhVbGhDV1ZaR1dtRmtNV1JIWWtaV1VsZEhhRlJVVm1SVFRWWmFTR1ZHVG1oV01GWTJWVmQ0YzFkR1duUlZhbHBWVm14d2VsWnFSbXRYVm5CSVlVWk9WMVpHV2paV01XUXdXVlpaZDA1V1pHcFNiSEJ2VldwT1UxWnNVbGhrUm5CT1lrWmFNRnBGWkVkWFIwcFdWbXBTVjAxdVFsQldNRnBoWkVaV2MyRkdjRTVXYmtKSlZtMTRZVmxYVFhoV2JrNWhVbFJXYjFwWGRFZE9SbHAwWlVaa1dsWnNSalJXUnpWUFZXMUtSMU5zVmxkaE1VcEVXVEJXYzJKc1FsVk5SMnRwSWc9PSI=',
+    );
+
+    const migratedVal = (storageMigrator.storage as ExtensionPoint).migrate?.(
+      'key',
+      defaultLocalStorage,
+      defaultErrorHandler,
+      defaultLogger,
+    );
+    expect(migratedVal).toBe('1832d446-7ce1-4570-b7cd-d935ce25a108');
+  });
+
+  it('should recursively decrypt a value that is encrypted by v3 and then by v1 encryption method', () => {
+    // The original string is first encrypted by v3 and then by v1 encryption method
+    defaultLocalStorage.setItem(
+      'key',
+      'RudderEncrypt:U2FsdGVkX1+fLoH8oM56BgjpAjU5f/LSM5J9NFK76wplt1ovIMcEK4MDVJY+A065',
+    );
+
+    const migratedVal = (storageMigrator.storage as ExtensionPoint).migrate?.(
+      'key',
+      defaultLocalStorage,
+      defaultErrorHandler,
+      defaultLogger,
+    );
+    expect(migratedVal).toBe('automationqa_123');
   });
 });

--- a/packages/analytics-js-plugins/src/storageMigrator/index.ts
+++ b/packages/analytics-js-plugins/src/storageMigrator/index.ts
@@ -45,7 +45,7 @@ const StorageMigrator = (): ExtensionPlugin => ({
         // Recursively decrypt the value until we reach a point where the value
         // is not encrypted anymore
         while (isString(currentVal)) {
-          decryptedVal = decryptLegacy(currentVal as string);
+          decryptedVal = decryptLegacy(currentVal);
 
           // Decrypt using the latest encryption method as well
           decryptedVal = decrypt(decryptedVal) as string;

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -513,6 +513,9 @@ describe('Core - Analytics', () => {
       const addEventSpy = jest.spyOn(analytics.eventManager, 'addEvent');
 
       state.lifecycle.loaded.value = true;
+      // Set the user ID to null so that it falls back to the anonymous ID
+      state.session.userId.value = null;
+
       analytics.alias({ to: 'to' });
       expect(leaveBreadcrumbSpy).toHaveBeenCalledTimes(1);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([]);

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -513,16 +513,46 @@ describe('Core - Analytics', () => {
       const addEventSpy = jest.spyOn(analytics.eventManager, 'addEvent');
 
       state.lifecycle.loaded.value = true;
-      // Set the user ID to null so that it falls back to the anonymous ID
-      state.session.userId.value = null;
 
-      analytics.alias({ to: 'to' });
+      analytics.alias({ to: 'to', from: 'x' });
       expect(leaveBreadcrumbSpy).toHaveBeenCalledTimes(1);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([]);
       expect(addEventSpy).toHaveBeenCalledWith({
         type: 'alias',
         to: 'to',
-        from: 'test_uuid', // this is the mocked value from UUID generation
+        from: 'x',
+      });
+    });
+
+    it('should use the user ID if from is not provided', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      analytics.prepareInternalServices();
+      state.session.userId.value = 'userId';
+      const addEventSpy = jest.spyOn(analytics.eventManager, 'addEvent');
+      state.lifecycle.loaded.value = true;
+
+      analytics.alias({ to: 'to' });
+
+      expect(addEventSpy).toHaveBeenCalledWith({
+        type: 'alias',
+        to: 'to',
+        from: 'userId',
+      });
+    });
+
+    it('should use the anonymous ID if user ID is not set', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      analytics.prepareInternalServices();
+      state.session.userId.value = null;
+      const addEventSpy = jest.spyOn(analytics.eventManager, 'addEvent');
+      state.lifecycle.loaded.value = true;
+
+      analytics.alias({ to: 'to' });
+
+      expect(addEventSpy).toHaveBeenCalledWith({
+        type: 'alias',
+        to: 'to',
+        from: 'test_uuid',
       });
     });
   });

--- a/packages/analytics-js/__tests__/services/StoreManager/Store.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/Store.test.ts
@@ -63,17 +63,6 @@ describe('Store', () => {
       engine.setItem('name.id.queue', '[{]}');
       expect(store.get(QueueStatuses.QUEUE)).toBeNull();
     });
-
-    it('should log a warning if the underlying cookie value is a legacy encrypted value', () => {
-      const spy = jest.spyOn(defaultLogger, 'warn');
-      engine.setItem('name.id.queue', '"RudderEncrypt:encryptedValue"');
-
-      store.get('queue');
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(
-        'The cookie data for queue seems to be encrypted using SDK versions < v3. The data is dropped. This can potentially stem from using SDK versions < v3 on other sites or web pages that can share cookies with this webpage. We recommend using the same SDK (v3) version everywhere or avoid disabling the storage data migration.',
-      );
-    });
   });
 
   describe('.set', () => {

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -169,15 +169,15 @@
             };
 
             const envDestSDKBaseURL = '__DEST_SDK_BASE_URL__';
-            if (envDestSDKBaseURL !== 'undefined') {
+            if (!envDestSDKBaseURL.startsWith('undefined')) {
               loadOptions.destSDKBaseURL = envDestSDKBaseURL + window.rudderAnalyticsBuildType + '/js-integrations';
             }
             const envPluginsSDKBaseURL = '__PLUGINS_BASE_URL__';
-            if (envPluginsSDKBaseURL !== 'undefined') {
+            if (!envPluginsSDKBaseURL.startsWith('undefined')) {
               loadOptions.pluginsSDKBaseURL = envPluginsSDKBaseURL + window.rudderAnalyticsBuildType + '/plugins';
             }
             const envConfigUrl = '__CONFIG_SERVER_HOST__';
-            if (envConfigUrl !== 'undefined') {
+            if (!envConfigUrl.startsWith('undefined')) {
               loadOptions.configUrl = envConfigUrl;
             }
             rudderanalytics.load('__WRITE_KEY__', '__DATAPLANE_URL__', loadOptions);

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -604,9 +604,7 @@ class Analytics implements IAnalytics {
     state.metrics.triggered.value += 1;
 
     const previousId =
-      payload.from ??
-      this.userSessionManager?.getUserId() ??
-      this.userSessionManager?.getAnonymousId();
+      payload.from ?? this.getUserId() ?? this.userSessionManager?.getAnonymousId();
 
     this.eventManager?.addEvent({
       type,

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -604,7 +604,7 @@ class Analytics implements IAnalytics {
     state.metrics.triggered.value += 1;
 
     const previousId =
-      payload.from ?? this.getUserId() ?? this.userSessionManager?.getAnonymousId();
+      payload.from ?? (this.getUserId() || this.userSessionManager?.getAnonymousId());
 
     this.eventManager?.addEvent({
       type,

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -248,9 +248,6 @@ const INVALID_POLYFILL_URL_WARNING = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The provided polyfill URL "${customPolyfillUrl}" is invalid. The default polyfill URL will be used instead.`;
 
-const BAD_COOKIES_WARNING = (key: string) =>
-  `The cookie data for ${key} seems to be encrypted using SDK versions < v3. The data is dropped. This can potentially stem from using SDK versions < v3 on other sites or web pages that can share cookies with this webpage. We recommend using the same SDK (v3) version everywhere or avoid disabling the storage data migration.`;
-
 const PAGE_UNLOAD_ON_BEACON_DISABLED_WARNING = (context: string) =>
   `${context}${LOG_CONTEXT_SEPARATOR}Page Unloaded event can only be tracked when the Beacon transport is active. Please enable "useBeacon" load API option.`;
 
@@ -308,7 +305,6 @@ export {
   SOURCE_DISABLED_ERROR,
   COMPONENT_BASE_URL_ERROR,
   SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
-  BAD_COOKIES_WARNING,
   PAGE_UNLOAD_ON_BEACON_DISABLED_WARNING,
   BREADCRUMB_ERROR,
   NON_ERROR_WARNING,

--- a/packages/analytics-js/src/services/StoreManager/Store.ts
+++ b/packages/analytics-js/src/services/StoreManager/Store.ts
@@ -1,5 +1,5 @@
 import { trim } from '@rudderstack/analytics-js-common/utilities/string';
-import { isNullOrUndefined, isString } from '@rudderstack/analytics-js-common/utilities/checks';
+import { isNullOrUndefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import { stringifyWithoutCircular } from '@rudderstack/analytics-js-common/utilities/json';
 import type { IStorage, IStore, IStoreConfig } from '@rudderstack/analytics-js-common/types/Store';
 import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/ErrorHandler';
@@ -10,7 +10,6 @@ import { MEMORY_STORAGE } from '@rudderstack/analytics-js-common/constants/stora
 import { getMutatedError } from '@rudderstack/analytics-js-common/utilities/errors';
 import { isStorageQuotaExceeded } from '../../components/capabilitiesManager/detection';
 import {
-  BAD_COOKIES_WARNING,
   STORAGE_QUOTA_EXCEEDED_WARNING,
   STORE_DATA_FETCH_ERROR,
   STORE_DATA_SAVE_ERROR,
@@ -142,11 +141,6 @@ class Store implements IStore {
       return JSON.parse(decryptedValue as string);
     } catch (err) {
       this.onError(new Error(`${STORE_DATA_FETCH_ERROR(key)}: ${(err as Error).message}`));
-
-      // A hack for warning the users of potential partial SDK version migrations
-      if (isString(decryptedValue) && decryptedValue.startsWith('RudderEncrypt:')) {
-        this.logger.warn(BAD_COOKIES_WARNING(key));
-      }
 
       return null;
     }

--- a/packages/analytics-v1.1/public/index.html
+++ b/packages/analytics-v1.1/public/index.html
@@ -38,16 +38,29 @@
         })(method);
       }
 
-      // prettier-ignore
-      rudderanalytics.load('__WRITE_KEY__', '__DATAPLANE_URL__', {
+      const loadOptions = {
         logLevel: 'DEBUG',
-        configUrl: '__CONFIG_SERVER_HOST__',
-        destSDKBaseURL: '__DEST_SDK_BASE_URL__',
+        // integrations: {
+        //   All: false
+        // },
         // useBeacon: true,
         // beaconQueueOptions: {
         //   flushQueueInterval: 60 * 1000,
         // }
-      });
+      };
+
+      const envDestSDKBaseURL = '__DEST_SDK_BASE_URL__';
+      if (!envDestSDKBaseURL.startsWith('undefined')) {
+        loadOptions.destSDKBaseURL = envDestSDKBaseURL;
+      }
+
+      const envConfigUrl = '__CONFIG_SERVER_HOST__';
+      if (!envConfigUrl.startsWith('undefined')) {
+        loadOptions.configUrl = envConfigUrl;
+      }
+
+      // prettier-ignore
+      rudderanalytics.load('__WRITE_KEY__', '__DATAPLANE_URL__', loadOptions);
 
       rudderanalytics.page();
     </script>

--- a/packages/analytics-v1.1/rollup-configs/rollup.utilities.mjs
+++ b/packages/analytics-v1.1/rollup-configs/rollup.utilities.mjs
@@ -54,7 +54,7 @@ export function getDefaultConfig(distName) {
 
   return {
     watch: {
-      include: ['src/**'],
+      include: ['src/**', '../analytics-js-common/src/**'],
     },
     external: [],
     onwarn(warning, warn) {


### PR DESCRIPTION
## PR Description

I've updated the SDK v3 and v1.1 (legacy) packages to recursively decrypt cookies from both legacy and v3 (new) encryption formats until it is not encrypted anymore.

For v3 SDK, this happens as part of the cookie migration during the SDK initialization.

Without these fixes, a user visiting one more websites back and forth where either of the websites using v1.1 (a really old version) or v3 SDK packages, would end up in unencrypted values in the event payloads. 
A really old version of the v1.1 SDK cannot decrypt v3 cookies so it re-encrypts the already encrypted value. If this process repeats enough number of times, even the v3 SDK that can understand the v1.1 cookies will only decrypt once but the underlying value is still a encrypted value that is included in the events.

I also fixed the logic to only return the value from the state in the get APIs. Earlier, user ID and anonymous ID were returning values from the storage.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3225/handle-recursive-cookie-data-encryptions-js-sdk

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced storage decryption to support recursive multi-layer decryption, ensuring stored data is fully decrypted regardless of legacy or current encryption methods.
  - Improved control over storage migration, allowing explicit selection of stores to migrate and ensuring migration occurs before reading stored entries.

- **Bug Fixes**
  - Refined anonymous ID retrieval to prioritize session state over storage, providing more consistent user identification.

- **Refactor**
  - Streamlined environment variable checks for configuration options in initialization scripts.
  - Updated internal logic for determining previous user ID in alias events.
  - Simplified Rollup configuration to watch additional source directories for changes.

- **Chores**
  - Removed obsolete warning messages and related test cases concerning legacy encrypted cookie data.
  - Expanded test coverage for alias event behavior and storage migration, including recursive decryption scenarios.
  - Added enhanced type annotations in user session manager tests to improve code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->