### PR TITLE
feat: retry delivery failures in beacon plugin when page is unloaded

### DIFF
--- a/packages/analytics-js-plugins/__tests__/deviceModeTransformation/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeTransformation/index.test.ts
@@ -179,6 +179,7 @@ describe('Device mode transformation plugin', () => {
         reclaimed: false,
         timeSinceFirstAttempt: expect.any(Number),
         timeSinceLastAttempt: expect.any(Number),
+        isPageAccessible: true,
       },
     );
 

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
@@ -140,6 +140,7 @@ describe('XhrQueue', () => {
         timeSinceFirstAttempt: expect.any(Number),
         timeSinceLastAttempt: expect.any(Number),
         reclaimed: false,
+        isPageAccessible: true,
       },
     );
 
@@ -298,6 +299,7 @@ describe('XhrQueue', () => {
         timeSinceFirstAttempt: expect.any(Number),
         timeSinceLastAttempt: expect.any(Number),
         reclaimed: false,
+        isPageAccessible: true,
       },
     );
 

--- a/packages/analytics-js-plugins/src/beaconQueue/logMessages.ts
+++ b/packages/analytics-js-plugins/src/beaconQueue/logMessages.ts
@@ -10,7 +10,7 @@ const BEACON_QUEUE_BLOB_CONVERSION_FAILURE_ERROR = (context: string): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}Failed to convert events batch object to Blob.`;
 
 const BEACON_QUEUE_SEND_ERROR = (context: string): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}Failed to send events batch data to the browser's beacon queue. The events will be dropped.`;
+  `${context}${LOG_CONTEXT_SEPARATOR}Failed to send events batch data to the browser's beacon queue.`;
 
 const BEACON_QUEUE_DELIVERY_ERROR = (url: string): string =>
   `Failed to send events batch data to the browser's beacon queue for URL ${url}.`;

--- a/packages/analytics-js-plugins/src/types/plugins.ts
+++ b/packages/analytics-js-plugins/src/types/plugins.ts
@@ -42,6 +42,7 @@ export type QueueProcessCallbackInfo = {
   timeSinceLastAttempt: number;
   timeSinceFirstAttempt: number;
   reclaimed: boolean;
+  isPageAccessible: boolean;
 };
 
 /**
@@ -55,6 +56,7 @@ export type QueueProcessCallbackInfo = {
  *   - timeSinceLastAttempt: The number of seconds since the last attempt
  *   - timeSinceFirstAttempt: The number of seconds since the first attempt
  *   - reclaimed: A boolean indicating if the item has been reclaimed
+ *   - isPageAccessible: A boolean indicating if the page is accessible
  */
 export type QueueProcessCallback<T = any> = (
   item: T,

--- a/packages/analytics-js-plugins/src/utilities/retryQueue/RetryQueue.ts
+++ b/packages/analytics-js-plugins/src/utilities/retryQueue/RetryQueue.ts
@@ -598,6 +598,7 @@ class RetryQueue implements IQueue<QueueItemData> {
           timeSinceFirstAttempt,
           timeSinceLastAttempt,
           reclaimed,
+          isPageAccessible: this.isPageAccessible,
         });
       } catch (err) {
         let errMsg = '';

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -83,7 +83,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (UMD)',
     path: 'dist/npm/modern/bundled/umd/index.js',
     import: '*',
-    limit: '39.2 KiB',
+    limit: '39.5 KiB',
   },
   {
     name: 'Core (Content Script) - Legacy - NPM (ESM)',


### PR DESCRIPTION
## PR Description

I have updated the BeaconQueue plugin to retry event delivery failures occurring during the page unload.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3346/retry-beacon-queue-failures-and-log-warning-when-the-page-is-being

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new flag to queue processing that detects if the page is accessible, improving event handling reliability during page unloads.

- **Bug Fixes**
  - Enhanced error handling for failed event transmissions, ensuring events are only retried or dropped based on page accessibility.

- **Tests**
  - Updated test cases to validate the new page accessibility flag and its impact on queue processing and event handling logic.

- **Documentation**
  - Improved type documentation to reflect the addition of the new page accessibility property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->