### PR TITLE
chore: generate package versions output for releases

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -106,6 +106,12 @@ jobs:
           git add .
           git commit -m "chore(monorepo): sync versions and generate release logs" -n
 
+      - name: Generate packages versions table
+        id: packages-versions
+        run: |
+          chmod +x ./scripts/collect-packages-versions.sh
+          ./scripts/collect-packages-versions.sh > packages_versions.md
+
       - name: Push new version in release branch
         run: |
           git push --follow-tags
@@ -128,6 +134,10 @@ jobs:
           - **Release Version**: v${{ env.NEW_VERSION_VALUE }}
           - **Release Branch**: \`${{ steps.create-release.outputs.branch_name }}\`
           - **Related Ticket**: [${{ github.event.inputs.release_ticket_id }}](https://linear.app/rudderstack/issue/${{ github.event.inputs.release_ticket_id }})
+
+          ### Version updates
+
+          $(cat packages_versions.md)
 
           ---
           Please review and merge when ready. :rocket:

--- a/scripts/collect-packages-versions.sh
+++ b/scripts/collect-packages-versions.sh
@@ -9,7 +9,7 @@
 #   - Output is a Markdown table suitable for pasting into PR descriptions or tickets.
 #
 # Usage:
-#   ./scripts/collect-packages-versions.sh > package_versions.md
+#   ./scripts/collect-packages-versions.sh > packages_versions.md
 #
 # Output format:
 #   | Package | New version |

--- a/scripts/collect-packages-versions.sh
+++ b/scripts/collect-packages-versions.sh
@@ -42,4 +42,4 @@ print_version_row "package.json"
 # All packages in packages/
 find packages -name package.json | while read -r pkg; do
   print_version_row "$pkg"
-done 
+done

--- a/scripts/collect-packages-versions.sh
+++ b/scripts/collect-packages-versions.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This script generates a Markdown table of all package versions in the monorepo.
+#
+# Purpose:
+#   - Lists the root package and all packages under the 'packages' directory.
+#   - For each package, compares its current version to the version on origin/main.
+#   - If the version has changed, shows the new version; otherwise, shows 'N/A'.
+#   - Output is a Markdown table suitable for pasting into PR descriptions or tickets.
+#
+# Usage:
+#   ./scripts/collect-packages-versions.sh > package_versions.md
+#
+# Output format:
+#   | Package | New version |
+#   |---------|-------------|
+#   | @package/name | 1.2.3 |
+#   | ...           | N/A   |
+
+set -e
+
+echo "| Package | New version |"
+echo "|---------|-------------|"
+
+print_version_row() {
+  local file_path="$1"
+  if [ -f "$file_path" ]; then
+    local name version prev_version
+    name=$(jq -r .name "$file_path")
+    version=$(jq -r .version "$file_path")
+    prev_version=$(git show origin/main:"$file_path" 2>/dev/null | jq -r .version)
+    if [ "$version" == "$prev_version" ]; then
+      version="N/A"
+    fi
+    echo "| $name | $version |"
+  fi
+}
+
+# Root package.json
+print_version_row "package.json"
+
+# All packages in packages/
+find packages -name package.json | while read pkg; do
+  print_version_row "$pkg"
+done 

--- a/scripts/collect-packages-versions.sh
+++ b/scripts/collect-packages-versions.sh
@@ -40,6 +40,6 @@ print_version_row() {
 print_version_row "package.json"
 
 # All packages in packages/
-find packages -name package.json | while read pkg; do
+find packages -name package.json | while read -r pkg; do
   print_version_row "$pkg"
 done 

--- a/scripts/collect-packages-versions.sh
+++ b/scripts/collect-packages-versions.sh
@@ -28,11 +28,15 @@ print_version_row() {
     local name version prev_version
     name=$(jq -r .name "$file_path")
     version=$(jq -r .version "$file_path")
-    prev_version=$(git show origin/main:"$file_path" 2>/dev/null || echo '{}') | jq -r .version)
-    if [ "$version" == "$prev_version" ]; then
-      version="N/A"
+    prev_version=$(git show origin/main:"$file_path" 2>/dev/null | jq -r .version 2>/dev/null || echo "")
+    if [ -z "$prev_version" ]; then
+      # New package or file not present on origin/main
+      echo "| $name | $version |"
+    elif [ "$version" == "$prev_version" ]; then
+      echo "| $name | N/A |"
+    else
+      echo "| $name | $version |"
     fi
-    echo "| $name | $version |"
   fi
 }
 

--- a/scripts/collect-packages-versions.sh
+++ b/scripts/collect-packages-versions.sh
@@ -28,7 +28,7 @@ print_version_row() {
     local name version prev_version
     name=$(jq -r .name "$file_path")
     version=$(jq -r .version "$file_path")
-    prev_version=$(git show origin/main:"$file_path" 2>/dev/null | jq -r .version)
+    prev_version=$(git show origin/main:"$file_path" 2>/dev/null || echo '{}') | jq -r .version)
     if [ "$version" == "$prev_version" ]; then
       version="N/A"
     fi


### PR DESCRIPTION
## PR Description

I've updated the draft new release workflow to also create table at the end of the release PR description to list all the packages and their new versions.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a script to generate a Markdown table listing package versions across the monorepo for easier tracking of version changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->