### PR TITLE
chore: check for files existence in shell script

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -43,6 +43,7 @@ jobs:
 
   deploy-sanity-suite:
     name: Deploy sanity suite
+    if: github.event.pull_request.merged == true
     needs: [get-deploy-inputs]
     uses: ./.github/workflows/deploy-sanity-suite.yml
     with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -66,6 +66,7 @@ jobs:
   deploy-sanity-suite:
     name: Deploy sanity suite
     needs: [get-deploy-inputs]
+    if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true
     uses: ./.github/workflows/deploy-sanity-suite.yml
     with:
       environment: 'production'

--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -47,10 +47,12 @@ jobs:
           echo "affected_projects=$AFFECTED_PROJECTS" >> $GITHUB_OUTPUT
 
       - name: Execute unit tests
+        if: ${{ steps.check_affected.outputs.affected_projects != '' }}
         run: |
           npm run test:ci
 
       - name: Upload coverage reports to Codecov
+        if: ${{ steps.check_affected.outputs.affected_projects != '' }}
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -58,14 +60,17 @@ jobs:
           files: ./packages/analytics-js/reports/coverage/clover.xml,./packages/analytics-js-common/reports/coverage/clover.xml,./packages/analytics-js-integrations/reports/coverage/clover.xml,./packages/analytics-js-plugins/reports/coverage/clover.xml,./packages/analytics-js-service-worker/reports/coverage/clover.xml,./packages/analytics-v1.1/reports/coverage/clover.xml,./packages/analytics-js-cookies/reports/coverage/clover.xml
 
       - name: Execute linting check
+        if: ${{ steps.check_affected.outputs.affected_projects != '' }}
         run: |
           npm run check:lint:ci
 
       - name: Fix filesystem paths in generated reports
+        if: ${{ steps.check_affected.outputs.affected_projects != '' }}
         run: |
           ./scripts/fix-reports-path-in-github-runner.sh
 
       - name: SonarQube Scan
+        if: ${{ steps.check_affected.outputs.affected_projects != '' }}
         uses: SonarSource/sonarqube-scan-action@2500896589ef8f7247069a56136f8dc177c27ccf  # v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/fix-reports-path-in-github-runner.sh
+++ b/scripts/fix-reports-path-in-github-runner.sh
@@ -10,7 +10,19 @@ projectFolderNames=("analytics-js" "analytics-js-common" "analytics-js-integrati
 # List of files to alter
 for projectFolder in "${projectFolderNames[@]}"; do
   echo "Replacing $absolutePathPrefix for $projectFolder reports"
-  sed -i "s+$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/coverage/lcov.info"
-  sed -i "s+/$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/eslint.json"
-  sed -i "s+/$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/sonar/results-report.xml"
+  
+  # Check and process lcov.info file
+  if [ -f "packages/$projectFolder/reports/coverage/lcov.info" ]; then
+    sed -i "s+$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/coverage/lcov.info"
+  fi
+  
+  # Check and process eslint.json file
+  if [ -f "packages/$projectFolder/reports/eslint.json" ]; then
+    sed -i "s+/$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/eslint.json"
+  fi
+  
+  # Check and process sonar results-report.xml file
+  if [ -f "packages/$projectFolder/reports/sonar/results-report.xml" ]; then
+    sed -i "s+/$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/sonar/results-report.xml"
+  fi
 done

--- a/scripts/fix-reports-path-in-github-runner.sh
+++ b/scripts/fix-reports-path-in-github-runner.sh
@@ -11,18 +11,18 @@ projectFolderNames=("analytics-js" "analytics-js-common" "analytics-js-integrati
 for projectFolder in "${projectFolderNames[@]}"; do
   echo "Replacing $absolutePathPrefix for $projectFolder reports"
   
-  # Check and process lcov.info file
-  if [ -f "packages/$projectFolder/reports/coverage/lcov.info" ]; then
-    sed -i "s+$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/coverage/lcov.info"
-  fi
+  # Define report files to process with their sed patterns
+  declare -A reportFiles=(
+    ["reports/coverage/lcov.info"]="$absolutePathPrefix"
+    ["reports/eslint.json"]="/$absolutePathPrefix"
+    ["reports/sonar/results-report.xml"]="/$absolutePathPrefix"
+  )
   
-  # Check and process eslint.json file
-  if [ -f "packages/$projectFolder/reports/eslint.json" ]; then
-    sed -i "s+/$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/eslint.json"
-  fi
-  
-  # Check and process sonar results-report.xml file
-  if [ -f "packages/$projectFolder/reports/sonar/results-report.xml" ]; then
-    sed -i "s+/$absolutePathPrefix+$defaultPrefixToReplace+g" "packages/$projectFolder/reports/sonar/results-report.xml"
-  fi
+  # Process each report file
+  for reportFile in "${!reportFiles[@]}"; do
+    fullPath="packages/$projectFolder/$reportFile"
+    if [ -f "$fullPath" ]; then
+      sed -i "s+${reportFiles[$reportFile]}+$defaultPrefixToReplace+g" "$fullPath"
+    fi
+  done
 done

--- a/scripts/fix-reports-path-in-github-runner.sh
+++ b/scripts/fix-reports-path-in-github-runner.sh
@@ -23,6 +23,8 @@ for projectFolder in "${projectFolderNames[@]}"; do
     fullPath="packages/$projectFolder/$reportFile"
     if [ -f "$fullPath" ]; then
       sed -i "s+${reportFiles[$reportFile]}+$defaultPrefixToReplace+g" "$fullPath"
+    else
+      echo "Skipped: File $fullPath does not exist."
     fi
   done
 done


### PR DESCRIPTION
## PR Description

I've fixed an issue in the shell script where we have to ignore replacing the file paths in coverage reports if the files are missing.

As only the affected packages are run in the unit tests workflow, coverage reports for all the packages are not available always.

Similar clean up changes were made in other workflows too.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report file handling to prevent errors when certain files are missing during automated scripts.

* **Chores**
  * Enhanced automation workflow to skip unnecessary steps when no projects are affected, resulting in more efficient CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->