### PR TITLE
feat: disable dmt for cloned destination

### DIFF
--- a/packages/analytics-js-plugins/__tests__/nativeDestinationQueue/utilities.test.ts
+++ b/packages/analytics-js-plugins/__tests__/nativeDestinationQueue/utilities.test.ts
@@ -1,6 +1,9 @@
 import { clone } from 'ramda';
 import type { Destination } from '@rudderstack/analytics-js-common/types/Destination';
-import { isEventDenyListed } from '../../src/nativeDestinationQueue/utilities';
+import {
+  isEventDenyListed,
+  shouldApplyTransformation,
+} from '../../src/nativeDestinationQueue/utilities';
 
 describe('nativeDestinationQueue Plugin - utilities', () => {
   describe('isEventDenyListed', () => {
@@ -98,6 +101,47 @@ describe('nativeDestinationQueue Plugin - utilities', () => {
     it('should return true if allow list is selected and track event name is in different case than with with allowlist event name', () => {
       const outcome1 = isEventDenyListed('track', 'Sample track event 1', destination);
       expect(outcome1).toBeTruthy();
+    });
+  });
+
+  describe('shouldApplyTransformation', () => {
+    const destination: Destination = {
+      id: 'dest1',
+      displayName: 'Destination 1',
+      userFriendlyId: 'dest1_friendly',
+      enabled: true,
+      shouldApplyDeviceModeTransformation: true,
+      propagateEventsUntransformedOnError: false,
+      config: {
+        apiKey: 'key1',
+        blacklistedEvents: [],
+        whitelistedEvents: [],
+        eventFilteringOption: 'disable' as const,
+      },
+    };
+
+    it('should return false if cloned is undefined but shouldApplyDeviceModeTransformation is false', () => {
+      const dest = { ...destination, shouldApplyDeviceModeTransformation: false };
+      expect(shouldApplyTransformation(dest)).toBe(false);
+    });
+
+    it('should return true if shouldApplyDeviceModeTransformation is true and cloned is undefined', () => {
+      expect(shouldApplyTransformation(destination)).toBe(true);
+    });
+
+    it('should return true if shouldApplyDeviceModeTransformation is true and not cloned', () => {
+      const dest = { ...destination, cloned: false };
+      expect(shouldApplyTransformation(dest)).toBe(true);
+    });
+
+    it('should return false when shouldApplyDeviceModeTransformation and cloned both are true', () => {
+      const dest = { ...destination, cloned: true };
+      expect(shouldApplyTransformation(dest)).toBe(false);
+    });
+
+    it('should return false if both shouldApplyDeviceModeTransformation and cloned are false', () => {
+      const dest = { ...destination, shouldApplyDeviceModeTransformation: false, cloned: false };
+      expect(shouldApplyTransformation(dest)).toBe(false);
     });
   });
 });

--- a/packages/analytics-js-plugins/src/nativeDestinationQueue/index.ts
+++ b/packages/analytics-js-plugins/src/nativeDestinationQueue/index.ts
@@ -15,7 +15,12 @@ import type { ExtensionPlugin } from '@rudderstack/analytics-js-common/types/Plu
 import { clone } from 'ramda';
 import type { DoneCallback, IQueue } from '../types/plugins';
 import { RetryQueue } from '../utilities/retryQueue/RetryQueue';
-import { getNormalizedQueueOptions, isEventDenyListed, sendEventToDestination } from './utilities';
+import {
+  getNormalizedQueueOptions,
+  isEventDenyListed,
+  sendEventToDestination,
+  shouldApplyTransformation,
+} from './utilities';
 import { NATIVE_DESTINATION_QUEUE_PLUGIN, QUEUE_NAME } from './constants';
 import { DESTINATION_EVENT_FILTERING_WARNING } from './logMessages';
 import { MEMORY_STORAGE } from '../shared-chunks/common';
@@ -84,7 +89,7 @@ const NativeDestinationQueue = (): ExtensionPlugin => ({
                 return;
               }
 
-              if (dest.shouldApplyDeviceModeTransformation) {
+              if (shouldApplyTransformation(dest)) {
                 destWithTransformationEnabled.push(dest);
               } else {
                 sendEventToDestination(clonedRudderEvent, dest, errorHandler, logger);

--- a/packages/analytics-js-plugins/src/nativeDestinationQueue/utilities.ts
+++ b/packages/analytics-js-plugins/src/nativeDestinationQueue/utilities.ts
@@ -78,4 +78,18 @@ const sendEventToDestination = (
   }
 };
 
-export { getNormalizedQueueOptions, isEventDenyListed, sendEventToDestination };
+/**
+ * A function to check if device mode transformation should be applied for a destination.
+ * @param dest Destination object
+ * @returns Boolean indicating whether the transformation should be applied
+ */
+const shouldApplyTransformation = (dest: Destination): boolean => {
+  return dest.shouldApplyDeviceModeTransformation && !dest.cloned;
+};
+
+export {
+  getNormalizedQueueOptions,
+  isEventDenyListed,
+  sendEventToDestination,
+  shouldApplyTransformation,
+};


### PR DESCRIPTION
## PR Description

With this PR SDK will exclude cloned destinations from Device Mode Transformations (DMT) processing in the NativeDestinationQueue plugin. This ensures that cloned destinations bypass the transformation pipeline while maintaining normal DMT functionality for original destinations.

## Linear task (optional)

[Linear task link](https://linear.app/rudderstack/issue/SDK-3328/disable-dmt-support-for-cloned-destinations)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved event processing logic for device mode transformations, ensuring more accurate handling based on destination properties.

- **Tests**
  - Added comprehensive tests to verify correct behavior of device mode transformation logic under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->