### PR TITLE
feat: add new event mapping for tik tok

### DIFF
--- a/packages/analytics-js-common/src/constants/integrations/TiktokAds/constants.ts
+++ b/packages/analytics-js-common/src/constants/integrations/TiktokAds/constants.ts
@@ -83,6 +83,8 @@ const eventNameMapping = {
   submitform: 'SubmitForm',
   completeregistration: 'CompleteRegistration',
   subscribe: 'Subscribe',
+  lead: 'Lead',
+  purchase: 'Purchase',
 };
 
 export {

--- a/packages/analytics-js-common/src/constants/integrations/TiktokAds/constants.ts
+++ b/packages/analytics-js-common/src/constants/integrations/TiktokAds/constants.ts
@@ -90,6 +90,9 @@ const eventNameMapping = {
   subscribe: 'Subscribe',
   purchase: 'Purchase',
   lead: 'Lead',
+  customizeproduct: 'CustomizeProduct',
+  findlocation: 'FindLocation',
+  schedule: 'Schedule',
 };
 
 export {

--- a/packages/analytics-js-common/src/constants/integrations/TiktokAds/constants.ts
+++ b/packages/analytics-js-common/src/constants/integrations/TiktokAds/constants.ts
@@ -68,6 +68,11 @@ const trackMapping = [
     sourceKeys: ['context.traits.phone', 'traits.phone', 'properties.phone'],
   },
 ];
+
+// We need to remove 'checkout step completed' and 'submitform' from the list of events as per tiktok docs
+// tiktok changed the mapping for 'checkout step completed => purchase' and 'submitform => lead'
+// once all customer migrate to new event we can remove old mapping
+// https://ads.tiktok.com/help/article/standard-events-parameters?lang=en
 const eventNameMapping = {
   'product added to wishlist': 'AddToWishlist',
   'product added': 'AddToCart',
@@ -83,8 +88,8 @@ const eventNameMapping = {
   submitform: 'SubmitForm',
   completeregistration: 'CompleteRegistration',
   subscribe: 'Subscribe',
-  lead: 'Lead',
   purchase: 'Purchase',
+  lead: 'Lead',
 };
 
 export {


### PR DESCRIPTION
## PR Description

Added a new mapping for TikTok ads. Below is the list:
* Purchase
* Lead
* CustomizeProduct
* FindLocation
* Schedule

Tiktok standred event link:
https://ads.tiktok.com/help/article/standard-events-parameters?lang=en

Resolves INT-3608

https://github.com/user-attachments/assets/ccfa62b3-2571-4892-8a4f-87cee419b8a3

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-3608/tiktok-ads-device-support-new-events-for-tiktok-js-device-mode

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for new TikTok Ads events including "purchase," "lead," "customizeproduct," "findlocation," and "schedule."
  - Updated event mappings to align with TikTok's latest documentation while maintaining backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->