### PR TITLE
mixpanel: add heatmap support

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Mixpanel/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Mixpanel/browser.test.js
@@ -256,6 +256,7 @@ describe('Init tests', () => {
           recordMaskTextSelector: '.sensitive',
           recordMaxMs: 30000,
           recordMinMs: 1000,
+          recordHeatmapData: true,
         },
       },
       logLevel: 'debug',
@@ -285,6 +286,7 @@ describe('Init tests', () => {
       record_max_ms: 30000,
       record_min_ms: 1000,
       record_sessions_percent: 50,
+      record_heatmap_data: true,
       loaded: expect.any(Function),
     });
   });

--- a/packages/analytics-js-integrations/src/integrations/Mixpanel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Mixpanel/browser.js
@@ -118,6 +118,8 @@ class Mixpanel {
             record_min_ms: mixpanelIntgConfig.recordMinMs,
             record_block_selector: mixpanelIntgConfig.recordBlockSelector,
             record_canvas: mixpanelIntgConfig.recordCanvas,
+            // ref: https://docs.mixpanel.com/docs/session-replay/heatmaps#implementation
+            record_heatmap_data: mixpanelIntgConfig.recordHeatmapData,
           });
           options = { ...options, ...sessionReplayConfig };
         }


### PR DESCRIPTION
## PR Description

Add support for new mixpanel heatmap feature
ref: https://docs.mixpanel.com/docs/session-replay/heatmaps#implementation

I have added it to the session replay config because session replay is a requirement for heatmaps to work, so I'm treating it more as a sub-feature

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring heatmap data recording in the Mixpanel integration via a new option.

* **Tests**
  * Updated test suite to cover the new heatmap data recording configuration option for Mixpanel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->