### PR TITLE
fix: validate integration

### DIFF
--- a/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
@@ -1261,6 +1261,26 @@ describe('DeviceModeDestinations Plugin', () => {
       );
     });
 
+    it('should not add custom integration when it is not in the expected format', () => {
+      const integrationName = 'TestIntegration';
+
+      const mockIntegration = {
+        track: jest.fn(),
+      };
+
+      plugin.nativeDestinations.addCustomIntegration(
+        integrationName,
+        mockIntegration,
+        mockState,
+        mockLogger,
+      );
+
+      expect(mockState.nativeDestinations.activeDestinations.value).toHaveLength(0);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        `DeviceModeDestinationsPlugin:: The custom integration "${integrationName}" does not match the expected format.`,
+      );
+    });
+
     it('should create destination with correct properties', () => {
       const integrationName = 'TestIntegration';
 

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
@@ -16,7 +16,7 @@ import {
   applySourceConfigurationOverrides,
   filterDisabledDestinations,
   createCustomIntegrationDestination,
-  validateCustomIntegrationName,
+  validateCustomIntegration,
 } from './utils';
 import { DEVICE_MODE_DESTINATIONS_PLUGIN, SCRIPT_LOAD_TIMEOUT_MS } from './constants';
 import { INTEGRATION_NOT_SUPPORTED_ERROR, INTEGRATION_SDK_LOAD_ERROR } from './logMessages';
@@ -39,7 +39,7 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
       state: ApplicationState,
       logger: ILogger,
     ): void {
-      if (!validateCustomIntegrationName(name, state, logger)) {
+      if (!validateCustomIntegration(name, integration, state, logger)) {
         return;
       }
 

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/logMessages.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/logMessages.ts
@@ -24,6 +24,9 @@ const CUSTOM_INTEGRATION_INVALID_NAME_ERROR = (context: string, name: string): s
 const CUSTOM_INTEGRATION_ALREADY_EXISTS_ERROR = (context: string, name: string): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}An integration with name "${name}" already exists.`;
 
+const INVALID_CUSTOM_INTEGRATION_ERROR = (context: string, name: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The custom integration "${name}" does not match the expected format.`;
+
 export {
   INTEGRATION_NOT_SUPPORTED_ERROR,
   INTEGRATION_SDK_LOAD_ERROR,
@@ -33,4 +36,5 @@ export {
   INTEGRATION_READY_CHECK_ERROR,
   CUSTOM_INTEGRATION_INVALID_NAME_ERROR,
   CUSTOM_INTEGRATION_ALREADY_EXISTS_ERROR,
+  INVALID_CUSTOM_INTEGRATION_ERROR,
 };

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
@@ -23,6 +23,8 @@ import type {
 } from '@rudderstack/analytics-js-common/types/LoadOptions';
 import {
   isBoolean,
+  isDefined,
+  isNullOrUndefined,
   isString,
   isUndefined,
 } from '@rudderstack/analytics-js-common/utilities/checks';
@@ -41,6 +43,7 @@ import {
   INTEGRATION_READY_CHECK_ERROR,
   CUSTOM_INTEGRATION_INVALID_NAME_ERROR,
   CUSTOM_INTEGRATION_ALREADY_EXISTS_ERROR,
+  INVALID_CUSTOM_INTEGRATION_ERROR,
 } from './logMessages';
 import { isHybridModeDestination } from '../shared-chunks/deviceModeDestinations';
 import { getSanitizedValue, isFunction } from '../shared-chunks/common';
@@ -335,12 +338,14 @@ const applyOverrideToDestination = (
 /**
  * Validates if a custom integration name is unique and not conflicting with existing destinations
  * @param name - The integration name to validate
+ * @param integration - The custom integration instance
  * @param state - Application state
  * @param logger - Logger instance
  * @returns boolean indicating if the name is valid
  */
-const validateCustomIntegrationName = (
+const validateCustomIntegration = (
   name: string,
+  integration: RSACustomIntegration,
   state: ApplicationState,
   logger: ILogger,
 ): boolean => {
@@ -358,6 +363,21 @@ const validateCustomIntegrationName = (
     initializedDestinations.some(dest => dest.displayName === name)
   ) {
     logger.error(CUSTOM_INTEGRATION_ALREADY_EXISTS_ERROR(DEVICE_MODE_DESTINATIONS_PLUGIN, name));
+    return false;
+  }
+
+  // Check if the integration is correctly implemented
+  if (
+    isNullOrUndefined(integration) ||
+    !isFunction(integration.isReady) ||
+    (isDefined(integration.init) && !isFunction(integration.init)) ||
+    (isDefined(integration.track) && !isFunction(integration.track)) ||
+    (isDefined(integration.page) && !isFunction(integration.page)) ||
+    (isDefined(integration.identify) && !isFunction(integration.identify)) ||
+    (isDefined(integration.group) && !isFunction(integration.group)) ||
+    (isDefined(integration.alias) && !isFunction(integration.alias))
+  ) {
+    logger.error(INVALID_CUSTOM_INTEGRATION_ERROR(DEVICE_MODE_DESTINATIONS_PLUGIN, name));
     return false;
   }
 
@@ -450,6 +470,6 @@ export {
   applySourceConfigurationOverrides,
   applyOverrideToDestination,
   filterDisabledDestinations,
-  validateCustomIntegrationName,
+  validateCustomIntegration,
   createCustomIntegrationDestination,
 };


### PR DESCRIPTION
## PR Description

Added validation for integration implementation.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3408/lifecycle-management-and-error-handling

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation for adding custom integrations, ensuring both the integration name and object structure are correct before activation.
  * Improved error messaging for invalid custom integrations, providing clearer feedback when integrations do not meet expected requirements.

* **Tests**
  * Expanded and updated test coverage to include comprehensive checks for both integration names and object structure validation, ensuring robust error handling and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->