### PR TITLE
feat: change log level to warning for retryable event delivery failures

### DIFF
--- a/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
@@ -187,7 +187,7 @@ describe('XhrQueue', () => {
     // In actual implementation, this is done based on the state signals
     queue.start();
 
-    expect(defaultLogger.error).toHaveBeenCalledWith(
+    expect(defaultLogger.warn).toHaveBeenCalledWith(
       'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried.',
     );
 

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
@@ -274,6 +274,66 @@ describe('xhrQueue Plugin Utilities', () => {
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. Retries exhausted (10). The event(s) will be dropped.',
       );
     });
+
+    it('should not log anything when no logger is provided', () => {
+      const details = {
+        error: { message: 'Unauthorized' },
+      } as ResponseDetails;
+
+      // Should not throw an error and should handle gracefully
+      expect(() => {
+        logMessageOnFailure(
+          details,
+          false,
+          {
+            retryAttemptNumber: 1,
+            maxRetryAttempts: 10,
+            willBeRetried: false,
+            timeSinceFirstAttempt: 1,
+            timeSinceLastAttempt: 1,
+            reclaimed: false,
+          },
+          undefined, // No logger provided
+        );
+      }).not.toThrow();
+
+      // Also test with retryable scenario
+      expect(() => {
+        logMessageOnFailure(
+          details,
+          true,
+          {
+            retryAttemptNumber: 1,
+            maxRetryAttempts: 10,
+            willBeRetried: true,
+            timeSinceFirstAttempt: 1,
+            timeSinceLastAttempt: 1,
+            reclaimed: false,
+          },
+          undefined, // No logger provided
+        );
+      }).not.toThrow();
+    });
+
+    it('should handle undefined error details gracefully', () => {
+      logMessageOnFailure(
+        undefined, // No error details
+        false,
+        {
+          retryAttemptNumber: 1,
+          maxRetryAttempts: 10,
+          willBeRetried: false,
+          timeSinceFirstAttempt: 1,
+          timeSinceLastAttempt: 1,
+          reclaimed: false,
+        },
+        defaultLogger,
+      );
+
+      expect(defaultLogger.error).toHaveBeenCalledWith(
+        'XhrQueuePlugin:: Failed to deliver event(s). Cause: Unknown. The event(s) will be dropped.',
+      );
+    });
   });
 
   describe('getRequestInfo', () => {

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/utilities.test.ts
@@ -7,7 +7,7 @@ import {
   getNormalizedQueueOptions,
   getDeliveryUrl,
   getBatchDeliveryUrl,
-  logErrorOnFailure,
+  logMessageOnFailure,
   getRequestInfo,
   getBatchDeliveryPayload,
 } from '../../src/xhrQueue/utilities';
@@ -114,13 +114,13 @@ describe('xhrQueue Plugin Utilities', () => {
     });
   });
 
-  describe('logErrorOnFailure', () => {
+  describe('logMessageOnFailure', () => {
     it('should log an error for delivery failure', () => {
       const details = {
         error: { message: 'Unauthorized' },
       } as ResponseDetails;
 
-      logErrorOnFailure(
+      logMessageOnFailure(
         details,
         false,
         {
@@ -139,7 +139,7 @@ describe('xhrQueue Plugin Utilities', () => {
       );
     });
 
-    it('should log an error for retryable network failure', () => {
+    it('should log a warning for retryable network failure', () => {
       const details = {
         error: { message: 'Too many requests' },
         xhr: {
@@ -147,7 +147,7 @@ describe('xhrQueue Plugin Utilities', () => {
         },
       } as ResponseDetails;
 
-      logErrorOnFailure(
+      logMessageOnFailure(
         details,
         true,
         {
@@ -161,7 +161,7 @@ describe('xhrQueue Plugin Utilities', () => {
         defaultLogger,
       );
 
-      expect(defaultLogger.error).toHaveBeenCalledWith(
+      expect(defaultLogger.warn).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried. Retry attempt 1 of 10.',
       );
 
@@ -169,7 +169,7 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 429;
 
-      logErrorOnFailure(
+      logMessageOnFailure(
         details,
         true,
         {
@@ -182,7 +182,7 @@ describe('xhrQueue Plugin Utilities', () => {
         },
         defaultLogger,
       );
-      expect(defaultLogger.error).toHaveBeenCalledWith(
+      expect(defaultLogger.warn).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried.',
       );
 
@@ -190,7 +190,7 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 500;
 
-      logErrorOnFailure(
+      logMessageOnFailure(
         details,
         true,
         {
@@ -204,7 +204,7 @@ describe('xhrQueue Plugin Utilities', () => {
         defaultLogger,
       );
 
-      expect(defaultLogger.error).toHaveBeenCalledWith(
+      expect(defaultLogger.warn).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried. Retry attempt 1 of 10.',
       );
 
@@ -212,7 +212,7 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 501;
 
-      logErrorOnFailure(
+      logMessageOnFailure(
         details,
         true,
         {
@@ -226,7 +226,7 @@ describe('xhrQueue Plugin Utilities', () => {
         defaultLogger,
       );
 
-      expect(defaultLogger.error).toHaveBeenCalledWith(
+      expect(defaultLogger.warn).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried. Retry attempt 1 of 10.',
       );
 
@@ -234,7 +234,7 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 600;
 
-      logErrorOnFailure(
+      logMessageOnFailure(
         details,
         true,
         {
@@ -248,7 +248,7 @@ describe('xhrQueue Plugin Utilities', () => {
         defaultLogger,
       );
 
-      expect(defaultLogger.error).toHaveBeenCalledWith(
+      expect(defaultLogger.warn).toHaveBeenCalledWith(
         'XhrQueuePlugin:: Failed to deliver event(s). Cause: Too many requests. The event(s) will be retried. Retry attempt 1 of 10.',
       );
 
@@ -256,7 +256,7 @@ describe('xhrQueue Plugin Utilities', () => {
       // @ts-expect-error Needed to set the status for testing
       (details.xhr as XMLHttpRequest).status = 520;
 
-      logErrorOnFailure(
+      logMessageOnFailure(
         details,
         true,
         {

--- a/packages/analytics-js-plugins/src/xhrQueue/index.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/index.ts
@@ -12,7 +12,7 @@ import type { PluginName } from '@rudderstack/analytics-js-common/types/PluginsM
 import {
   getNormalizedQueueOptions,
   getDeliveryUrl,
-  logErrorOnFailure,
+  logMessageOnFailure,
   getRequestInfo,
   getBatchDeliveryPayload,
 } from './utilities';
@@ -103,7 +103,7 @@ const XhrQueue = (): ExtensionPlugin => ({
 
               const isRetryable = isErrRetryable(details?.xhr?.status ?? 0);
 
-              logErrorOnFailure(details, isRetryable, qItemProcessInfo, logger);
+              logMessageOnFailure(details, isRetryable, qItemProcessInfo, logger);
 
               // null means item will not be processed further and will be removed from the queue (even from the storage)
               const queueErrResp = isRetryable ? details : null;

--- a/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/utilities.ts
@@ -46,6 +46,10 @@ const logMessageOnFailure = (
   qItemProcessInfo: QueueProcessCallbackInfo,
   logger?: ILogger,
 ) => {
+  if (!logger) {
+    return;
+  }
+
   let logMsg = EVENT_DELIVERY_FAILURE_ERROR_PREFIX(
     XHR_QUEUE_PLUGIN,
     details?.error?.message ?? 'Unknown',
@@ -58,15 +62,15 @@ const logMessageOnFailure = (
         logMsg = `${logMsg} Retry attempt ${qItemProcessInfo.retryAttemptNumber} of ${qItemProcessInfo.maxRetryAttempts}.`;
       }
       // Use warning for retryable failures that will be retried
-      logger?.warn(logMsg);
+      logger.warn(logMsg);
     } else {
-      logger?.error(
+      logger.error(
         `${logMsg} Retries exhausted (${qItemProcessInfo.maxRetryAttempts}). ${dropMsg}`,
       );
     }
   } else {
     // Use error for non-retryable failures
-    logger?.error(`${logMsg} ${dropMsg}`);
+    logger.error(`${logMsg} ${dropMsg}`);
   }
 };
 


### PR DESCRIPTION
## PR Description

Changed log level from `error` to `warning` for retryable event delivery failures to reduce noise in browser console error logs.

## 📋 Changes Made
- **Smart Logging Logic**: Retryable failures that will be retried now log as `warnings` instead of `errors`
- **Preserved Error Logging**: Non-retryable failures and exhausted retries continue to log as `errors`
- **Improved Code Quality**: Renamed `logErrorOnFailure` → `logMessageOnFailure` for better semantic clarity
- **Comprehensive Test Updates**: Updated all test expectations to match new logging behavior


## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3345/change-log-level-to-warning-from-error-for-event-delivery-failure-that

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced logging to differentiate retryable network failures with warnings and non-retryable or exhausted retries with errors.
  - Renamed internal logging function for improved clarity.
- **Tests**
  - Updated tests to reflect new logging behavior and function names.
  - Added coverage for scenarios with missing loggers and undefined error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->