### PR TITLE
feat: group errors by message

### DIFF
--- a/packages/analytics-js-common/src/types/Metrics.ts
+++ b/packages/analytics-js-common/src/types/Metrics.ts
@@ -24,7 +24,10 @@ export type ErrorEventPayload = {
   events: ErrorEvent[];
 };
 
-export type ErrorEvent = Pick<Event, 'severity' | 'app' | 'device' | 'request' | 'context'> & {
+export type ErrorEvent = Pick<
+  Event,
+  'severity' | 'app' | 'device' | 'request' | 'context' | 'groupingHash'
+> & {
   exceptions: Exception[];
   unhandled: boolean;
   severityReason: { type: string };

--- a/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
@@ -335,7 +335,7 @@ describe('Error Reporting utilities', () => {
         ],
       };
 
-      const bsErrorEvent = getBugsnagErrorEvent(exception, errorState, state);
+      const bsErrorEvent = getBugsnagErrorEvent(exception, errorState, state, 'dummy message');
 
       const expectedOutcome = {
         payloadVersion: '5',
@@ -396,6 +396,7 @@ describe('Error Reporting utilities', () => {
               },
             ],
             context: 'dummy message',
+            groupingHash: 'dummy message',
             metaData: {
               app: {
                 snippetVersion: 'sample_snippet_version',
@@ -654,6 +655,7 @@ describe('Error Reporting utilities', () => {
       ['', true, 'should allow empty messages'],
     ];
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     test.each(testCases)('%s -> %s (%s)', (message, expected, testName) => {
       const result = isAllowedToBeNotified({ message } as unknown as Exception);
       expect(result).toBe(expected);

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -115,8 +115,12 @@ class ErrorHandler implements IErrorHandler {
           severityReason: { type: errorType },
         };
 
-        // enrich error payload
-        const bugsnagPayload = getBugsnagErrorEvent(bsException, errorState, state);
+        // Set grouping hash only for CDN installations (as an experiment)
+        const groupingHash =
+          state.context.app.value.installType === 'cdn' ? bsException.message : undefined;
+
+        // Get the final payload to be sent to the metrics service
+        const bugsnagPayload = getBugsnagErrorEvent(bsException, errorState, state, groupingHash);
 
         // send it to metrics service
         this.httpClient.getAsyncData({

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -116,6 +116,11 @@ class ErrorHandler implements IErrorHandler {
         };
 
         // Set grouping hash only for CDN installations (as an experiment)
+        // This will allow us to group errors by the message instead of the surrounding code.
+        // In case of NPM installations, the default grouping by surrounding code does not make sense as each user application is different.
+        // References:
+        // https://docs.bugsnag.com/platforms/javascript/customizing-error-reports/#groupinghash
+        // https://docs.bugsnag.com/product/error-grouping/#user_defined
         const groupingHash =
           state.context.app.value.installType === 'cdn' ? bsException.message : undefined;
 

--- a/packages/analytics-js/src/services/ErrorHandler/utils.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/utils.ts
@@ -98,6 +98,7 @@ const getBugsnagErrorEvent = (
   exception: Exception,
   errorState: ErrorState,
   state: ApplicationState,
+  groupingHash?: string,
 ): ErrorEventPayload => {
   const { context, lifecycle, session, source, reporting, autoTrack } = state;
   const { app, locale, userAgent, timezone, screen, library } = context;
@@ -127,6 +128,7 @@ const getBugsnagErrorEvent = (
         },
         breadcrumbs: clone(reporting.breadcrumbs.value),
         context: exception.message,
+        groupingHash,
         metaData: {
           app: {
             snippetVersion: library.value.snippetVersion,


### PR DESCRIPTION
## PR Description

I've set the error message as the grouping hash in error reporting event object. This will ensure the errors are properly grouped on the dashboard.
For now, we did this only for the CDN installations.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3248/implement-grouping-hash-for-error-messages-to-bugsnag

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced error reporting for CDN installations by including a grouping hash in error events to improve error grouping and diagnostics.
- **Tests**
	- Added and updated tests to verify the correct behavior of error grouping hash generation and inclusion in error events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->