### PR TITLE
chore: mark sdk release as latest on github

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -135,7 +135,7 @@ jobs:
         id: mark_latest_release
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get the analytics-js package version from package.json
           ANALYTICS_JS_VERSION=$(jq -r '.version' packages/analytics-js/package.json)

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -131,6 +131,40 @@ jobs:
           # Restore working copy
           git checkout -- .nxignore
 
+      - name: Mark analytics-js as latest release
+        id: mark_latest_release
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          # Get the analytics-js package version from package.json
+          ANALYTICS_JS_VERSION=$(jq -r '.version' packages/analytics-js/package.json)
+          RELEASE_TAG="@rudderstack/analytics-js@${ANALYTICS_JS_VERSION}"
+          
+          echo "Looking for release: $RELEASE_TAG"
+          
+          # Wait for the release to be available and retry up to 10 times
+          for i in {1..10}; do
+            echo "Attempt $i: Checking if release $RELEASE_TAG exists..."
+            
+            if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
+              echo "Release found! Marking $RELEASE_TAG as latest..."
+              
+              if gh release edit "$RELEASE_TAG" --latest; then
+                echo "Successfully marked $RELEASE_TAG as the latest release"
+                exit 0
+              else
+                echo "Failed to mark release as latest, but release exists"
+                exit 1
+              fi
+            else
+              echo "Release $RELEASE_TAG not found yet, waiting 10 seconds..."
+              sleep 10
+            fi
+          done
+          
+          echo "ERROR: Release $RELEASE_TAG was not found after 10 attempts"
+
       - name: Create pull request into develop
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## PR Description

I've updated the workflow to mark the SDK release as the latest once all the packages are published.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
