### PR TITLE
feat: add custom events support in microsoft clarity

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/MicrosoftClarity/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/MicrosoftClarity/browser.test.js
@@ -1,0 +1,206 @@
+import MicrosoftClarity from '../../../src/integrations/MicrosoftClarity/browser';
+
+// Mock the nativeSdkLoader to prevent DOM manipulation during tests
+jest.mock('../../../src/integrations/MicrosoftClarity/nativeSdkLoader', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  loadNativeSdk: jest.fn(),
+}));
+
+// Mock the constants import
+jest.mock('@rudderstack/analytics-js-common/v1.1/utils/constants', () => ({
+  LOAD_ORIGIN: 'RS_JS_SDK',
+}));
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+const destinationInfo = {
+  areTransformationsConnected: false,
+  destinationId: 'sample-destination-id',
+};
+
+describe('MicrosoftClarity init tests', () => {
+  let clarityInstance;
+
+  test('Testing init call of MicrosoftClarity', () => {
+    clarityInstance = new MicrosoftClarity(
+      { projectId: 'test-project-id', cookieConsent: true },
+      { logLevel: 'debug' },
+      destinationInfo,
+    );
+    clarityInstance.init();
+    expect(clarityInstance.name).toBe('MICROSOFT_CLARITY');
+    expect(clarityInstance.projectId).toBe('test-project-id');
+    expect(clarityInstance.cookieConsent).toBe(true);
+  });
+});
+
+describe('MicrosoftClarity isLoaded tests', () => {
+  let clarityInstance;
+
+  beforeEach(() => {
+    clarityInstance = new MicrosoftClarity(
+      { projectId: 'test-project-id', cookieConsent: true },
+      { logLevel: 'debug' },
+      destinationInfo,
+    );
+  });
+
+  test('should return false when window.clarity is undefined', () => {
+    delete window.clarity;
+    expect(clarityInstance.isLoaded()).toBe(false);
+  });
+
+  test('should return false when window.clarity exists but has queue', () => {
+    window.clarity = { q: [] };
+    expect(clarityInstance.isLoaded()).toBe(false);
+  });
+
+  test('should return true when window.clarity exists without queue', () => {
+    window.clarity = jest.fn();
+    expect(clarityInstance.isLoaded()).toBe(true);
+  });
+});
+
+describe('MicrosoftClarity identify tests', () => {
+  let clarityInstance;
+
+  beforeEach(() => {
+    clarityInstance = new MicrosoftClarity(
+      { projectId: 'test-project-id', cookieConsent: true },
+      { logLevel: 'debug' },
+      destinationInfo,
+    );
+    window.clarity = jest.fn();
+  });
+
+  test('should call clarity identify with userId only', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {},
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+  });
+
+  test('should call clarity identify with userId and sessionId', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          sessionId: 'session-456',
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith(
+      'identify',
+      'test-user-123',
+      'session-456',
+      undefined,
+    );
+  });
+
+  test('should call clarity identify with userId, sessionId, and customPageId', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          sessionId: 'session-456',
+          traits: {
+            customPageId: 'page-789',
+            name: 'John Doe',
+            email: 'john@example.com',
+          },
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith(
+      'identify',
+      'test-user-123',
+      'session-456',
+      'page-789',
+    );
+    expect(window.clarity).toHaveBeenCalledWith('set', 'customPageId', 'page-789');
+    expect(window.clarity).toHaveBeenCalledWith('set', 'name', 'John Doe');
+    expect(window.clarity).toHaveBeenCalledWith('set', 'email', 'john@example.com');
+  });
+});
+
+describe('MicrosoftClarity track tests', () => {
+  let clarityInstance;
+
+  beforeEach(() => {
+    clarityInstance = new MicrosoftClarity(
+      { projectId: 'test-project-id', cookieConsent: true },
+      { logLevel: 'debug' },
+      destinationInfo,
+    );
+    window.clarity = jest.fn();
+  });
+
+  test('should call clarity event with valid event name', () => {
+    const rudderElement = {
+      message: {
+        event: 'Button Clicked',
+        properties: {
+          buttonId: 'submit-btn',
+          page: 'checkout',
+        },
+      },
+    };
+
+    clarityInstance.track(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('event', 'Button Clicked');
+  });
+
+  test('should not call clarity when event name is missing', () => {
+    const rudderElement = {
+      message: {},
+    };
+
+    clarityInstance.track(rudderElement);
+    expect(window.clarity).not.toHaveBeenCalled();
+  });
+
+  test('should not call clarity when event name is empty string', () => {
+    const rudderElement = {
+      message: {
+        event: '',
+      },
+    };
+
+    clarityInstance.track(rudderElement);
+    expect(window.clarity).not.toHaveBeenCalled();
+  });
+
+  test('should not call clarity when event name is only whitespace', () => {
+    const rudderElement = {
+      message: {
+        event: '   ',
+      },
+    };
+
+    clarityInstance.track(rudderElement);
+    expect(window.clarity).not.toHaveBeenCalled();
+  });
+
+  test('should not call clarity when event is not a string', () => {
+    const rudderElement = {
+      message: {
+        event: 123,
+      },
+    };
+
+    clarityInstance.track(rudderElement);
+    expect(window.clarity).not.toHaveBeenCalled();
+  });
+});

--- a/packages/analytics-js-integrations/__tests__/integrations/MicrosoftClarity/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/MicrosoftClarity/browser.test.js
@@ -223,6 +223,182 @@ describe('MicrosoftClarity identify tests', () => {
     expect(window.clarity).not.toHaveBeenCalled();
     loggerSpy.mockRestore();
   });
+
+  test('should call clarity identify without sessionId when context.sessionId is not provided', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          // no sessionId
+          traits: {
+            name: 'John Doe',
+          },
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+    expect(window.clarity).toHaveBeenCalledWith('set', 'name', 'John Doe');
+  });
+
+  test('should call clarity identify without sessionId when context.sessionId is null', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          sessionId: null,
+          traits: {
+            name: 'John Doe',
+          },
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+    expect(window.clarity).toHaveBeenCalledWith('set', 'name', 'John Doe');
+  });
+
+  test('should call clarity identify without customPageId when context.traits.customPageId is not provided', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          sessionId: 'session-456',
+          traits: {
+            // no customPageId
+            name: 'John Doe',
+            email: 'john@example.com',
+          },
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith(
+      'identify',
+      'test-user-123',
+      'session-456',
+      undefined,
+    );
+    expect(window.clarity).toHaveBeenCalledWith('set', 'name', 'John Doe');
+    expect(window.clarity).toHaveBeenCalledWith('set', 'email', 'john@example.com');
+  });
+
+  test('should call clarity identify without customPageId when context.traits.customPageId is null', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          sessionId: 'session-456',
+          traits: {
+            customPageId: null,
+            name: 'John Doe',
+          },
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith(
+      'identify',
+      'test-user-123',
+      'session-456',
+      undefined,
+    );
+    expect(window.clarity).toHaveBeenCalledWith('set', 'customPageId', null);
+    expect(window.clarity).toHaveBeenCalledWith('set', 'name', 'John Doe');
+  });
+
+  test('should call clarity identify without traits when context.traits is not provided', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          sessionId: 'session-456',
+          // no traits
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith(
+      'identify',
+      'test-user-123',
+      'session-456',
+      undefined,
+    );
+    expect(window.clarity).toHaveBeenCalledTimes(1); // Only called once for identify, no set calls
+  });
+
+  test('should call clarity identify without traits when context.traits is null', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          sessionId: 'session-456',
+          traits: null,
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith(
+      'identify',
+      'test-user-123',
+      'session-456',
+      undefined,
+    );
+    expect(window.clarity).toHaveBeenCalledTimes(1); // Only called once for identify, no set calls
+  });
+
+  test('should call clarity identify without traits when context.traits is empty object', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {
+          sessionId: 'session-456',
+          traits: {},
+        },
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith(
+      'identify',
+      'test-user-123',
+      'session-456',
+      undefined,
+    );
+    expect(window.clarity).toHaveBeenCalledTimes(1); // Only called once for identify, no set calls
+  });
+
+  test('should call clarity identify without context when context is not provided', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        // no context
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+    expect(window.clarity).toHaveBeenCalledTimes(1); // Only called once for identify, no set calls
+  });
+
+  test('should call clarity identify without context when context is null', () => {
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: null,
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+    expect(window.clarity).toHaveBeenCalledTimes(1); // Only called once for identify, no set calls
+  });
 });
 
 describe('MicrosoftClarity track tests', () => {

--- a/packages/analytics-js-integrations/__tests__/integrations/MicrosoftClarity/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/MicrosoftClarity/browser.test.js
@@ -399,6 +399,100 @@ describe('MicrosoftClarity identify tests', () => {
     expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
     expect(window.clarity).toHaveBeenCalledTimes(1); // Only called once for identify, no set calls
   });
+
+  test('should handle when clarity identify returns a promise and promise resolves', () => {
+    const mockPromise = Promise.resolve();
+    window.clarity = jest.fn().mockReturnValue(mockPromise);
+
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {},
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+  });
+
+  test('should handle when clarity identify returns a promise and promise rejects', async () => {
+    const mockError = new Error('Clarity API error');
+    const mockPromise = Promise.reject(mockError);
+    window.clarity = jest.fn().mockReturnValue(mockPromise);
+
+    const loggerSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {},
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+
+    // Wait for the promise to be processed
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    loggerSpy.mockRestore();
+  });
+
+  test('should handle when clarity identify returns undefined (not a promise)', () => {
+    window.clarity = jest.fn().mockReturnValue(undefined);
+
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {},
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+  });
+
+  test('should handle when clarity identify returns null (not a promise)', () => {
+    window.clarity = jest.fn().mockReturnValue(null);
+
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {},
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+  });
+
+  test('should handle when clarity identify returns an object without then method', () => {
+    window.clarity = jest.fn().mockReturnValue({ someProperty: 'value' });
+
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {},
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+  });
+
+  test('should handle when clarity identify returns an object with then property that is not a function', () => {
+    window.clarity = jest.fn().mockReturnValue({ then: 'not-a-function' });
+
+    const rudderElement = {
+      message: {
+        userId: 'test-user-123',
+        context: {},
+      },
+    };
+
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).toHaveBeenCalledWith('identify', 'test-user-123', undefined, undefined);
+  });
 });
 
 describe('MicrosoftClarity track tests', () => {

--- a/packages/analytics-js-integrations/__tests__/integrations/MicrosoftClarity/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/MicrosoftClarity/browser.test.js
@@ -64,6 +64,33 @@ describe('MicrosoftClarity isLoaded tests', () => {
   });
 });
 
+describe('MicrosoftClarity isReady tests', () => {
+  let clarityInstance;
+
+  beforeEach(() => {
+    clarityInstance = new MicrosoftClarity(
+      { projectId: 'test-project-id', cookieConsent: true },
+      { logLevel: 'debug' },
+      destinationInfo,
+    );
+  });
+
+  test('should return false when window.clarity is undefined', () => {
+    delete window.clarity;
+    expect(clarityInstance.isReady()).toBe(false);
+  });
+
+  test('should return false when window.clarity exists but has queue', () => {
+    window.clarity = { q: [] };
+    expect(clarityInstance.isReady()).toBe(false);
+  });
+
+  test('should return true when window.clarity exists without queue', () => {
+    window.clarity = jest.fn();
+    expect(clarityInstance.isReady()).toBe(true);
+  });
+});
+
 describe('MicrosoftClarity identify tests', () => {
   let clarityInstance;
 
@@ -132,6 +159,69 @@ describe('MicrosoftClarity identify tests', () => {
     expect(window.clarity).toHaveBeenCalledWith('set', 'customPageId', 'page-789');
     expect(window.clarity).toHaveBeenCalledWith('set', 'name', 'John Doe');
     expect(window.clarity).toHaveBeenCalledWith('set', 'email', 'john@example.com');
+  });
+
+  test('should not call clarity when userId is missing', () => {
+    const rudderElement = {
+      message: {
+        context: {
+          sessionId: 'session-456',
+        },
+      },
+    };
+
+    const loggerSpy = jest.spyOn(console, 'error').mockImplementation();
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).not.toHaveBeenCalled();
+    loggerSpy.mockRestore();
+  });
+
+  test('should not call clarity when userId is undefined', () => {
+    const rudderElement = {
+      message: {
+        userId: undefined,
+        context: {
+          sessionId: 'session-456',
+        },
+      },
+    };
+
+    const loggerSpy = jest.spyOn(console, 'error').mockImplementation();
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).not.toHaveBeenCalled();
+    loggerSpy.mockRestore();
+  });
+
+  test('should not call clarity when userId is null', () => {
+    const rudderElement = {
+      message: {
+        userId: null,
+        context: {
+          sessionId: 'session-456',
+        },
+      },
+    };
+
+    const loggerSpy = jest.spyOn(console, 'error').mockImplementation();
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).not.toHaveBeenCalled();
+    loggerSpy.mockRestore();
+  });
+
+  test('should not call clarity when userId is empty string', () => {
+    const rudderElement = {
+      message: {
+        userId: '',
+        context: {
+          sessionId: 'session-456',
+        },
+      },
+    };
+
+    const loggerSpy = jest.spyOn(console, 'error').mockImplementation();
+    clarityInstance.identify(rudderElement);
+    expect(window.clarity).not.toHaveBeenCalled();
+    loggerSpy.mockRestore();
   });
 });
 

--- a/packages/analytics-js-integrations/src/integrations/MicrosoftClarity/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/MicrosoftClarity/browser.js
@@ -58,7 +58,8 @@ class MicrosoftClarity {
     }
 
     const identifyPromise = window.clarity('identify', userId, sessionId, customPageId);
-    if (typeof identifyPromise?.then === 'function') { // Clarity SDK is ready
+    if (typeof identifyPromise?.then === 'function') {
+      // Clarity SDK is ready
       identifyPromise.catch(error => {
         logger.error('The "identify" promise was rejected', error);
       });
@@ -70,6 +71,20 @@ class MicrosoftClarity {
         window.clarity('set', key, traits[key]);
       });
     }
+  }
+
+  track(rudderElement) {
+    const { message } = rudderElement;
+    const { event } = message;
+    if (!event || typeof event !== 'string' || event.trim() === '') {
+      logger.error('event name is required for track call');
+      return;
+    }
+
+    // Send the custom event to Microsoft Clarity
+    // https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-api#add-custom-events
+    // Note: Clarity custom events only support event names, not event properties
+    window.clarity('event', event);
   }
 }
 


### PR DESCRIPTION
## PR Description

This pull request  adds a new `track` method to handle [custom event tracking](https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-api#add-custom-events) anf introduces unit tests for the Microsoft Clarity integration. 

### Feature Addition:
* [`packages/analytics-js-integrations/src/integrations/MicrosoftClarity/browser.js`](diffhunk://#diff-c76e7ffc248064952588c00b09aaf1be60929267cf4894428e343e9156f1ce54R75-R88): Implemented a new `track` method to send custom events to Microsoft Clarity. This method ensures that only valid event names are sent and logs an error for invalid or missing event names.

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-3491/adding-conversion-events-integration-with-microsoft-clarity

Resolves INT-3491
## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking custom events with Microsoft Clarity integration.
* **Tests**
  * Introduced a comprehensive test suite covering initialization, event tracking, user identification, and integration loading behavior for Microsoft Clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->