### PR TITLE
chore(release): merge hotfix-release/3.89.0-SDK-3414 into main [SDK-3414]

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -131,7 +131,7 @@ jobs:
           This ensures that the latest release branch changes are incorporated into the \`main\` branch for production.
 
           ### Details
-          - **Release Version**: v${{ env.NEW_VERSION_VALUE }}
+          - **Monorepo Release Version**: v${{ env.NEW_VERSION_VALUE }}
           - **Release Branch**: \`${{ steps.create-release.outputs.branch_name }}\`
           - **Related Ticket**: [${{ github.event.inputs.release_ticket_id }}](https://linear.app/rudderstack/issue/${{ github.event.inputs.release_ticket_id }})
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -118,7 +118,7 @@ jobs:
           This ensures that the \`develop\` branch stays up to date with all release-related changes from the \`main\` branch.
 
           ### Details
-          - **Release Version**: v${{ steps.extract-version.outputs.release_version }}
+          - **Monorepo Release Version**: v${{ steps.extract-version.outputs.release_version }}
           - **Related Ticket**: [${{ steps.extract-version.outputs.release_ticket_id }}](https://linear.app/rudderstack/issue/${{ steps.extract-version.outputs.release_ticket_id }})
 
           ---

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const rollbackVersion = ${{ env.LEGACY_SDK_ROLLBACK_VERSION_VALUE }};
+            const rollbackVersion = process.env.LEGACY_SDK_ROLLBACK_VERSION_VALUE;
             const releaseTag = `@rudderstack/analytics-js@${rollbackVersion}`;
             
             console.log(`Marking ${releaseTag} as the latest release on GitHub`);
@@ -165,7 +165,7 @@ jobs:
           
           # Deprecate the specified version with a message
           npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npm deprecate "@rudderstack/analytics-js@$VERSION_TO_DEPRECATE" "We've identified issues with this version of the package. Please use the latest version instead."
+          npm deprecate "@rudderstack/analytics-js@$VERSION_TO_DEPRECATE" "We've identified issues with this version of the package. Please switch to v${{ env.ROLLBACK_VERSION_VALUE }} or the latest version if available."
 
           # Note: The legacy SDK is not deprecated as it is deprecated by default with every release.
           # Refer to deploy-npm.yml for more details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rudderstack/analytics-js-monorepo",
-  "version": "3.88.0",
+  "version": "3.89.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rudderstack/analytics-js-monorepo",
-      "version": "3.88.0",
+      "version": "3.89.0",
       "hasInstallScript": true,
       "license": "Elastic-2.0",
       "workspaces": [
@@ -24152,7 +24152,7 @@
     },
     "packages/analytics-js": {
       "name": "@rudderstack/analytics-js",
-      "version": "3.20.0",
+      "version": "3.20.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@preact/signals-core": "1.9.0",
@@ -24215,7 +24215,7 @@
     },
     "packages/analytics-js-plugins": {
       "name": "@rudderstack/analytics-js-plugins",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@rudderstack/analytics-js-common": "*",
@@ -24271,7 +24271,7 @@
     },
     "packages/sanity-suite": {
       "name": "@rudderstack/analytics-js-sanity-suite",
-      "version": "3.2.13",
+      "version": "3.2.14",
       "license": "Elastic-2.0",
       "dependencies": {
         "@rudderstack/analytics-js": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-monorepo",
-  "version": "3.88.0",
+  "version": "3.89.0",
   "private": true,
   "description": "Monorepo for RudderStack Analytics JS SDK",
   "workspaces": [

--- a/packages/analytics-js-plugins/CHANGELOG.md
+++ b/packages/analytics-js-plugins/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.10.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.10.0...@rudderstack/analytics-js-plugins@3.10.1) (2025-06-12)
+
+
+### Bug Fixes
+
+* filter disable destinations ([#2286](https://github.com/rudderlabs/rudder-sdk-js/issues/2286)) ([7ca8398](https://github.com/rudderlabs/rudder-sdk-js/commit/7ca8398cb288360e1dca49c6266c04d58ce88e05))
+
 ## [3.10.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.9.0...@rudderstack/analytics-js-plugins@3.10.0) (2025-06-11)
 
 ### Dependency Updates

--- a/packages/analytics-js-plugins/CHANGELOG_LATEST.md
+++ b/packages/analytics-js-plugins/CHANGELOG_LATEST.md
@@ -1,16 +1,7 @@
-## [3.10.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.9.0...@rudderstack/analytics-js-plugins@3.10.0) (2025-06-11)
+## [3.10.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.10.0...@rudderstack/analytics-js-plugins@3.10.1) (2025-06-12)
 
-### Dependency Updates
 
-* `@rudderstack/analytics-js-common` updated to version `3.20.0`
-* `@rudderstack/analytics-js-cookies` updated to version `0.4.26`
+### Bug Fixes
 
-### Features
-
-* add support to dynamically override destinations status ([#2266](https://github.com/rudderlabs/rudder-sdk-js/issues/2266)) ([5af2f22](https://github.com/rudderlabs/rudder-sdk-js/commit/5af2f22ebdcac4eb04d57ecb51efa427607bc849))
-* disable dmt for cloned destination ([#2277](https://github.com/rudderlabs/rudder-sdk-js/issues/2277)) ([6fed4f6](https://github.com/rudderlabs/rudder-sdk-js/commit/6fed4f6a7bf338e6040e2292e965acc06fa3c1a6))
-* dynamically clone destinations ([#2276](https://github.com/rudderlabs/rudder-sdk-js/issues/2276)) ([f136454](https://github.com/rudderlabs/rudder-sdk-js/commit/f1364541743b15d240ceed6d8f403c23b6984086))
-* enable destination config override ([#2267](https://github.com/rudderlabs/rudder-sdk-js/issues/2267)) ([c570106](https://github.com/rudderlabs/rudder-sdk-js/commit/c5701065133d3fbddcff9072950ce935ef69e38a))
-* enhance retry headers with RSA-prefixed naming ([#2279](https://github.com/rudderlabs/rudder-sdk-js/issues/2279)) ([c25b2bc](https://github.com/rudderlabs/rudder-sdk-js/commit/c25b2bc5bb4b5b41469065138eef88c2fa21a460))
-* set proper grouping hash for all errors ([#2246](https://github.com/rudderlabs/rudder-sdk-js/issues/2246)) ([430c497](https://github.com/rudderlabs/rudder-sdk-js/commit/430c49782b95bf3e8de1f6a62b442b363208a66b))
+* filter disable destinations ([#2286](https://github.com/rudderlabs/rudder-sdk-js/issues/2286)) ([7ca8398](https://github.com/rudderlabs/rudder-sdk-js/commit/7ca8398cb288360e1dca49c6266c04d58ce88e05))
 

--- a/packages/analytics-js-plugins/package.json
+++ b/packages/analytics-js-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-plugins",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "private": true,
   "description": "RudderStack JavaScript SDK plugins",
   "main": "dist/npm/modern/cjs/index.cjs",

--- a/packages/analytics-js-plugins/project.json
+++ b/packages/analytics-js-plugins/project.json
@@ -51,9 +51,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js-plugins@3.10.0",
-        "title": "@rudderstack/analytics-js-plugins@3.10.0",
-        "discussion-category": "@rudderstack/analytics-js-plugins@3.10.0",
+        "tag": "@rudderstack/analytics-js-plugins@3.10.1",
+        "title": "@rudderstack/analytics-js-plugins@3.10.1",
+        "discussion-category": "@rudderstack/analytics-js-plugins@3.10.1",
         "notesFile": "./packages/analytics-js-plugins/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
@@ -13,6 +13,7 @@ import {
   isDestinationSDKMounted,
   initializeDestination,
   applySourceConfigurationOverrides,
+  filterDisabledDestination,
 } from './utils';
 import { DEVICE_MODE_DESTINATIONS_PLUGIN, SCRIPT_LOAD_TIMEOUT_MS } from './constants';
 import { INTEGRATION_NOT_SUPPORTED_ERROR, INTEGRATION_SDK_LOAD_ERROR } from './logMessages';
@@ -60,7 +61,7 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
             state.loadOptions.value.sourceConfigurationOverride,
             logger,
           )
-        : configSupportedDestinations;
+        : filterDisabledDestination(configSupportedDestinations);
 
       // Filter destinations that are disabled through load or consent API options
       const destinationsToLoad = filterDestinations(

--- a/packages/analytics-js/CHANGELOG.md
+++ b/packages/analytics-js/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.20.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.20.0...@rudderstack/analytics-js@3.20.1) (2025-06-12)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js-plugins` updated to version `3.10.1`
 ## [3.20.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.19.0...@rudderstack/analytics-js@3.20.0) (2025-06-11)
 
 ### Dependency Updates

--- a/packages/analytics-js/CHANGELOG_LATEST.md
+++ b/packages/analytics-js/CHANGELOG_LATEST.md
@@ -1,16 +1,5 @@
-## [3.20.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.19.0...@rudderstack/analytics-js@3.20.0) (2025-06-11)
+## [3.20.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.20.0...@rudderstack/analytics-js@3.20.1) (2025-06-12)
 
 ### Dependency Updates
 
-* `@rudderstack/analytics-js-cookies` updated to version `0.4.26`
-* `@rudderstack/analytics-js-common` updated to version `3.20.0`
-* `@rudderstack/analytics-js-plugins` updated to version `3.10.0`
-
-### Features
-
-* add support to dynamically override destinations status ([#2266](https://github.com/rudderlabs/rudder-sdk-js/issues/2266)) ([5af2f22](https://github.com/rudderlabs/rudder-sdk-js/commit/5af2f22ebdcac4eb04d57ecb51efa427607bc849))
-* dynamically clone destinations ([#2276](https://github.com/rudderlabs/rudder-sdk-js/issues/2276)) ([f136454](https://github.com/rudderlabs/rudder-sdk-js/commit/f1364541743b15d240ceed6d8f403c23b6984086))
-* enable destination config override ([#2267](https://github.com/rudderlabs/rudder-sdk-js/issues/2267)) ([c570106](https://github.com/rudderlabs/rudder-sdk-js/commit/c5701065133d3fbddcff9072950ce935ef69e38a))
-* enhance retry headers with RSA-prefixed naming ([#2279](https://github.com/rudderlabs/rudder-sdk-js/issues/2279)) ([c25b2bc](https://github.com/rudderlabs/rudder-sdk-js/commit/c25b2bc5bb4b5b41469065138eef88c2fa21a460))
-* set proper grouping hash for all errors ([#2246](https://github.com/rudderlabs/rudder-sdk-js/issues/2246)) ([430c497](https://github.com/rudderlabs/rudder-sdk-js/commit/430c49782b95bf3e8de1f6a62b442b363208a66b))
-
+* `@rudderstack/analytics-js-plugins` updated to version `3.10.1`

--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "description": "RudderStack JavaScript SDK",
   "main": "dist/npm/modern/cjs/index.cjs",
   "module": "dist/npm/modern/esm/index.mjs",

--- a/packages/analytics-js/project.json
+++ b/packages/analytics-js/project.json
@@ -52,9 +52,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js@3.20.0",
-        "title": "@rudderstack/analytics-js@3.20.0",
-        "discussion-category": "@rudderstack/analytics-js@3.20.0",
+        "tag": "@rudderstack/analytics-js@3.20.1",
+        "title": "@rudderstack/analytics-js@3.20.1",
+        "discussion-category": "@rudderstack/analytics-js@3.20.1",
         "notesFile": "./packages/analytics-js/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/sanity-suite/CHANGELOG.md
+++ b/packages/sanity-suite/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.2.14](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-sanity-suite@3.2.13...@rudderstack/analytics-js-sanity-suite@3.2.14) (2025-06-12)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js` updated to version `3.20.1`
 ## [3.2.13](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-sanity-suite@3.2.12...@rudderstack/analytics-js-sanity-suite@3.2.13) (2025-06-11)
 
 ### Dependency Updates

--- a/packages/sanity-suite/__fixtures__/sourceConfig1.json
+++ b/packages/sanity-suite/__fixtures__/sourceConfig1.json
@@ -382,7 +382,9 @@
                 }
               ]
             }
-          ]
+          ],
+          "sdkBaseUrl": "https://www.googletagmanager.com",
+          "serverContainerUrl": ""
         },
         "destinationDefinitionId": "1mQ0yXGAQM08MTdVxws7ENIPjYS",
         "destinationDefinition": {

--- a/packages/sanity-suite/package.json
+++ b/packages/sanity-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-sanity-suite",
-  "version": "3.2.13",
+  "version": "3.2.14",
   "private": true,
   "description": "Sanity suite for testing JS SDK package",
   "main": "./dist/v3/cdn/testBook.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_repo_rudder-sdk-js
 sonar.organization=rudderlabs
 sonar.projectName=rudder-sdk-js
-sonar.projectVersion=3.88.0
+sonar.projectVersion=3.89.0
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-js


### PR DESCRIPTION
:crown: **Automated Release PR**

This pull request was created automatically by the GitHub Actions workflow. It merges the release branch (`hotfix-release/3.89.0-SDK-3414`) into the `main` branch.

This ensures that the latest release branch changes are incorporated into the `main` branch for production.

### Details
- **Release Version**: v3.89.0
- **Release Branch**: `hotfix-release/3.89.0-SDK-3414`
- **Related Ticket**: [SDK-3414](https://linear.app/rudderstack/issue/SDK-3414)

### Version updates

| Package | New version |
|---------|-------------|
| @rudderstack/analytics-js-monorepo | 3.89.0 |
| @rudderstack/analytics-js-common | N/A |
| @rudderstack/analytics-js-cookies | N/A |
| @rudderstack/analytics-js-integrations | N/A |
| @rudderstack/analytics-js-plugins | 3.10.1 |
| @rudderstack/analytics-js-service-worker | N/A |
| @rudderstack/analytics-js | 3.20.1 |
| rudder-sdk-js | N/A |
| @rudderstack/analytics-js-loading-scripts | N/A |
| @rudderstack/analytics-js-sanity-suite | 3.2.14 |

---
Please review and merge when ready. :rocket:
