### PR TITLE
chore: remove optional dependencies configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
       npm-prod-deps:
         patterns:
           - "*"
-        excludes:
+        exclude-patterns:
           - "@nx/nx-*"
           - "@rollup/rollup-*"
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,41 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/" 
+    directory: "/"
     schedule:
       interval: "weekly"
     target-branch: "develop"
 
   - package-ecosystem: "npm"
-    directory: "/" 
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "00:00"
+      timezone: "UTC"
     target-branch: "develop"
     groups:
+      npm-dev-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        dependency-type: "development"
+      
       npm-prod-deps:
         patterns:
           - "*"
+        excludes:
+          - "@nx/nx-*"
+          - "@rollup/rollup-*"
         update-types:
           - "minor"
           - "patch"
         dependency-type: "production"
-      npm-dev-deps:
+
+      npm-major-deps:
         patterns:
           - "*"
-        dependency-type: "development"
         update-types:
-          - "minor"
-          - "patch"
+          - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "00:00"
-      timezone: "UTC"
+      interval: "cron"
+      # every wednesday at 00:01
+      cronjob: "1 0 * * 3"
     target-branch: "develop"
+    labels:
+      - "dependencies"
     groups:
       npm-dev-deps:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,13 @@
         "tslib": "2.8.1",
         "typescript": "5.8.3",
         "user-agent-data-types": "0.4.2"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "21.2.2",
+        "@nx/nx-darwin-x64": "21.2.2",
+        "@nx/nx-linux-x64-gnu": "21.2.2",
+        "@nx/nx-win32-x64-msvc": "21.2.2",
+        "@rollup/rollup-linux-x64-gnu": "4.44.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5523,11 +5530,49 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@nx/nx-darwin-x64": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-21.2.2.tgz",
+      "integrity": "sha512-gdxOcfGonAD+eM5oKKd+2rcrGWmJOfON5HJpLkDfgOO/vyb6FUQub3xUu/JB2RAJ4r6iW/8JZxzheFDIiHDEug==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-21.2.2.tgz",
+      "integrity": "sha512-je6D2kG8jCB72QVrYRXs4xRrU2g2zQREqODt+s1zI2lWlMDJcBwxDxGtlxXM3mDyeUGCh2s9nlkrA0GCTin1LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-21.2.2.tgz",
+      "integrity": "sha512-qBrVdqYVRV1KQFyRtQbtic/R5ByH9F0kZJoQM3hSmcHgbg2s2+v9ivnaik4L6iX8FbAoCjYYm+J8L42yuOgCJA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@nx/workspace": {
@@ -5948,6 +5993,19 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.44.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.2.tgz",
+      "integrity": "sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@rtsao/scc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,13 +140,6 @@
         "tslib": "2.8.1",
         "typescript": "5.8.3",
         "user-agent-data-types": "0.4.2"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "21.2.2",
-        "@nx/nx-darwin-x64": "21.2.2",
-        "@nx/nx-linux-x64-gnu": "21.2.2",
-        "@nx/nx-win32-x64-msvc": "21.2.2",
-        "@rollup/rollup-linux-x64-gnu": "4.44.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -586,7 +579,7 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.27.1",
+      "version": "7.28.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1589,11 +1582,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.27.1",
+      "version": "7.28.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-create-class-features-plugin": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
@@ -2491,16 +2484,16 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.2",
+        "@emnapi/wasi-threads": "1.0.3",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2508,7 +2501,7 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2707,11 +2700,11 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -2719,7 +2712,7 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2799,11 +2792,11 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.12",
+      "version": "5.1.13",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.13",
+        "@inquirer/core": "^10.1.14",
         "@inquirer/type": "^3.0.7"
       },
       "engines": {
@@ -2819,7 +2812,7 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.13",
+      "version": "10.1.14",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4740,7 +4733,7 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
+      "version": "0.3.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4749,7 +4742,7 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
+      "version": "1.5.4",
       "dev": true,
       "license": "MIT"
     },
@@ -5321,17 +5314,6 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/@nx/eslint-plugin/node_modules/globals": {
-      "version": "15.15.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@nx/eslint-plugin/node_modules/semver": {
       "version": "7.7.2",
       "dev": true,
@@ -5541,49 +5523,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@nx/nx-darwin-x64": {
-      "version": "21.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-21.2.2.tgz",
-      "integrity": "sha512-gdxOcfGonAD+eM5oKKd+2rcrGWmJOfON5HJpLkDfgOO/vyb6FUQub3xUu/JB2RAJ4r6iW/8JZxzheFDIiHDEug==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "21.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-21.2.2.tgz",
-      "integrity": "sha512-je6D2kG8jCB72QVrYRXs4xRrU2g2zQREqODt+s1zI2lWlMDJcBwxDxGtlxXM3mDyeUGCh2s9nlkrA0GCTin1LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "21.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-21.2.2.tgz",
-      "integrity": "sha512-qBrVdqYVRV1KQFyRtQbtic/R5ByH9F0kZJoQM3hSmcHgbg2s2+v9ivnaik4L6iX8FbAoCjYYm+J8L42yuOgCJA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@nx/workspace": {
@@ -6004,19 +5948,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.2.tgz",
-      "integrity": "sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -6802,6 +6733,50 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.35.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.35.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.5",
       "dev": true,
@@ -6885,12 +6860,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -6904,6 +6879,132 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/project-service": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.36.0",
+        "@typescript-eslint/types": "^8.36.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.36.0",
+        "@typescript-eslint/tsconfig-utils": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.36.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
+      "version": "9.0.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -6971,14 +7072,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1"
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/typescript-estree": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6990,6 +7091,148 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/project-service": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.36.0",
+        "@typescript-eslint/types": "^8.36.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.36.0",
+        "@typescript-eslint/tsconfig-utils": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.36.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.36.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+      "version": "9.0.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -7025,7 +7268,7 @@
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.9.2",
+      "version": "1.11.0",
       "cpu": [
         "arm64"
       ],
@@ -7366,7 +7609,7 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
+      "version": "7.1.4",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8274,7 +8517,7 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
+      "version": "4.25.1",
       "dev": true,
       "funding": [
         {
@@ -8292,8 +8535,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -8537,7 +8780,7 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001724",
+      "version": "1.0.30001727",
       "dev": true,
       "funding": [
         {
@@ -8699,7 +8942,7 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.2.0",
+      "version": "4.3.0",
       "dev": true,
       "funding": [
         {
@@ -9493,11 +9736,11 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.43.0",
+      "version": "3.44.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.25.0"
+        "browserslist": "^4.25.1"
       },
       "funding": {
         "type": "opencollective",
@@ -10280,7 +10523,7 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.173",
+      "version": "1.5.180",
       "dev": true,
       "license": "ISC"
     },
@@ -10659,12 +10902,12 @@
       }
     },
     "node_modules/eslint-import-context": {
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-tsconfig": "^4.10.1",
-        "stable-hash-x": "^0.1.1"
+        "stable-hash-x": "^0.2.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -10732,14 +10975,6 @@
         }
       }
     },
-    "node_modules/eslint-import-resolver-typescript/node_modules/stable-hash-x": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/eslint-module-utils": {
       "version": "2.12.1",
       "dev": true,
@@ -10795,17 +11030,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/globals": {
-      "version": "15.15.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11012,7 +11236,7 @@
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/globals": {
-      "version": "16.2.0",
+      "version": "16.3.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11970,18 +12194,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -12327,6 +12539,17 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -19512,7 +19735,7 @@
       }
     },
     "node_modules/napi-postinstall": {
-      "version": "0.2.4",
+      "version": "0.3.0",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -20108,18 +20331,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/nx/node_modules/@nx/nx-darwin-arm64": {
-      "version": "21.2.2",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
     },
     "node_modules/nx/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -23497,7 +23708,7 @@
       }
     },
     "node_modules/stable-hash-x": {
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -24716,36 +24927,36 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.9.2",
+      "version": "1.11.0",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.2.4"
+        "napi-postinstall": "^0.3.0"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.9.2",
-        "@unrs/resolver-binding-android-arm64": "1.9.2",
-        "@unrs/resolver-binding-darwin-arm64": "1.9.2",
-        "@unrs/resolver-binding-darwin-x64": "1.9.2",
-        "@unrs/resolver-binding-freebsd-x64": "1.9.2",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.9.2",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.9.2",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.9.2",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.9.2",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-x64-musl": "1.9.2",
-        "@unrs/resolver-binding-wasm32-wasi": "1.9.2",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.9.2",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.9.2",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.9.2"
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.0",
+        "@unrs/resolver-binding-android-arm64": "1.11.0",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.0",
+        "@unrs/resolver-binding-darwin-x64": "1.11.0",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.0",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.0",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.0",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.0",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.0",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.0",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.0",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.0",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.0",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   ],
   "scripts": {
     "setup": "npm i --include=optional && npm run build:package:modern",
-    "setup:ci": "npm ci && npm i @nx/nx-linux-x64-gnu && npm run build:package:modern",
-    "setup:deps": "npm ci && npm i @nx/nx-linux-x64-gnu",
+    "setup:ci": "npm ci && npm run build:package:modern",
+    "setup:deps": "npm ci",
     "clean": "nx run-many -t clean && nx reset && git clean -xdf node_modules",
     "clean:cache": "rimraf -rf ./node_modules/.cache && rimraf -rf ./.nx/cache",
     "start": "nx run-many --targets=start --parallel=3 --projects=@rudderstack/analytics-js-integrations,@rudderstack/analytics-js-plugins,@rudderstack/analytics-js",
@@ -197,13 +197,6 @@
     "tslib": "2.8.1",
     "typescript": "5.8.3",
     "user-agent-data-types": "0.4.2"
-  },
-  "optionalDependencies": {
-    "@nx/nx-darwin-arm64": "21.2.2",
-    "@nx/nx-darwin-x64": "21.2.2",
-    "@nx/nx-linux-x64-gnu": "21.2.2",
-    "@nx/nx-win32-x64-msvc": "21.2.2",
-    "@rollup/rollup-linux-x64-gnu": "4.44.2"
   },
   "overrides": {
     "rudder-component-cookie": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   ],
   "scripts": {
     "setup": "npm i --include=optional && npm run build:package:modern",
-    "setup:ci": "npm ci && npm run build:package:modern",
-    "setup:deps": "npm ci",
+    "setup:ci": "npm run setup:deps && npm run build:package:modern",
+    "setup:deps": "npm ci --prefer-offline --no-audit",
     "clean": "nx run-many -t clean && nx reset && git clean -xdf node_modules",
     "clean:cache": "rimraf -rf ./node_modules/.cache && rimraf -rf ./.nx/cache",
     "start": "nx run-many --targets=start --parallel=3 --projects=@rudderstack/analytics-js-integrations,@rudderstack/analytics-js-plugins,@rudderstack/analytics-js",
@@ -197,6 +197,13 @@
     "tslib": "2.8.1",
     "typescript": "5.8.3",
     "user-agent-data-types": "0.4.2"
+  },
+  "optionalDependencies": {
+    "@nx/nx-darwin-arm64": "21.2.2",
+    "@nx/nx-darwin-x64": "21.2.2",
+    "@nx/nx-linux-x64-gnu": "21.2.2",
+    "@nx/nx-win32-x64-msvc": "21.2.2",
+    "@rollup/rollup-linux-x64-gnu": "4.44.2"
   },
   "overrides": {
     "rudder-component-cookie": {

--- a/patches/@mswjs+interceptors+0.39.2.patch
+++ b/patches/@mswjs+interceptors+0.39.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@mswjs/interceptors/lib/node/chunk-GLGFOTGJ.mjs b/node_modules/@mswjs/interceptors/lib/node/chunk-GLGFOTGJ.mjs
-index 0beca9e..dbcea95 100644
+index 0beca9e..3586c4b 100644
 --- a/node_modules/@mswjs/interceptors/lib/node/chunk-GLGFOTGJ.mjs
 +++ b/node_modules/@mswjs/interceptors/lib/node/chunk-GLGFOTGJ.mjs
 @@ -439,13 +439,6 @@ var MockHttpSocket = class extends MockSocket {
@@ -17,7 +17,7 @@ index 0beca9e..dbcea95 100644
        socket.destroy(error);
      });
 diff --git a/node_modules/@mswjs/interceptors/lib/node/chunk-ZAIODWHA.js b/node_modules/@mswjs/interceptors/lib/node/chunk-ZAIODWHA.js
-index e1125f0..2cfc456 100644
+index e1125f0..e6b0bf8 100644
 --- a/node_modules/@mswjs/interceptors/lib/node/chunk-ZAIODWHA.js
 +++ b/node_modules/@mswjs/interceptors/lib/node/chunk-ZAIODWHA.js
 @@ -439,13 +439,6 @@ var MockHttpSocket = class extends MockSocket {

--- a/patches/nx+21.2.2.patch
+++ b/patches/nx+21.2.2.patch
@@ -51,7 +51,7 @@ index f58f821..5660e84 100644
  }
  exports.StaticRunManyTerminalOutputLifeCycle = StaticRunManyTerminalOutputLifeCycle;
 diff --git a/node_modules/nx/src/tasks-runner/run-command.js b/node_modules/nx/src/tasks-runner/run-command.js
-index 0a3a2ea..aab4327 100644
+index 0a3a2ea..860408a 100644
 --- a/node_modules/nx/src/tasks-runner/run-command.js
 +++ b/node_modules/nx/src/tasks-runner/run-command.js
 @@ -689,7 +689,9 @@ async function invokeTasksRunner({ tasks, projectGraph, taskGraph, lifeCycle, nx
@@ -59,7 +59,7 @@ index 0a3a2ea..aab4327 100644
      const lifeCycles = [];
      lifeCycles.push(new store_run_information_life_cycle_1.StoreRunInformationLifeCycle());
 -    lifeCycles.push(new nx_cloud_ci_message_life_cycle_1.NxCloudCIMessageLifeCycle());
-+    if (lifeCycle.args.silent !== true) {
++    if (lifeCycle.args?.silent !== true) {
 +        lifeCycles.push(new nx_cloud_ci_message_life_cycle_1.NxCloudCIMessageLifeCycle());
 +    }
      lifeCycles.push(lifeCycle);


### PR DESCRIPTION
## PR Description

Updated dependabot config to not treat optional NPM dependencies as "prod". The schedule is fixed to every Wednesday.

I've also updated a couple of patch files and clean up NPM scripts.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update schedule and grouping for npm dependencies.
  * Improved configuration for automated dependency updates, including more granular control over major, minor, and patch updates.

* **New Features**
  * Added a hidden option to suppress most output for certain command-line tasks, enabling a silent mode for cleaner terminal output.

* **Bug Fixes**
  * Internal improvements to dependency patching and output handling for third-party tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->