### PR TITLE
fix: remove unnecessary bugsnag dependency in declaration files

### DIFF
--- a/packages/analytics-js-common/src/types/ErrorHandler.ts
+++ b/packages/analytics-js-common/src/types/ErrorHandler.ts
@@ -1,4 +1,4 @@
-import type { Event } from '@bugsnag/js';
+import type { Event as BugSnagEvent } from '@bugsnag/js';
 import type { ILogger } from './Logger';
 import type { IHttpClient } from './HttpClient';
 
@@ -22,7 +22,7 @@ export interface IErrorHandler {
 }
 
 export type ErrorState = {
-  severity: Event['severity'];
+  severity: BugSnagEvent['severity'];
   unhandled: boolean;
   severityReason: { type: string };
 };

--- a/packages/analytics-js-cookies/rollup.config.mjs
+++ b/packages/analytics-js-cookies/rollup.config.mjs
@@ -48,6 +48,14 @@ export function getDefaultConfig(distName) {
         preventAssignment: true,
         __PACKAGE_VERSION__: `'${version}'`,
       }),
+      alias({
+        entries: [
+          {
+            find: '@rudderstack/analytics-js-common',
+            replacement: path.resolve('../analytics-js-common/src'),
+          },
+        ],
+      }),
       resolve({
         jsnext: true,
         browser: true,

--- a/packages/analytics-js-service-worker/rollup.config.mjs
+++ b/packages/analytics-js-service-worker/rollup.config.mjs
@@ -49,6 +49,18 @@ export function getDefaultConfig(distName) {
         preventAssignment: true,
         __PACKAGE_VERSION__: `'${version}'`,
       }),
+      alias({
+        entries: [
+          {
+            find: '@rudderstack/analytics-js-service-worker',
+            replacement: path.resolve('../analytics-js-service-worker/src'),
+          },
+          {
+            find: '@rudderstack/analytics-js-common',
+            replacement: path.resolve('../analytics-js-common/src'),
+          },
+        ],
+      }),
       resolve({
         jsnext: true,
         browser: true,

--- a/packages/analytics-js/rollup.config.mjs
+++ b/packages/analytics-js/rollup.config.mjs
@@ -376,6 +376,30 @@ const buildEntries = () => {
     {
       input: `dist/dts/packages/analytics-js/src/index.d.ts`,
       plugins: [
+        alias({
+          entries: [
+            {
+              find: '@rudderstack/analytics-js',
+              replacement: path.resolve('./dist/dts/packages/analytics-js/src'),
+            },
+            {
+              find: '@rudderstack/analytics-js-plugins',
+              replacement: path.resolve('./dist/dts/packages/analytics-js-plugins/src'),
+            },
+            {
+              find: '@rudderstack/analytics-js-common',
+              replacement: path.resolve('./dist/dts/packages/analytics-js-common/src'),
+            },
+            {
+              find: '@rudderstack/analytics-js-cookies',
+              replacement: path.resolve('./dist/dts/packages/analytics-js-cookies/src'),
+            },
+            {
+              find: '@rudderstack/analytics-js-integrations',
+              replacement: path.resolve('./dist/dts/packages/analytics-js-integrations/src'),
+            },
+          ],
+        }),
         dts(),
         del({ hook: 'buildEnd', targets: './dist/dts' }),
       ],


### PR DESCRIPTION
## PR Description

I've fixed types definition to avoid clash with Bugsnag dependency and also fixed declaration files generation aliasing in rollup.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3534/fix-bugsnag-package-dependency-in-declaration-files

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations to improve handling of internal package imports during bundling.
  * Refined type references for improved clarity in error handling types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->