### PR TITLE
chore: suppress nx warnings for projects

### DIFF
--- a/patches/nx+21.2.3.patch
+++ b/patches/nx+21.2.3.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/nx/src/command-line/run-many/run-many.js b/node_modules/nx/src/command-line/run-many/run-many.js
+index 52cb033..5d7863e 100644
+--- a/node_modules/nx/src/command-line/run-many/run-many.js
++++ b/node_modules/nx/src/command-line/run-many/run-many.js
+@@ -64,7 +64,7 @@ function projectsToRun(nxArgs, projectGraph) {
+                 selectedProjects[project] = projectGraph.nodes[project];
+             }
+         }
+-        if (invalidProjects.length > 0) {
++        if (invalidProjects.length > 0 && nxArgs.silent !== true) {
+             output_1.output.warn({
+                 title: `The following projects do not have a configuration for any of the provided targets ("${nxArgs.targets.join(', ')}")`,
+                 bodyLines: invalidProjects.map((name) => `- ${name}`),
 diff --git a/node_modules/nx/src/command-line/yargs-utils/shared-options.js b/node_modules/nx/src/command-line/yargs-utils/shared-options.js
 index d20e82d..38faf3c 100644
 --- a/node_modules/nx/src/command-line/yargs-utils/shared-options.js


### PR DESCRIPTION
## PR Description

I have patched the Nx package to suppress Nx warnings when running in silent mode.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to suppress warnings and terminal output when running multiple project tasks using a silent mode.

* **Chores**
  * Improved command-line options to include a silent flag for controlling output verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->