### PR TITLE
fix: integration name validation

### DIFF
--- a/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../src/shared-chunks/deviceModeDestinations', () => ({
     'Google Analytics 4 (GA4)': 'GA4',
     'Google Analytics': 'GoogleAnalytics',
     Amplitude: 'Amplitude',
+    VWO: 'VWO',
   },
   filterDestinations: jest.fn((integrations, destinations) => destinations),
   isHybridModeDestination: jest.fn(() => false),
@@ -1173,8 +1174,6 @@ describe('DeviceModeDestinations Plugin', () => {
 
     beforeEach(() => {
       mockState.nativeDestinations.activeDestinations.value = [];
-      mockState.nativeDestinations.configuredDestinations.value = [];
-      mockState.nativeDestinations.initializedDestinations.value = [];
     });
 
     it('should add custom integration to active destinations when validation passes', () => {
@@ -1223,11 +1222,8 @@ describe('DeviceModeDestinations Plugin', () => {
       );
     });
 
-    it('should not add custom integration when name conflicts with configured destination', () => {
-      const conflictingName = 'GA4';
-      mockState.nativeDestinations.configuredDestinations.value = [
-        { displayName: conflictingName } as Destination,
-      ];
+    it('should not add custom integration when name conflicts with supported destination', () => {
+      const conflictingName = 'VWO';
 
       plugin.nativeDestinations.addCustomIntegration(
         conflictingName,
@@ -1242,9 +1238,9 @@ describe('DeviceModeDestinations Plugin', () => {
       );
     });
 
-    it('should not add custom integration when name conflicts with initialized destination', () => {
-      const conflictingName = 'GoogleAnalytics';
-      mockState.nativeDestinations.initializedDestinations.value = [
+    it('should not add custom integration when name conflicts with already added custom destination', () => {
+      const conflictingName = 'Custom Integration 1';
+      mockState.nativeDestinations.activeDestinations.value = [
         { displayName: conflictingName } as Destination,
       ];
 
@@ -1255,7 +1251,9 @@ describe('DeviceModeDestinations Plugin', () => {
         mockLogger,
       );
 
-      expect(mockState.nativeDestinations.activeDestinations.value).toHaveLength(0);
+      expect(mockState.nativeDestinations.activeDestinations.value).toEqual([
+        { displayName: conflictingName } as Destination,
+      ]);
       expect(mockLogger.error).toHaveBeenCalledWith(
         `DeviceModeDestinationsPlugin:: An integration with name "${conflictingName}" already exists.`,
       );

--- a/packages/analytics-js-plugins/__tests__/deviceModeDestinations/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeDestinations/utils.test.ts
@@ -1142,6 +1142,7 @@ describe('deviceModeDestinations utils', () => {
       expect(result).toEqual([]);
     });
   });
+
   describe('getCumulativeIntegrationsConfig', () => {
     it('should return the cumulative integrations config', () => {
       const destination = {
@@ -1549,15 +1550,31 @@ describe('deviceModeDestinations utils', () => {
     });
 
     describe('name conflict validation', () => {
-      it('should return false when name conflicts with configured destination', () => {
-        const conflictingName = 'ExistingDestination';
+      it('should return false when name conflicts with supported destinations', () => {
+        const conflictingName = 'Google Analytics 4 (GA4)';
 
-        // Mock existing configured destination
-        state.nativeDestinations.configuredDestinations.value = [
+        const result = validateCustomIntegration(
+          conflictingName,
+          mockValidIntegration,
+          state,
+          defaultLogger,
+        );
+
+        expect(result).toBe(false);
+        expect(defaultLogger.error).toHaveBeenCalledWith(
+          'DeviceModeDestinationsPlugin:: An integration with name "Google Analytics 4 (GA4)" already exists.',
+        );
+      });
+
+      it('should return false when name conflicts with active destination', () => {
+        const conflictingName = 'Custom Integration 1';
+
+        // Mock existing active destination (not initialized)
+        state.nativeDestinations.activeDestinations.value = [
           {
-            displayName: 'ExistingDestination',
-            id: 'existing_123',
-            userFriendlyId: 'existing_123',
+            displayName: 'Custom Integration 1',
+            id: 'custom_integration_1',
+            userFriendlyId: 'custom_integration_1',
             enabled: true,
           } as any,
         ];
@@ -1571,48 +1588,18 @@ describe('deviceModeDestinations utils', () => {
 
         expect(result).toBe(false);
         expect(defaultLogger.error).toHaveBeenCalledWith(
-          'DeviceModeDestinationsPlugin:: An integration with name "ExistingDestination" already exists.',
+          'DeviceModeDestinationsPlugin:: An integration with name "Custom Integration 1" already exists.',
         );
       });
 
-      it('should return false when name conflicts with initialized destination', () => {
-        const conflictingName = 'InitializedDestination';
-
-        // Mock existing initialized destination
-        state.nativeDestinations.initializedDestinations.value = [
-          {
-            displayName: 'InitializedDestination',
-            id: 'initialized_123',
-            userFriendlyId: 'initialized_123',
-            enabled: true,
-          } as any,
-        ];
-
-        const result = validateCustomIntegration(
-          conflictingName,
-          mockValidIntegration,
-          state,
-          defaultLogger,
-        );
-
-        expect(result).toBe(false);
-        expect(defaultLogger.error).toHaveBeenCalledWith(
-          'DeviceModeDestinationsPlugin:: An integration with name "InitializedDestination" already exists.',
-        );
-      });
-
-      it('should return true when name does not conflict with existing destinations', () => {
+      it('should return true when name does not conflict with any destinations', () => {
         const uniqueName = 'UniqueCustomIntegration';
 
-        // Mock existing destinations with different names
-        state.nativeDestinations.configuredDestinations.value = [
-          { displayName: 'GA4', id: 'ga4_123', userFriendlyId: 'ga4_123', enabled: true } as any,
-        ];
-        state.nativeDestinations.initializedDestinations.value = [
+        state.nativeDestinations.activeDestinations.value = [
           {
-            displayName: 'Amplitude',
-            id: 'amp_123',
-            userFriendlyId: 'amp_123',
+            displayName: 'Custom Integration 1',
+            id: 'custom_integration_1',
+            userFriendlyId: 'custom_integration_1',
             enabled: true,
           } as any,
         ];
@@ -1632,8 +1619,7 @@ describe('deviceModeDestinations utils', () => {
         const validName = 'CustomIntegration';
 
         // Ensure arrays are empty
-        state.nativeDestinations.configuredDestinations.value = [];
-        state.nativeDestinations.initializedDestinations.value = [];
+        state.nativeDestinations.activeDestinations.value = [];
 
         const result = validateCustomIntegration(
           validName,
@@ -1650,8 +1636,7 @@ describe('deviceModeDestinations utils', () => {
         const validName = 'CustomIntegration';
 
         // Set arrays to null
-        state.nativeDestinations.configuredDestinations.value = null as any;
-        state.nativeDestinations.initializedDestinations.value = null as any;
+        state.nativeDestinations.activeDestinations.value = null as any;
 
         const result = validateCustomIntegration(
           validName,
@@ -1660,6 +1645,77 @@ describe('deviceModeDestinations utils', () => {
           defaultLogger,
         );
 
+        expect(result).toBe(true);
+        expect(defaultLogger.error).not.toHaveBeenCalled();
+      });
+
+      it('should handle case sensitivity in name conflicts', () => {
+        const conflictingName = 'custom integration 1';
+
+        // Mock existing destination with different case
+        state.nativeDestinations.activeDestinations.value = [
+          {
+            displayName: 'Custom Integration 1',
+            id: 'custom_integration_1',
+            userFriendlyId: 'custom_integration_1',
+            enabled: true,
+          } as any,
+        ];
+
+        const result = validateCustomIntegration(
+          conflictingName,
+          mockValidIntegration,
+          state,
+          defaultLogger,
+        );
+
+        // Should pass since JavaScript string comparison is case-sensitive
+        expect(result).toBe(true);
+        expect(defaultLogger.error).not.toHaveBeenCalled();
+      });
+
+      it('should return false when name conflicts with additional supported destinations', () => {
+        // Test with more built-in destination names to ensure comprehensive coverage
+        const additionalTestCases = [
+          'HubSpot',
+          'Hotjar',
+          'Facebook Pixel',
+          'Intercom',
+          'Mixpanel',
+          'PostHog',
+        ];
+
+        additionalTestCases.forEach(destinationName => {
+          jest.clearAllMocks();
+
+          const result = validateCustomIntegration(
+            destinationName,
+            mockValidIntegration,
+            state,
+            defaultLogger,
+          );
+
+          expect(result).toBe(false);
+          expect(defaultLogger.error).toHaveBeenCalledWith(
+            `DeviceModeDestinationsPlugin:: An integration with name "${destinationName}" already exists.`,
+          );
+        });
+      });
+
+      it('should be case-sensitive when checking built-in destination names', () => {
+        const modifiedName = 'google analytics 4 (ga4)'; // lowercase version
+
+        // Ensure no existing destinations
+        state.nativeDestinations.activeDestinations.value = [];
+
+        const result = validateCustomIntegration(
+          modifiedName,
+          mockValidIntegration,
+          state,
+          defaultLogger,
+        );
+
+        // Should pass since the exact case doesn't match the built-in destination
         expect(result).toBe(true);
         expect(defaultLogger.error).not.toHaveBeenCalled();
       });

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
@@ -45,7 +45,10 @@ import {
   CUSTOM_INTEGRATION_ALREADY_EXISTS_ERROR,
   INVALID_CUSTOM_INTEGRATION_ERROR,
 } from './logMessages';
-import { isHybridModeDestination } from '../shared-chunks/deviceModeDestinations';
+import {
+  destDisplayNamesToFileNamesMap,
+  isHybridModeDestination,
+} from '../shared-chunks/deviceModeDestinations';
 import { getSanitizedValue, isFunction } from '../shared-chunks/common';
 
 /**
@@ -355,12 +358,11 @@ const validateCustomIntegration = (
   }
 
   // Check against existing configured destinations
-  const configuredDestinations = state.nativeDestinations.configuredDestinations.value || [];
-  const initializedDestinations = state.nativeDestinations.initializedDestinations.value || [];
+  const activeDestinations = state.nativeDestinations.activeDestinations.value || [];
 
   if (
-    configuredDestinations.some(dest => dest.displayName === name) ||
-    initializedDestinations.some(dest => dest.displayName === name)
+    isDefined(destDisplayNamesToFileNamesMap[name]) ||
+    activeDestinations.some(dest => dest.displayName === name)
   ) {
     logger.error(CUSTOM_INTEGRATION_ALREADY_EXISTS_ERROR(DEVICE_MODE_DESTINATIONS_PLUGIN, name));
     return false;


### PR DESCRIPTION
## PR Description

I have fixed two issues in the custom integration name validation.
- Duplicate integration
- All supported integrations

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to check for name conflicts in active destinations and supported built-in destinations, rather than configured or initialized destinations.
  * Added new test cases for case sensitivity and a wider range of built-in destination names.
  * Improved error messages in test outputs for conflict validation.

* **Bug Fixes**
  * Enhanced conflict detection logic for custom integrations to prevent name clashes with both supported and active destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->