### PR TITLE
chore: skip sanity suite project in size limit check

### DIFF
--- a/.github/workflows/security-code-quality-and-bundle-size-checks.yml
+++ b/.github/workflows/security-code-quality-and-bundle-size-checks.yml
@@ -76,8 +76,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           install_script: npm run setup:ci
-          build_script: npm run check:size:build -- --projects=${{ needs.get-affected-projects.outputs.affected_projects }}
-          script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --projects=${{ needs.get-affected-projects.outputs.affected_projects }}
+          build_script: npm run check:size:build -- --projects=${{ needs.get-affected-projects.outputs.affected_projects }} --exclude=@rudderstack/analytics-js-sanity-suite
+          script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --projects=${{ needs.get-affected-projects.outputs.affected_projects }} --exclude=@rudderstack/analytics-js-sanity-suite
           is_monorepo: true
 
   code-quality-checks:


### PR DESCRIPTION
## PR Description

Explicitly ignoring the sanity suite package from size limit check as Nx is polluting the output terminal with warnings.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow to exclude a specific project from bundle size checks. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->