### PR TITLE
feat: update custom integrations init api

### DIFF
--- a/packages/analytics-js-common/src/types/Destination.ts
+++ b/packages/analytics-js-common/src/types/Destination.ts
@@ -94,14 +94,22 @@ export type ConsentManagementProviderConfig = {
   resolutionStrategy: string | undefined;
 };
 
-export type DestinationConfig = {
+/**
+ * The common configuration properties for all device
+ * and hybrid mode supported destinations.
+ */
+export type BaseDestinationConfig = {
   blacklistedEvents: DestinationEvent[];
   whitelistedEvents: DestinationEvent[];
+  eventFilteringOption: EventFilteringOption;
+  consentManagement: ConsentManagementProviderConfig[];
+  connectionMode: DestinationConnectionMode;
+};
+
+export type DestinationConfig = BaseDestinationConfig & {
   iubendaConsentPurposes?: IubendaConsentPurpose[];
   oneTrustCookieCategories?: OneTrustCookieCategory[];
   ketchConsentPurposes?: KetchConsentPurpose[];
-  consentManagement?: ConsentManagementProviderConfig[];
-  eventFilteringOption: EventFilteringOption;
   clickEventConversions?: Conversion[];
   pageLoadConversions?: Conversion[];
   conversionID?: string;
@@ -119,7 +127,6 @@ export type DestinationConfig = {
   measurementId?: string;
   capturePageView?: string;
   useNativeSDKToSend?: boolean;
-  connectionMode?: DestinationConnectionMode;
   extendPageViewParams?: boolean;
   eventMappingFromConfig?: EventMapping[];
   appKey?: string;

--- a/packages/analytics-js-common/src/types/IRudderAnalytics.ts
+++ b/packages/analytics-js-common/src/types/IRudderAnalytics.ts
@@ -7,6 +7,7 @@ import type { IdentifyTraits } from './traits';
 import type { ConsentOptions } from './Consent';
 import type { IntegrationOpts } from './Integration';
 import type { RSAEvent } from './Event';
+import type { BaseDestinationConfig } from './Destination';
 
 export type AnalyticsIdentifyMethod = {
   (
@@ -223,17 +224,29 @@ export type RSAnalytics = Pick<
 >;
 
 /**
+ * Type for the custom destination configuration object
+ * For now, it is the same as the base destination config
+ * but in the future, it can be extended to include more properties
+ */
+export type CustomDestinationConfig = BaseDestinationConfig;
+
+/**
  * Type for the custom integration to be used in addCustomIntegration API
  * Defines the contract that all custom integrations must implement
  */
 export type RSACustomIntegration = {
   /**
    * Initialize the integration
+   * @param destinationConfig - The custom destination configuration object
    * @param analytics - The RudderStack analytics instance
    * @param logger - The logger instance for this integration
    * @optional
    */
-  init?: (analytics: RSAnalytics, logger: RSALogger) => void;
+  init?: (
+    destinationConfig: CustomDestinationConfig,
+    analytics: RSAnalytics,
+    logger: RSALogger,
+  ) => void;
 
   /**
    * Check if the integration is ready to process events

--- a/packages/analytics-js-plugins/__tests__/deviceModeDestinations/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeDestinations/utils.test.ts
@@ -120,6 +120,8 @@ describe('deviceModeDestinations utils', () => {
         blacklistedEvents: [],
         whitelistedEvents: [],
         eventFilteringOption: 'disable',
+        consentManagement: [],
+        connectionMode: 'device',
       },
     };
 
@@ -382,6 +384,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
+          consentManagement: [],
+          connectionMode: 'device' as const,
         },
       },
       {
@@ -396,6 +400,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
+          consentManagement: [],
+          connectionMode: 'device' as const,
         },
       },
       {
@@ -410,6 +416,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
+          consentManagement: [],
+          connectionMode: 'device' as const,
         },
       },
     ];
@@ -809,6 +817,8 @@ describe('deviceModeDestinations utils', () => {
         blacklistedEvents: [],
         whitelistedEvents: [],
         eventFilteringOption: 'disable' as const,
+        consentManagement: [],
+        connectionMode: 'device' as const,
       },
     };
 
@@ -1467,6 +1477,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
+          consentManagement: [],
+          connectionMode: 'device' as const,
         },
       };
 
@@ -1525,6 +1537,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
+          consentManagement: [],
+          connectionMode: 'device' as const,
         },
       };
 
@@ -1589,6 +1603,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
+          consentManagement: [],
+          connectionMode: 'device' as const,
         },
       };
 
@@ -1715,8 +1731,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2043,8 +2059,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2091,8 +2107,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2126,8 +2142,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2154,6 +2170,13 @@ describe('deviceModeDestinations utils', () => {
       // Test init wrapper
       testDestination.integration?.init!();
       expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blacklistedEvents: [],
+          whitelistedEvents: [],
+          eventFilteringOption: 'disable',
+          connectionMode: 'device',
+          consentManagement: [],
+        }),
         mockAnalyticsInstance,
         expect.objectContaining({
           log: expect.any(Function),
@@ -2208,8 +2231,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2256,7 +2279,17 @@ describe('deviceModeDestinations utils', () => {
         setMinLogLevel: expect.any(Function),
       });
 
-      expect(mockInit).toHaveBeenCalledWith(mockAnalyticsInstance, expectedLogger);
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blacklistedEvents: [],
+          whitelistedEvents: [],
+          eventFilteringOption: 'disable',
+          connectionMode: 'device',
+          consentManagement: [],
+        }),
+        mockAnalyticsInstance,
+        expectedLogger,
+      );
       expect(mockTrack).toHaveBeenCalledWith(mockAnalyticsInstance, expectedLogger, mockEvent);
       expect(mockPage).toHaveBeenCalledWith(mockAnalyticsInstance, expectedLogger, mockPageEvent);
       expect(mockIdentify).toHaveBeenCalledWith(
@@ -2280,8 +2313,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2298,6 +2331,13 @@ describe('deviceModeDestinations utils', () => {
 
       testDestination.integration?.init!();
       expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blacklistedEvents: [],
+          whitelistedEvents: [],
+          eventFilteringOption: 'disable',
+          connectionMode: 'device' as const,
+          consentManagement: [],
+        }),
         customAnalyticsInstance,
         expect.objectContaining({
           log: expect.any(Function),
@@ -2322,8 +2362,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2332,7 +2372,7 @@ describe('deviceModeDestinations utils', () => {
 
       // Mock a realistic custom integration
       const realisticIntegration = {
-        init: (analytics: any, logger: any) => {
+        init: (destinationConfig: any, analytics: any, logger: any) => {
           logger.info('Initializing CustomAnalytics integration');
 
           // Use analytics API to get user information
@@ -2539,8 +2579,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2572,8 +2612,8 @@ describe('deviceModeDestinations utils', () => {
           blacklistedEvents: [],
           whitelistedEvents: [],
           eventFilteringOption: 'disable' as const,
-          connectionMode: 'device',
-          useNativeSDKToSend: true,
+          connectionMode: 'device' as const,
+          consentManagement: [],
         },
       };
 
@@ -2600,7 +2640,7 @@ describe('deviceModeDestinations utils', () => {
       testDestination.integration?.init!();
 
       // Verify that the logger methods are bound functions
-      const loggerArg = mockInit.mock.calls[0][1];
+      const loggerArg = mockInit.mock.calls[0][2];
 
       // Test that the logger methods are properly bound by verifying they're functions
       // and that calling them invokes the original logger methods

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
@@ -11,6 +11,7 @@ import type {
 import type { ApplicationState } from '@rudderstack/analytics-js-common/types/ApplicationState';
 import type { ILogger, RSALogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type {
+  CustomDestinationConfig,
   IntegrationRSAnalytics,
   RSACustomIntegration,
   RSAnalytics,
@@ -432,10 +433,16 @@ const addIntegrationToDestination = (
   // Mark it as a custom integration
   destination.isCustomIntegration = true;
 
+  // Create configuration object for the custom integration
+  // to pass to the init method
+  const customDestinationConfig = clone(destination.config) as CustomDestinationConfig;
+
   // Create a wrapper around the custom integration APIs
   // to make them consistent with the standard device mode integrations
   destination.integration = {
-    ...(integration.init && { init: () => integration.init!(analyticsInstance, safeLogger) }),
+    ...(integration.init && {
+      init: () => integration.init!(customDestinationConfig, analyticsInstance, safeLogger),
+    }),
     ...(integration.track && {
       track: (event: RSAEvent) => integration.track!(analyticsInstance, safeLogger, event),
     }),

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -187,10 +187,10 @@
             }
 
             rudderanalytics.addCustomIntegration('test-dest-id-1', {
-              init: (analytics, logger) => {
+              init: (destinationConfig, analytics, logger) => {
                 logger.debug('"init" called');
                 
-                logger.debug('Received arguments', analytics, logger);
+                logger.debug('Received arguments', destinationConfig, analytics, logger);
               },
               isReady: (analytics, logger) => {
                 logger.debug('"isReady" called');


### PR DESCRIPTION
## PR Description

I've updated the custom integrations API as per the latest design to send destination configuration object.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3528/update-init-api-of-custom-integrations

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized and modularized destination configuration types for improved consistency.
  * Updated custom integration initialization to receive destination configuration as a parameter.

* **Tests**
  * Adjusted test mocks and method signatures to align with the new destination configuration structure and initialization method.

* **Documentation**
  * Updated method documentation to reflect changes in integration initialization parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->