### PR TITLE
chore: enable beta deployments

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -89,9 +89,59 @@ jobs:
               
               console.log(`PR #${prNumber} has ${approvals.length} approval(s). Proceeding with beta deployment.`);
               console.log(`Approvals from: ${approvals.map(a => a.user.login).join(', ')}`);
+
+              // Check if all required checks have passed
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha,
+                filter: 'latest'
+              });
               
+              // Get status checks from the commit status API as well (some CI systems use this instead of checks API)
+              const { data: commitStatus } = await github.rest.repos.getCombinedStatusForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha
+              });
+              
+              // Get required status checks for the base branch
+              const { data: branchProtection } = await github.rest.repos.getBranchProtection({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: pr.base.ref
+              }).catch(e => {
+                console.log(`No branch protection found for ${pr.base.ref}: ${e.message}`);
+                return { data: { required_status_checks: { contexts: [] } } };
+              });
+              
+              const requiredChecks = branchProtection.required_status_checks?.contexts || [];
+              
+              // Check if any required checks have failed
+              let failedChecks = [];
+              
+              // Check status API results
+              if (commitStatus.state !== 'success') {
+                failedChecks = commitStatus.statuses
+                  .filter(status => status.state !== 'success')
+                  .filter(status => requiredChecks.length === 0 || requiredChecks.includes(status.context))
+                  .map(status => status.context);
+              }
+              
+              // Check check runs API results
+              const failedCheckRuns = checkRuns.check_runs
+                .filter(check => check.conclusion !== 'success' && check.conclusion !== 'neutral')
+                .filter(check => requiredChecks.length === 0 || requiredChecks.includes(check.name))
+                .map(check => check.name);
+              
+              failedChecks = [...failedChecks, ...failedCheckRuns];
+              
+              if (failedChecks.length > 0) {
+                core.setFailed(`PR #${prNumber} has failed checks: ${failedChecks.join(', ')}. All checks must pass before deploying.`);
+                return;
+              }
+
               core.setOutput('pr_number', prNumber);
-              core.setOutput('pr_approvals', approvals.length);
             } else {
               core.setFailed(`No open PR found for branch ${branch} targeting develop branch`);
               core.setOutput('pr_number', '');

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -50,7 +50,7 @@ jobs:
               core.setOutput('pr_number', prNumber);
             } else {
               console.log(`No open PR found for branch ${branch} targeting develop branch. Aborting beta deployment.`);
-              core.setFailed('No open PR found for branch ${branch} targeting develop branch');
+              core.setFailed(`No open PR found for branch ${branch} targeting develop branch`);
               core.setOutput('pr_number', '');
             }
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -21,14 +21,23 @@ env:
   NODE_OPTIONS: '--no-warnings'
 
 jobs:
-  get-deploy-inputs:
-    name: Get Deploy Inputs
-    runs-on: [self-hosted, Linux, X64]
+  validate-actor:
     # Allow only to run from branches and not tags
     if: ${{ startsWith(github.ref, 'refs/heads/') }}
+    uses: ./.github/workflows/validate-actor.yml
+    with:
+      team_names: 'js-sdk,integrations'
+    secrets:
+      PAT: ${{ secrets.PAT }}
+
+  get-deploy-inputs:
+    name: Get Deploy Inputs
+    needs: validate-actor
+    runs-on: [self-hosted, Linux, X64]
     outputs:
       version_suffix: ${{ steps.deploy-inputs.outputs.version_suffix }}
       beta_identifier: ${{ steps.deploy-inputs.outputs.beta_identifier }}
+      beta_identifier_for_automation_tests: ${{ steps.deploy-inputs.outputs.beta_identifier_for_automation_tests }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -111,8 +120,9 @@ jobs:
           SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)
           echo "version_suffix=beta.pr.${{ steps.pr-info.outputs.pr_number }}.$SHA_SHORT" >> $GITHUB_OUTPUT
           echo "beta_identifier=PR-${{ steps.pr-info.outputs.pr_number }}/$SHA_SHORT" >> $GITHUB_OUTPUT
+          echo "beta_identifier_for_automation_tests=pr-${{ steps.pr-info.outputs.pr_number }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
-  deploy:
+  deploy-cdn:
     name: Deploy to CDN
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
@@ -152,7 +162,7 @@ jobs:
 
   deploy-sanity-suite:
     name: Deploy sanity suite
-    needs: get-deploy-inputs
+    needs: [get-deploy-inputs, deploy-cdn]
     uses: ./.github/workflows/deploy-sanity-suite.yml
     with:
       environment: 'beta'
@@ -168,3 +178,14 @@ jobs:
       BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
+
+  trigger-test-suites:
+    uses: ./.github/workflows/trigger-test-suites.yml
+    name: Trigger test suites
+    needs: [get-deploy-inputs, deploy-sanity-suite]
+    with:
+      environment: beta
+      sanity_test_suite_url: https://cdn.rudderlabs.com/sanity-suite/beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/
+      build_source_id: ${{ needs.get-deploy-inputs.outputs.beta_identifier_for_automation_tests }}
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -118,6 +118,10 @@ jobs:
         run: |
           # Suffix the short commit hash with the PR number
           SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)
+          # The version_suffix is structured as "beta.pr.<PR_NUMBER>.<SHORT_COMMIT_HASH>".
+          # - "beta.pr." is a fixed prefix indicating a beta release for a pull request.
+          # - <PR_NUMBER> is the number of the pull request associated with the branch.
+          # - <SHORT_COMMIT_HASH> is the first 7 characters of the commit hash for traceability.
           echo "version_suffix=beta.pr.${{ steps.pr-info.outputs.pr_number }}.$SHA_SHORT" >> $GITHUB_OUTPUT
           echo "beta_identifier=PR-${{ steps.pr-info.outputs.pr_number }}/$SHA_SHORT" >> $GITHUB_OUTPUT
           echo "beta_identifier_for_automation_tests=pr-${{ steps.pr-info.outputs.pr_number }}-$SHA_SHORT" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -10,6 +10,7 @@ concurrency:
 permissions:
   id-token: write # allows the JWT to be requested from GitHub's OIDC provider
   contents: read # This is required for actions/checkout
+  pull-requests: read # This is required to get PR information
 
 env:
   NODE_OPTIONS: '--no-warnings'
@@ -17,37 +18,59 @@ env:
 jobs:
   get-deploy-inputs:
     name: Get Deploy Inputs
-    if: startsWith(github.ref, 'refs/heads/beta/') || startsWith(github.ref, 'refs/tags/bugbash/')
     runs-on: [self-hosted, Linux, X64]
     outputs:
-      release_type: ${{ steps.deploy-inputs.outputs.release_type }}
-      feature_name: ${{ steps.deploy-inputs.outputs.feature_name }}
-
+      version_suffix: ${{ steps.deploy-inputs.outputs.version_suffix }}
+      beta_identifier: ${{ steps.deploy-inputs.outputs.beta_identifier }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Find PR for current branch
+        id: pr-info
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            console.log(`Finding PRs for branch: ${branch}`);
+            
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              base: 'develop',
+              state: 'open'
+            });
+            
+            if (pullRequests.length > 0) {
+              const prNumber = pullRequests[0].number.toString();
+              console.log(`Found PR #${prNumber} for branch ${branch}: https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`);
+              core.setOutput('pr_number', prNumber);
+            } else {
+              console.log(`No open PR found for branch ${branch} targeting develop branch. Aborting beta deployment.`);
+              core.setFailed('No open PR found for branch ${branch} targeting develop branch');
+              core.setOutput('pr_number', '');
+            }
+
       - name: Extract deploy inputs
         id: deploy-inputs
         shell: bash
         run: |
-          source_branch_name=${GITHUB_REF##*/}
-          RELEASE_TYPE=beta
-          grep -q "bugbash/" <<< "${GITHUB_REF}" && RELEASE_TYPE=bugbash
-          FEATURE_NAME=${source_branch_name#bugbash/}
-          FEATURE_NAME=${FEATURE_NAME#beta/}
-          FEATURE_NAME=${FEATURE_NAME#refs/heads/}
-          FEATURE_NAME=${FEATURE_NAME#refs/tags/}
-
-          echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
-          echo "feature_name=$FEATURE_NAME" >> $GITHUB_OUTPUT
+          echo "version_suffix=beta.pr.${{ steps.pr-info.outputs.pr_number }}" >> $GITHUB_OUTPUT
+          echo "beta_identifier=PR-${{ steps.pr-info.outputs.pr_number }}" >> $GITHUB_OUTPUT
 
   deploy:
+    if: false
     name: Deploy BETA/BugBash Feature
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
     with:
-      environment: ${{ needs.get-deploy-inputs.outputs.release_type }}
-      bugsnag_release_stage: ${{ needs.get-deploy-inputs.outputs.release_type }}
-      s3_dir_path: ${{ needs.get-deploy-inputs.outputs.release_type }}/${{ needs.get-deploy-inputs.outputs.feature_name }}
-      s3_dir_path_legacy: ${{ needs.get-deploy-inputs.outputs.release_type }}/${{ needs.get-deploy-inputs.outputs.feature_name }}/v1.1
+      environment: beta
+      bugsnag_release_stage: beta
+      s3_dir_path: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/v3
+      s3_dir_path_legacy: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/v1.1
       action_type: ''
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PROD_ACCOUNT_ID }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -55,92 +55,41 @@ jobs:
                 return;
               }
               
-              // Get PR reviews
-              const { data: reviews } = await github.rest.pulls.listReviews({
+              // Get detailed PR information including mergeable state
+              const { data: prDetails } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber
               });
               
-              // Check for approvals
-              const approvals = reviews.filter(review => {
-                const username = review.user.login;
-                // Exclude bot users and GitHub Copilot related accounts
-                const isBotUser = review.user.type === 'Bot' ||
-                                  /\[bot\]$/.test(username) ||
-                                  /copilot/i.test(username) ||
-                                  /code.*rabbit/i.test(username) ||
-                                  ['github-actions', 'github-code-scanning'].includes(username);
+              // Check if PR is mergeable and all requirements are satisfied
+              if (prDetails.mergeable === false) {
+                core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
+                return;
+              }
+              
+              // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
+              // Only 'clean' means all requirements are met (checks passed, approvals received, no conflicts)
+              if (prDetails.mergeable_state !== 'clean') {
+                // Get more details about why it's not clean
+                let reason = '';
                 
-                return review.state === 'APPROVED' && 
-                       !isBotUser &&
-                       // Check if this is the latest review from this user
-                       !reviews.some(r => 
-                         r.user.login === username && 
-                         r.id > review.id && 
-                         r.state !== 'APPROVED'
-                       );
-              });
-              
-              if (approvals.length === 0) {
-                core.setFailed(`PR #${prNumber} requires at least one approval from a human reviewer before deploying.`);
+                if (prDetails.mergeable_state === 'blocked') {
+                  reason = 'required checks or approvals are missing';
+                } else if (prDetails.mergeable_state === 'dirty') {
+                  reason = 'there are merge conflicts';
+                } else if (prDetails.mergeable_state === 'unstable') {
+                  reason = 'required checks are failing';
+                } else {
+                  reason = `the mergeable state is "${prDetails.mergeable_state}"`;
+                }
+                
+                core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
                 return;
               }
               
-              console.log(`PR #${prNumber} has ${approvals.length} approval(s). Proceeding with beta deployment.`);
-              console.log(`Approvals from: ${approvals.map(a => a.user.login).join(', ')}`);
-
-              // Check if all required checks have passed
-              const { data: checkRuns } = await github.rest.checks.listForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: pr.head.sha,
-                filter: 'latest'
-              });
+              console.log(`PR #${prNumber} is in a clean mergeable state. All requirements satisfied. Proceeding with beta deployment.`);
               
-              // Get status checks from the commit status API as well (some CI systems use this instead of checks API)
-              const { data: commitStatus } = await github.rest.repos.getCombinedStatusForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: pr.head.sha
-              });
-              
-              // Get required status checks for the base branch
-              const { data: branchProtection } = await github.rest.repos.getBranchProtection({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                branch: pr.base.ref
-              }).catch(e => {
-                console.log(`No branch protection found for ${pr.base.ref}: ${e.message}`);
-                return { data: { required_status_checks: { contexts: [] } } };
-              });
-              
-              const requiredChecks = branchProtection.required_status_checks?.contexts || [];
-              
-              // Check if any required checks have failed
-              let failedChecks = [];
-              
-              // Check status API results
-              if (commitStatus.state !== 'success') {
-                failedChecks = commitStatus.statuses
-                  .filter(status => status.state !== 'success')
-                  .filter(status => requiredChecks.length === 0 || requiredChecks.includes(status.context))
-                  .map(status => status.context);
-              }
-              
-              // Check check runs API results
-              const failedCheckRuns = checkRuns.check_runs
-                .filter(check => check.conclusion !== 'success' && check.conclusion !== 'neutral')
-                .filter(check => requiredChecks.length === 0 || requiredChecks.includes(check.name))
-                .map(check => check.name);
-              
-              failedChecks = [...failedChecks, ...failedCheckRuns];
-              
-              if (failedChecks.length > 0) {
-                core.setFailed(`PR #${prNumber} has failed checks: ${failedChecks.join(', ')}. All checks must pass before deploying.`);
-                return;
-              }
-
               core.setOutput('pr_number', prNumber);
             } else {
               core.setFailed(`No open PR found for branch ${branch} targeting develop branch`);

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -63,17 +63,27 @@ jobs:
               });
               
               // Check for approvals
-              const approvals = reviews.filter(review => 
-                review.state === 'APPROVED' && 
-                !reviews.some(r => 
-                  r.user.login === review.user.login && 
-                  r.id > review.id && 
-                  r.state !== 'APPROVED'
-                )
-              );
+              const approvals = reviews.filter(review => {
+                const username = review.user.login;
+                // Exclude bot users and GitHub Copilot related accounts
+                const isBotUser = review.user.type === 'Bot' ||
+                                  /\[bot\]$/.test(username) ||
+                                  /copilot/i.test(username) ||
+                                  /code.*rabbit/i.test(username) ||
+                                  ['github-actions', 'github-code-scanning'].includes(username);
+                
+                return review.state === 'APPROVED' && 
+                       !isBotUser &&
+                       // Check if this is the latest review from this user
+                       !reviews.some(r => 
+                         r.user.login === username && 
+                         r.id > review.id && 
+                         r.state !== 'APPROVED'
+                       );
+              });
               
               if (approvals.length === 0) {
-                core.setFailed(`PR #${prNumber} requires at least one approval before deploying.`);
+                core.setFailed(`PR #${prNumber} requires at least one approval from a human reviewer before deploying.`);
                 return;
               }
               

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,4 +1,4 @@
-name: Deploy BETA/BugBash Feature
+name: Deploy Beta to Production Environment
 
 on:
   workflow_dispatch:
@@ -115,7 +115,7 @@ jobs:
           echo "beta_identifier=PR-${{ steps.pr-info.outputs.pr_number }}/$SHA_SHORT" >> $GITHUB_OUTPUT
 
   deploy:
-    name: Deploy BETA/BugBash Feature
+    name: Deploy to CDN
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
     if: ${{ inputs.deployment_type == 'cdn' || inputs.deployment_type == 'both' }}
@@ -132,5 +132,23 @@ jobs:
       AWS_S3_SYNC_ROLE: ${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
       AWS_CF_DISTRIBUTION_ID: ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}
       BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
+
+  deploy-npm:
+    name: Deploy to NPM
+    uses: ./.github/workflows/deploy-npm.yml
+    needs: get-deploy-inputs
+    if: ${{ inputs.deployment_type == 'npm' || inputs.deployment_type == 'both' }}
+    with:
+      is_called: true
+      environment: beta
+      bugsnag_release_stage: beta
+      version_suffix: ${{ needs.get-deploy-inputs.outputs.version_suffix }}
+      base_version: develop
+      head_version: ${{ github.ref_name }}
+    secrets:
+      RS_PROD_BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -55,38 +55,38 @@ jobs:
                 return;
               }
               
-              // Get detailed PR information including mergeable state
-              const { data: prDetails } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
+              # // Get detailed PR information including mergeable state
+              # const { data: prDetails } = await github.rest.pulls.get({
+              #   owner: context.repo.owner,
+              #   repo: context.repo.repo,
+              #   pull_number: prNumber
+              # });
               
-              // Check if PR is mergeable and all requirements are satisfied
-              if (prDetails.mergeable === false) {
-                core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
-                return;
-              }
+              # // Check if PR is mergeable and all requirements are satisfied
+              # if (prDetails.mergeable === false) {
+              #   core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
+              #   return;
+              # }
               
-              // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
-              // Only 'clean' means all requirements are met (checks passed, approvals received, no conflicts)
-              if (prDetails.mergeable_state !== 'clean') {
-                // Get more details about why it's not clean
-                let reason = '';
+              # // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
+              # // Only 'clean' means all requirements are met (checks passed, approvals received, no conflicts)
+              # if (prDetails.mergeable_state !== 'clean') {
+              #   // Get more details about why it's not clean
+              #   let reason = '';
                 
-                if (prDetails.mergeable_state === 'blocked') {
-                  reason = 'required checks or approvals are missing';
-                } else if (prDetails.mergeable_state === 'dirty') {
-                  reason = 'there are merge conflicts';
-                } else if (prDetails.mergeable_state === 'unstable') {
-                  reason = 'required checks are failing';
-                } else {
-                  reason = `the mergeable state is "${prDetails.mergeable_state}"`;
-                }
+              #   if (prDetails.mergeable_state === 'blocked') {
+              #     reason = 'required checks or approvals are missing';
+              #   } else if (prDetails.mergeable_state === 'dirty') {
+              #     reason = 'there are merge conflicts';
+              #   } else if (prDetails.mergeable_state === 'unstable') {
+              #     reason = 'required checks are failing';
+              #   } else {
+              #     reason = `the mergeable state is "${prDetails.mergeable_state}"`;
+              #   }
                 
-                core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
-                return;
-              }
+              #   core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
+              #   return;
+              # }
               
               console.log(`PR #${prNumber} is in a clean mergeable state. All requirements satisfied. Proceeding with beta deployment.`);
               
@@ -104,14 +104,13 @@ jobs:
           echo "beta_identifier=PR-${{ steps.pr-info.outputs.pr_number }}" >> $GITHUB_OUTPUT
 
   deploy:
-    if: false
     name: Deploy BETA/BugBash Feature
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
     with:
       environment: beta
       bugsnag_release_stage: beta
-      s3_dir_path: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/v3
+      s3_dir_path: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}
       s3_dir_path_legacy: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/v1.1
       action_type: ''
     secrets:

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -55,38 +55,38 @@ jobs:
                 return;
               }
               
-              # // Get detailed PR information including mergeable state
-              # const { data: prDetails } = await github.rest.pulls.get({
-              #   owner: context.repo.owner,
-              #   repo: context.repo.repo,
-              #   pull_number: prNumber
-              # });
+              // // Get detailed PR information including mergeable state
+              // const { data: prDetails } = await github.rest.pulls.get({
+              //   owner: context.repo.owner,
+              //   repo: context.repo.repo,
+              //   pull_number: prNumber
+              // });
               
-              # // Check if PR is mergeable and all requirements are satisfied
-              # if (prDetails.mergeable === false) {
-              #   core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
-              #   return;
-              # }
+              // // Check if PR is mergeable and all requirements are satisfied
+              // if (prDetails.mergeable === false) {
+              //   core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
+              //   return;
+              // }
               
-              # // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
-              # // Only 'clean' means all requirements are met (checks passed, approvals received, no conflicts)
-              # if (prDetails.mergeable_state !== 'clean') {
-              #   // Get more details about why it's not clean
-              #   let reason = '';
+              // // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
+              // // Only 'clean' means all requirements are met (checks passed, approvals received, no conflicts)
+              // if (prDetails.mergeable_state !== 'clean') {
+              //   // Get more details about why it's not clean
+              //   let reason = '';
                 
-              #   if (prDetails.mergeable_state === 'blocked') {
-              #     reason = 'required checks or approvals are missing';
-              #   } else if (prDetails.mergeable_state === 'dirty') {
-              #     reason = 'there are merge conflicts';
-              #   } else if (prDetails.mergeable_state === 'unstable') {
-              #     reason = 'required checks are failing';
-              #   } else {
-              #     reason = `the mergeable state is "${prDetails.mergeable_state}"`;
-              #   }
+              //   if (prDetails.mergeable_state === 'blocked') {
+              //     reason = 'required checks or approvals are missing';
+              //   } else if (prDetails.mergeable_state === 'dirty') {
+              //     reason = 'there are merge conflicts';
+              //   } else if (prDetails.mergeable_state === 'unstable') {
+              //     reason = 'required checks are failing';
+              //   } else {
+              //     reason = `the mergeable state is "${prDetails.mergeable_state}"`;
+              //   }
                 
-              #   core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
-              #   return;
-              # }
+              //   core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
+              //   return;
+              // }
               
               console.log(`PR #${prNumber} is in a clean mergeable state. All requirements satisfied. Proceeding with beta deployment.`);
               

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -45,11 +45,44 @@ jobs:
             });
             
             if (pullRequests.length > 0) {
-              const prNumber = pullRequests[0].number.toString();
+              const pr = pullRequests[0];
+              const prNumber = pr.number.toString();
               console.log(`Found PR #${prNumber} for branch ${branch}: https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`);
+              
+              // Check if PR is in draft state
+              if (pr.draft) {
+                core.setFailed(`PR #${prNumber} is in draft state. Please mark it as ready for review before deploying.`);
+                return;
+              }
+              
+              // Get PR reviews
+              const { data: reviews } = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              
+              // Check for approvals
+              const approvals = reviews.filter(review => 
+                review.state === 'APPROVED' && 
+                !reviews.some(r => 
+                  r.user.login === review.user.login && 
+                  r.id > review.id && 
+                  r.state !== 'APPROVED'
+                )
+              );
+              
+              if (approvals.length === 0) {
+                core.setFailed(`PR #${prNumber} requires at least one approval before deploying.`);
+                return;
+              }
+              
+              console.log(`PR #${prNumber} has ${approvals.length} approval(s). Proceeding with beta deployment.`);
+              console.log(`Approvals from: ${approvals.map(a => a.user.login).join(', ')}`);
+              
               core.setOutput('pr_number', prNumber);
+              core.setOutput('pr_approvals', approvals.length);
             } else {
-              console.log(`No open PR found for branch ${branch} targeting develop branch. Aborting beta deployment.`);
               core.setFailed(`No open PR found for branch ${branch} targeting develop branch`);
               core.setOutput('pr_number', '');
             }

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -28,6 +28,8 @@ jobs:
   get-deploy-inputs:
     name: Get Deploy Inputs
     runs-on: [self-hosted, Linux, X64]
+    # Allow only to run from branches and not tags
+    if: ${{ startsWith(github.ref, 'refs/heads/') }}
     outputs:
       version_suffix: ${{ steps.deploy-inputs.outputs.version_suffix }}
       beta_identifier: ${{ steps.deploy-inputs.outputs.beta_identifier }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -119,7 +119,7 @@ jobs:
     with:
       environment: beta
       bugsnag_release_stage: beta
-      s3_dir_path: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}
+      s3_dir_path: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/v3
       s3_dir_path_legacy: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/v1.1
       version_suffix: ${{ needs.get-deploy-inputs.outputs.version_suffix }}
       action_type: ''
@@ -147,5 +147,24 @@ jobs:
     secrets:
       RS_PROD_BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
+
+  deploy-sanity-suite:
+    name: Deploy sanity suite
+    needs: get-deploy-inputs
+    uses: ./.github/workflows/deploy-sanity-suite.yml
+    with:
+      environment: 'beta'
+      beta_identifier: ${{ needs.get-deploy-inputs.outputs.beta_identifier }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_PROD_ACCOUNT_ID }}
+      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_PROD_S3_BUCKET_NAME }}
+      AWS_S3_SYNC_ROLE: ${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
+      AWS_CF_DISTRIBUTION_ID: ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }}
+      SANITY_SUITE_WRITE_KEY: ${{ secrets.SANITY_SUITE_PROD_WRITE_KEY }}
+      SANITY_SUITE_DATAPLANE_URL: ${{ secrets.SANITY_SUITE_PROD_DATAPLANE_URL }}
+      SANITY_SUITE_CONFIG_SERVER_HOST: ${{ secrets.SANITY_SUITE_PROD_CONFIG_SERVER_HOST }}
+      BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -112,6 +112,7 @@ jobs:
       bugsnag_release_stage: beta
       s3_dir_path: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}
       s3_dir_path_legacy: beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/v1.1
+      version_suffix: ${{ needs.get-deploy-inputs.outputs.version_suffix }}
       action_type: ''
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PROD_ACCOUNT_ID }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -2,6 +2,15 @@ name: Deploy BETA/BugBash Feature
 
 on:
   workflow_dispatch:
+    inputs:
+      deployment_type:
+        description: "The type of deployment to perform"
+        required: true
+        type: choice
+        options:
+          - cdn
+          - npm
+          - both
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -100,13 +109,16 @@ jobs:
         id: deploy-inputs
         shell: bash
         run: |
-          echo "version_suffix=beta.pr.${{ steps.pr-info.outputs.pr_number }}" >> $GITHUB_OUTPUT
-          echo "beta_identifier=PR-${{ steps.pr-info.outputs.pr_number }}" >> $GITHUB_OUTPUT
+          # Suffix the short commit hash with the PR number
+          SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)
+          echo "version_suffix=beta.pr.${{ steps.pr-info.outputs.pr_number }}.$SHA_SHORT" >> $GITHUB_OUTPUT
+          echo "beta_identifier=PR-${{ steps.pr-info.outputs.pr_number }}/$SHA_SHORT" >> $GITHUB_OUTPUT
 
   deploy:
     name: Deploy BETA/BugBash Feature
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
+    if: ${{ inputs.deployment_type == 'cdn' || inputs.deployment_type == 'both' }}
     with:
       environment: beta
       bugsnag_release_stage: beta

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Find PR for current branch
         id: pr-info
         uses: actions/github-script@v6
@@ -71,38 +71,38 @@ jobs:
                 return;
               }
               
-              // // Get detailed PR information including mergeable state
-              // const { data: prDetails } = await github.rest.pulls.get({
-              //   owner: context.repo.owner,
-              //   repo: context.repo.repo,
-              //   pull_number: prNumber
-              // });
+              // Get detailed PR information including mergeable state
+              const { data: prDetails } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
               
-              // // Check if PR is mergeable and all requirements are satisfied
-              // if (prDetails.mergeable === false) {
-              //   core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
-              //   return;
-              // }
+              // Check if PR is mergeable and all requirements are satisfied
+              if (prDetails.mergeable === false) {
+                core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
+                return;
+              }
               
-              // // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
-              // // Only 'clean' means all requirements are met (checks passed, approvals received, no conflicts)
-              // if (prDetails.mergeable_state !== 'clean') {
-              //   // Get more details about why it's not clean
-              //   let reason = '';
+              // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
+              // Only 'clean' means all requirements are met (checks passed, approvals received, no conflicts)
+              if (prDetails.mergeable_state !== 'clean') {
+                // Get more details about why it's not clean
+                let reason = '';
                 
-              //   if (prDetails.mergeable_state === 'blocked') {
-              //     reason = 'required checks or approvals are missing';
-              //   } else if (prDetails.mergeable_state === 'dirty') {
-              //     reason = 'there are merge conflicts';
-              //   } else if (prDetails.mergeable_state === 'unstable') {
-              //     reason = 'required checks are failing';
-              //   } else {
-              //     reason = `the mergeable state is "${prDetails.mergeable_state}"`;
-              //   }
+                if (prDetails.mergeable_state === 'blocked') {
+                  reason = 'required checks or approvals are missing';
+                } else if (prDetails.mergeable_state === 'dirty') {
+                  reason = 'there are merge conflicts';
+                } else if (prDetails.mergeable_state === 'unstable') {
+                  reason = 'required checks are failing';
+                } else {
+                  reason = `the mergeable state is "${prDetails.mergeable_state}"`;
+                }
                 
-              //   core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
-              //   return;
-              // }
+                core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
+                return;
+              }
               
               console.log(`PR #${prNumber} is in a clean mergeable state. All requirements satisfied. Proceeding with beta deployment.`);
               
@@ -120,7 +120,7 @@ jobs:
           SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)
           echo "version_suffix=beta.pr.${{ steps.pr-info.outputs.pr_number }}.$SHA_SHORT" >> $GITHUB_OUTPUT
           echo "beta_identifier=PR-${{ steps.pr-info.outputs.pr_number }}/$SHA_SHORT" >> $GITHUB_OUTPUT
-          echo "beta_identifier_for_automation_tests=pr-${{ steps.pr-info.outputs.pr_number }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "beta_identifier_for_automation_tests=pr-${{ steps.pr-info.outputs.pr_number }}-$SHA_SHORT" >> $GITHUB_OUTPUT
 
   deploy-cdn:
     name: Deploy to CDN
@@ -185,7 +185,7 @@ jobs:
     needs: [get-deploy-inputs, deploy-sanity-suite]
     with:
       environment: beta
-      sanity_test_suite_url: https://cdn.rudderlabs.com/sanity-suite/beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}/
+      sanity_test_suite_url: https://cdn.rudderlabs.com/sanity-suite/beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}
       build_source_id: ${{ needs.get-deploy-inputs.outputs.beta_identifier_for_automation_tests }}
     secrets:
       PAT: ${{ secrets.PAT }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,4 +1,4 @@
-name: Deploy Beta to Production Environment
+name: Deploy to Beta Environment
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -3,14 +3,10 @@ name: Deploy Beta to Production Environment
 on:
   workflow_dispatch:
     inputs:
-      deployment_type:
-        description: "The type of deployment to perform"
-        required: true
-        type: choice
-        options:
-          - cdn
-          - npm
-          - both
+      deploy_to_npm:
+        description: "Deploy to NPM"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -120,7 +116,6 @@ jobs:
     name: Deploy to CDN
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
-    if: ${{ inputs.deployment_type == 'cdn' || inputs.deployment_type == 'both' }}
     with:
       environment: beta
       bugsnag_release_stage: beta
@@ -141,7 +136,7 @@ jobs:
     name: Deploy to NPM
     uses: ./.github/workflows/deploy-npm.yml
     needs: get-deploy-inputs
-    if: ${{ inputs.deployment_type == 'npm' || inputs.deployment_type == 'both' }}
+    if: ${{ inputs.deploy_to_npm }}
     with:
       is_called: true
       environment: beta

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -148,7 +148,7 @@ jobs:
           ./scripts/make-package-json-publish-ready.sh
 
           npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npx nx release publish --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }}
+          npx nx release publish --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }} --dry-run
 
           # Reset the changes made to package.json
           git reset --hard

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -7,6 +7,22 @@ on:
       is_called:
         type: string
         required: true
+      base_version:
+        type: string
+        required: false
+      head_version:
+        type: string
+        required: false
+      version_suffix:
+        type: string
+        required: false
+      bugsnag_release_stage:
+        description: 'Bugsnag release stage'
+        type: string
+        required: false
+      environment:
+        type: string
+        required: true
     secrets:
       RS_PROD_BUGSNAG_API_KEY:
         required: true
@@ -37,6 +53,24 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
+
+      - name: Modify package versions
+        if: ${{ inputs.version_suffix != '' }}
+        run: |
+          CURRENT_VERSION_JS=$(jq -r .version packages/analytics-js/package.json)
+          CURRENT_VERSION_V1=$(jq -r .version packages/analytics-v1.1/package.json)
+          
+          # Append the suffix to create new versions
+          NEW_VERSION_JS="${CURRENT_VERSION_JS}-${{ inputs.version_suffix }}"
+          NEW_VERSION_V1="${CURRENT_VERSION_V1}-${{ inputs.version_suffix }}"
+          
+          echo "Updating versions:"
+          echo "analytics-js: $CURRENT_VERSION_JS -> $NEW_VERSION_JS"
+          echo "analytics-v1.1: $CURRENT_VERSION_V1 -> $NEW_VERSION_V1"
+          
+          # Update all package.json files using jq
+          jq ".version = \"$NEW_VERSION_JS\"" packages/analytics-js/package.json > tmp && mv tmp packages/analytics-js/package.json
+          jq ".version = \"$NEW_VERSION_V1\"" packages/analytics-v1.1/package.json > tmp && mv tmp packages/analytics-v1.1/package.json
 
       - name: Get new version number
         run: |
@@ -71,24 +105,31 @@ jobs:
           HUSKY: 0
           REMOTE_MODULES_BASE_PATH: 'https://cdn.rudderlabs.com/v3/modern/plugins'
           BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
-          LOCK_DEPS_VERSION: 'true'
-          BUGSNAG_RELEASE_STAGE: 'production'
+          LOCK_DEPS_VERSION: ${{ inputs.environment == 'production' && 'true' || 'false' }}
+          BUGSNAG_RELEASE_STAGE: ${{ inputs.bugsnag_release_stage || 'production' }}
         run: |
           npm run setup:ci
 
       - name: Build release artifacts
         env:
           BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
-          BUGSNAG_RELEASE_STAGE: 'production'
-          LOCK_DEPS_VERSION: 'true'
+          BUGSNAG_RELEASE_STAGE: ${{ inputs.bugsnag_release_stage || 'production' }}
+          LOCK_DEPS_VERSION: ${{ inputs.environment == 'production' && 'true' || 'false' }}
         run: |
           npm run build:package
           npm run build:package:modern
 
-      - name: Get the two latest monorepo versions
+      - name: Get the monorepo versions for the base and head versions
         run: |
-          CURRENT_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 1)
-          LAST_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 2 | awk 'NR == 2 { print $1 }')
+          # If both base and head versions are provided, use them
+          if [ -n "${{ inputs.base_version }}" ] && [ -n "${{ inputs.head_version }}" ]; then
+            CURRENT_VERSION=${{ inputs.base_version }}
+            LAST_VERSION=${{ inputs.head_version }}
+          else
+            # Otherwise, get the two latest monorepo versions
+            CURRENT_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 1)
+            LAST_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 2 | awk 'NR == 2 { print $1 }')
+          fi
 
           echo "Current version: $CURRENT_VERSION"
           echo "Previous version: $LAST_VERSION"
@@ -107,7 +148,7 @@ jobs:
           ./scripts/make-package-json-publish-ready.sh
 
           npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npx nx release publish --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }}
+          npx nx release publish --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }}
 
           # Reset the changes made to package.json
           git reset --hard
@@ -159,7 +200,7 @@ jobs:
         continue-on-error: true
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d  # v2.0.0
         env:
-          PROJECT_NAME: 'JS SDK NPM Package'
+          PROJECT_NAME: ${{ inputs.environment == 'beta' && 'JS SDK NPM Package - beta' || 'JS SDK NPM Package' }}
           NPM_PACKAGE_URL: 'https://www.npmjs.com/package/@rudderstack/analytics-js'
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js@'
         with:
@@ -193,16 +234,8 @@ jobs:
                     "image_url": "https://img.icons8.com/color/452/npm.png",
                     "alt_text": "NPM Icon"
                   }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "For more details, check the full release notes <${{env.RELEASES_URL}}${{ env.CURRENT_VERSION_VALUE }}|here>."
-                    }
-                  ]
                 }
+                ${{ inputs.environment == 'production' && format(',{{"type": "context", "elements": [{{"type": "mrkdwn", "text": "For more details, check the full release notes <{0}{1}|here>."}}]}}', env.RELEASES_URL, env.CURRENT_VERSION_VALUE) || ''  }}
               ]
             }
 
@@ -212,7 +245,7 @@ jobs:
         continue-on-error: true
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d  # v2.0.0
         env:
-          PROJECT_NAME: 'JS SDK Service Worker NPM Package'
+          PROJECT_NAME: ${{ inputs.environment == 'beta' && 'JS SDK Service Worker NPM Package - beta' || 'JS SDK Service Worker NPM Package' }}
           NPM_PACKAGE_URL: 'https://www.npmjs.com/package/@rudderstack/analytics-js-service-worker'
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js-service-worker@'
         with:
@@ -246,16 +279,8 @@ jobs:
                     "image_url": "https://img.icons8.com/color/452/npm.png",
                     "alt_text": "NPM Icon"
                   }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "For more details, check the full release notes <${{ env.RELEASES_URL }}${{ env.CURRENT_VERSION_SW_VALUE }}|here>."
-                    }
-                  ]
                 }
+                ${{ inputs.environment == 'production' && format(',{{"type": "context", "elements": [{{"type": "mrkdwn", "text": "For more details, check the full release notes <{0}{1}|here>."}}]}}', env.RELEASES_URL, env.CURRENT_VERSION_SW_VALUE) || ''  }}
               ]
             }
 
@@ -265,7 +290,7 @@ jobs:
         continue-on-error: true
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d  # v2.0.0
         env:
-          PROJECT_NAME: 'JS SDK Cookies Utilities'
+          PROJECT_NAME: ${{ inputs.environment == 'beta' && 'JS SDK Cookies Utilities - beta' || 'JS SDK Cookies Utilities' }}
           NPM_PACKAGE_URL: 'https://www.npmjs.com/package/@rudderstack/analytics-js-cookies'
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js-cookies@'
         with:
@@ -299,15 +324,7 @@ jobs:
                     "image_url": "https://img.icons8.com/color/452/npm.png",
                     "alt_text": "NPM Icon"
                   }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "For more details, check the full release notes <${{ env.RELEASES_URL }}${{ env.CURRENT_VERSION_COOKIE_UTILS_VALUE }}|here>."
-                    }
-                  ]
                 }
+                ${{ inputs.environment == 'production' && format(',{{"type": "context", "elements": [{{"type": "mrkdwn", "text": "For more details, check the full release notes <{0}{1}|here>."}}]}}', env.RELEASES_URL, env.CURRENT_VERSION_COOKIE_UTILS_VALUE) || ''  }}
               ]
             }

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -70,8 +70,10 @@ jobs:
           echo "analytics-v1.1: $CURRENT_VERSION_V1 -> $NEW_VERSION_V1"
           
           # Update all package.json files using jq
-          jq ".version = \"$NEW_VERSION_JS\"" packages/analytics-js/package.json > tmp && mv tmp packages/analytics-js/package.json
-          jq ".version = \"$NEW_VERSION_V1\"" packages/analytics-v1.1/package.json > tmp && mv tmp packages/analytics-v1.1/package.json
+          TMP_FILE_JS=$(mktemp)
+          jq ".version = \"$NEW_VERSION_JS\"" packages/analytics-js/package.json > "$TMP_FILE_JS" && mv "$TMP_FILE_JS" packages/analytics-js/package.json
+          TMP_FILE_V1=$(mktemp)
+          jq ".version = \"$NEW_VERSION_V1\"" packages/analytics-v1.1/package.json > "$TMP_FILE_V1" && mv "$TMP_FILE_V1" packages/analytics-v1.1/package.json
 
       - name: Get new version number
         run: |

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -22,7 +22,8 @@ on:
         required: false
       environment:
         type: string
-        required: true
+        required: false
+        default: 'production'
     secrets:
       RS_PROD_BUGSNAG_API_KEY:
         required: true
@@ -85,13 +86,14 @@ jobs:
 
       - name: Get versions in NPM
         run: |
-          current_npm_version=$(npm show @rudderstack/analytics-js version 2>/dev/null || echo "not found")
+          # Get latest version across all tags (most recently published)
+          current_npm_version=$(npm view @rudderstack/analytics-js time --json 2>/dev/null | jq -r 'to_entries | map(select(.key != "modified" and .key != "created")) | sort_by(.value) | last.key' || echo "not found")
           echo "CURRENT_NPM_VERSION=$current_npm_version" >> $GITHUB_ENV
 
-          current_npm_version_sw=$(npm show @rudderstack/analytics-js-service-worker version 2>/dev/null || echo "not found")
+          current_npm_version_sw=$(npm view @rudderstack/analytics-js-service-worker time --json 2>/dev/null | jq -r 'to_entries | map(select(.key != "modified" and .key != "created")) | sort_by(.value) | last.key' || echo "not found")
           echo "CURRENT_NPM_VERSION_SW=$current_npm_version_sw" >> $GITHUB_ENV
-
-          current_npm_version_cookie_utils=$(npm show @rudderstack/analytics-js-cookies version 2>/dev/null || echo "not found")
+          
+          current_npm_version_cookie_utils=$(npm view @rudderstack/analytics-js-cookies time --json 2>/dev/null | jq -r 'to_entries | map(select(.key != "modified" and .key != "created")) | sort_by(.value) | last.key' || echo "not found")
           echo "CURRENT_NPM_VERSION_COOKIE_UTILS=$current_npm_version_cookie_utils" >> $GITHUB_ENV
 
       - name: Setup Node
@@ -163,13 +165,15 @@ jobs:
       - name: Get versions in NPM after publish
         run: |
           npm cache clean --force
-          new_npm_version=$(npm show @rudderstack/analytics-js version 2>/dev/null || echo "not found")
+          
+          # Get latest version across all tags (most recently published)
+          new_npm_version=$(npm view @rudderstack/analytics-js time --json 2>/dev/null | jq -r 'to_entries | map(select(.key != "modified" and .key != "created")) | sort_by(.value) | last.key' || echo "not found")
           echo "NEW_NPM_VERSION=$new_npm_version" >> $GITHUB_ENV
 
-          new_npm_version_sw=$(npm show @rudderstack/analytics-js-service-worker version 2>/dev/null || echo "not found")
+          new_npm_version_sw=$(npm view @rudderstack/analytics-js-service-worker time --json 2>/dev/null | jq -r 'to_entries | map(select(.key != "modified" and .key != "created")) | sort_by(.value) | last.key' || echo "not found")
           echo "NEW_NPM_VERSION_SW=$new_npm_version_sw" >> $GITHUB_ENV
 
-          new_npm_version_cookie_utils=$(npm show @rudderstack/analytics-js-cookies version 2>/dev/null || echo "not found")
+          new_npm_version_cookie_utils=$(npm view @rudderstack/analytics-js-cookies time --json 2>/dev/null | jq -r 'to_entries | map(select(.key != "modified" and .key != "created")) | sort_by(.value) | last.key' || echo "not found")
           echo "NEW_NPM_VERSION_COOKIE_UTILS=$new_npm_version_cookie_utils" >> $GITHUB_ENV
 
       - name: Debug environment variables

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -123,8 +123,8 @@ jobs:
         run: |
           # If both base and head versions are provided, use them
           if [ -n "${{ inputs.base_version }}" ] && [ -n "${{ inputs.head_version }}" ]; then
-            CURRENT_VERSION=${{ inputs.base_version }}
-            LAST_VERSION=${{ inputs.head_version }}
+            LAST_VERSION=${{ inputs.base_version }}
+            CURRENT_VERSION=${{ inputs.head_version }}
           else
             # Otherwise, get the two latest monorepo versions
             CURRENT_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 1)
@@ -148,7 +148,7 @@ jobs:
           ./scripts/make-package-json-publish-ready.sh
 
           npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npx nx release publish --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }} --dry-run
+          npx nx release publish --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }}
 
           # Reset the changes made to package.json
           git reset --hard

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -9,6 +9,9 @@ on:
       use_pr_head_sha:
         type: string
         default: 'false'
+      beta_identifier:
+        type: string
+        required: false
     secrets:
       AWS_ACCOUNT_ID:
         required: true
@@ -75,6 +78,9 @@ jobs:
           elif [ "${{ inputs.environment }}" == "production" ]; then
             echo "SDK_CDN_VERSION_PATH_PREFIX=" >> $GITHUB_ENV
             echo "SUITE_CDN_PATH=" >> $GITHUB_ENV
+          elif [ "${{ inputs.environment }}" == "beta" ]; then
+            echo "SDK_CDN_VERSION_PATH_PREFIX=beta/${{ inputs.beta_identifier }}/" >> $GITHUB_ENV
+            echo "SUITE_CDN_PATH=/beta/${{ inputs.beta_identifier }}" >> $GITHUB_ENV
           else
             echo "SDK_CDN_VERSION_PATH_PREFIX=dev/latest/" >> $GITHUB_ENV
             echo "SUITE_CDN_PATH=/dev" >> $GITHUB_ENV

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -136,7 +136,7 @@ jobs:
         env:
           PROJECT_NAME: 'Sanity suite - ${{ inputs.environment }}'
           CDN_URL: 'https://cdn.rudderlabs.com/sanity-suite${{ env.SUITE_CDN_PATH }}/v3/cdn/index.html'
-          LINK_TEXT: ${{ ((inputs.environment == 'development' && format('v{0} - Development', env.CURRENT_VERSION_VALUE)) || (inputs.environment == 'staging' && format('v{0} - Staging', env.CURRENT_VERSION_VALUE)) || format('v{0}', env.CURRENT_VERSION_VALUE)) }}
+          LINK_TEXT: ${{ ((inputs.environment == 'development' && format('v{0} - Development', env.CURRENT_VERSION_VALUE)) || (inputs.environment == 'staging' && format('v{0} - Staging', env.CURRENT_VERSION_VALUE)) || (inputs.environment == 'beta' && format('v{0} - Beta', env.CURRENT_VERSION_VALUE)) || format('v{0}', env.CURRENT_VERSION_VALUE)) }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ on:
       use_pr_head_sha:
         type: string
         default: 'false'
+      version_suffix:
+        type: string
+        default: ''
     secrets:
       AWS_ACCOUNT_ID:
         required: true
@@ -89,6 +92,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.getSHA.outputs.SHA }}
+
+      - name: Modify package versions
+        run: |
+          # Append the version suffix to the package versions
+          if [ -n "${{ inputs.version_suffix }}" ]; then
+            # Extract the current versions using jq
+            CURRENT_VERSION_JS=$(jq -r .version packages/analytics-js/package.json)
+            CURRENT_VERSION_V1=$(jq -r .version packages/analytics-v1.1/package.json)
+            
+            # Append the suffix to create new versions
+            NEW_VERSION_JS="${CURRENT_VERSION_JS}-${{ inputs.version_suffix }}"
+            NEW_VERSION_V1="${CURRENT_VERSION_V1}-${{ inputs.version_suffix }}"
+            
+            echo "Updating versions:"
+            echo "analytics-js: $CURRENT_VERSION_JS -> $NEW_VERSION_JS"
+            echo "analytics-v1.1: $CURRENT_VERSION_V1 -> $NEW_VERSION_V1"
+            
+            # Update all package.json files using jq
+            jq ".version = \"$NEW_VERSION_JS\"" packages/analytics-js/package.json > tmp && mv tmp packages/analytics-js/package.json
+            jq ".version = \"$NEW_VERSION_V1\"" packages/analytics-v1.1/package.json > tmp && mv tmp packages/analytics-v1.1/package.json
+          fi
 
       - name: Get new versions
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,25 +94,22 @@ jobs:
           ref: ${{ steps.getSHA.outputs.SHA }}
 
       - name: Modify package versions
+        if: ${{ inputs.version_suffix != '' }}
         run: |
-          # Append the version suffix to the package versions
-          if [ -n "${{ inputs.version_suffix }}" ]; then
-            # Extract the current versions using jq
-            CURRENT_VERSION_JS=$(jq -r .version packages/analytics-js/package.json)
-            CURRENT_VERSION_V1=$(jq -r .version packages/analytics-v1.1/package.json)
-            
-            # Append the suffix to create new versions
-            NEW_VERSION_JS="${CURRENT_VERSION_JS}-${{ inputs.version_suffix }}"
-            NEW_VERSION_V1="${CURRENT_VERSION_V1}-${{ inputs.version_suffix }}"
-            
-            echo "Updating versions:"
-            echo "analytics-js: $CURRENT_VERSION_JS -> $NEW_VERSION_JS"
-            echo "analytics-v1.1: $CURRENT_VERSION_V1 -> $NEW_VERSION_V1"
-            
-            # Update all package.json files using jq
-            jq ".version = \"$NEW_VERSION_JS\"" packages/analytics-js/package.json > tmp && mv tmp packages/analytics-js/package.json
-            jq ".version = \"$NEW_VERSION_V1\"" packages/analytics-v1.1/package.json > tmp && mv tmp packages/analytics-v1.1/package.json
-          fi
+          CURRENT_VERSION_JS=$(jq -r .version packages/analytics-js/package.json)
+          CURRENT_VERSION_V1=$(jq -r .version packages/analytics-v1.1/package.json)
+          
+          # Append the suffix to create new versions
+          NEW_VERSION_JS="${CURRENT_VERSION_JS}-${{ inputs.version_suffix }}"
+          NEW_VERSION_V1="${CURRENT_VERSION_V1}-${{ inputs.version_suffix }}"
+          
+          echo "Updating versions:"
+          echo "analytics-js: $CURRENT_VERSION_JS -> $NEW_VERSION_JS"
+          echo "analytics-v1.1: $CURRENT_VERSION_V1 -> $NEW_VERSION_V1"
+          
+          # Update all package.json files using jq
+          jq ".version = \"$NEW_VERSION_JS\"" packages/analytics-js/package.json > tmp && mv tmp packages/analytics-js/package.json
+          jq ".version = \"$NEW_VERSION_V1\"" packages/analytics-v1.1/package.json > tmp && mv tmp packages/analytics-v1.1/package.json
 
       - name: Get new versions
         run: |

--- a/.github/workflows/trigger-test-suites.yml
+++ b/.github/workflows/trigger-test-suites.yml
@@ -9,6 +9,12 @@ on:
       use_pr_head_sha:
         type: string
         default: 'false'
+      build_source_id:
+        type: string
+        required: false
+      sanity_test_suite_url:
+        type: string
+        required: false
     secrets:
       PAT:
         description: Personal Access Token
@@ -60,7 +66,10 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/rudderlabs/rudder-client-side-test/actions/workflows/sdk-team-js-sanity-suite.yaml/dispatches" \
             -f "ref=main" \
-            -f "inputs[environment]=${{ inputs.environment }}" -f "inputs[monorepo_version]=${{ needs.extract-monorepo-version.outputs.version }}"
+            -f "inputs[environment]=${{ inputs.environment }}" \
+            -f "inputs[monorepo_version]=${{ needs.extract-monorepo-version.outputs.version }}" \
+            -f "inputs[sanity_test_suite_url]=${{ inputs.sanity_test_suite_url }}" \
+            -f "inputs[build_source_id]=${{ inputs.build_source_id }}"
 
   trigger-e2e-test-suite:
     runs-on: [self-hosted, Linux, X64]
@@ -80,4 +89,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/rudderlabs/rudder-client-side-test/actions/workflows/sdk-team-js-regression.yaml/dispatches" \
             -f "ref=main" \
-            -f "inputs[environment]=${{ inputs.environment }}" -f "inputs[monorepo_version]=${{ needs.extract-monorepo-version.outputs.version }}"
+            -f "inputs[environment]=${{ inputs.environment }}" \
+            -f "inputs[monorepo_version]=${{ needs.extract-monorepo-version.outputs.version }}" \
+            -f "inputs[sanity_test_suite_url]=${{ inputs.sanity_test_suite_url }}" \
+            -f "inputs[build_source_id]=${{ inputs.build_source_id }}"


### PR DESCRIPTION
## PR Description

I've updated the beta deployment workflow to support deploying even NPM packages with beta versions.
Now, the beta version can be deployed directly from the branches with a PR to the `develop` branch. Additionally, the PR should be in a "ready to merge" state with checks passing and required approvals etc.

The beta identifiers are also made consistent across CDN, NPM, sanity suite deployments along with automation test runs.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3249/deploy-npm-package-as-beta

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
