### PR TITLE
chore: organize monorepo packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30879,7 +30879,6 @@
       "dependencies": {
         "@lukeed/uuid": "2.0.1",
         "@preact/signals-core": "1.11.0",
-        "@segment/top-domain": "3.0.1",
         "crypto-js": "4.2.0",
         "get-value": "4.0.1",
         "ramda": "0.31.3",

--- a/packages/analytics-js-legacy-utilities/src/config_to_integration_names.js
+++ b/packages/analytics-js-legacy-utilities/src/config_to_integration_names.js
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/filename-case */
 // map b/w the names of integrations coming from config plane to integration module names
 const configToIntNames = {
   HS: 'HubSpot',

--- a/packages/analytics-js-plugins/rollup.config.mjs
+++ b/packages/analytics-js-plugins/rollup.config.mjs
@@ -96,26 +96,6 @@ export function getDefaultConfig(distName) {
           },
         ],
       }),
-      alias({
-        entries: [
-          {
-            find: '@rudderstack/analytics-js-plugins',
-            replacement: path.resolve('../analytics-js-plugins/src'),
-          },
-          {
-            find: '@rudderstack/analytics-js-common',
-            replacement: path.resolve('../analytics-js-common/src'),
-          },
-          {
-            find: '@rudderstack/analytics-js-cookies',
-            replacement: path.resolve('../analytics-js-cookies/src'),
-          },
-          {
-            find: '@rudderstack/analytics-js-integrations',
-            replacement: path.resolve('../analytics-js-integrations/src'),
-          },
-        ],
-      }),
       resolve({
         jsnext: true,
         browser: true,

--- a/packages/analytics-js-plugins/rollup.config.mjs
+++ b/packages/analytics-js-plugins/rollup.config.mjs
@@ -96,6 +96,26 @@ export function getDefaultConfig(distName) {
           },
         ],
       }),
+      alias({
+        entries: [
+          {
+            find: '@rudderstack/analytics-js-plugins',
+            replacement: path.resolve('../analytics-js-plugins/src'),
+          },
+          {
+            find: '@rudderstack/analytics-js-common',
+            replacement: path.resolve('../analytics-js-common/src'),
+          },
+          {
+            find: '@rudderstack/analytics-js-cookies',
+            replacement: path.resolve('../analytics-js-cookies/src'),
+          },
+          {
+            find: '@rudderstack/analytics-js-integrations',
+            replacement: path.resolve('../analytics-js-integrations/src'),
+          },
+        ],
+      }),
       resolve({
         jsnext: true,
         browser: true,


### PR DESCRIPTION
## PR Description

This PR focuses on organizing the monorepo packages to reduce dependencies and improve the overall structure of the RudderStack JavaScript SDK ecosystem. The changes include optimizing package dependencies, and updating internal references.

A new package `analytics-js-legacy-utilities` has been created to host all the common code b/w the legacy SDK and integrations packages.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated file to disable a specific linting rule related to filename casing. No changes to functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->