### PR TITLE
fix: removed duplicated key from properties in test_custom_pii_properties_non_string_val

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/utils.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/utils.test.js
@@ -102,7 +102,6 @@ describe('buildPayLoad_function', () => {
     const rudderElement = {
       message: {
         properties: {
-          customPiiPropertyWhiteHashFalse: 1234,
           BlacklistPiiPropertyHashTrueNonString: 1234,
           BlacklistPiiPropertyHashFalseNonString: 1234,
           customPiiPropertyWhiteHashFalse: 1234,


### PR DESCRIPTION
## PR Description

The current test `test_custom_pii_properties_non_string_val` duplicates the key `customPiiPropertyWhiteHashFalse`, which appears to be redundant and causes a compile error in IDEs like WebStorm.

<img width="1416" height="848" alt="image" src="https://github.com/user-attachments/assets/046a01ad-154b-42ba-a4bc-02eb86d2d970" />

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
