### PR TITLE
fix(plugins): allow disabled custom device mode in configured destinations

### DIFF
--- a/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
@@ -1299,11 +1299,11 @@ describe('DeviceModeDestinations Plugin', () => {
       );
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        `DeviceModeDestinationsPlugin:: The destination ID "${invalidDestinationId}" does not correspond to an enabled custom device mode destination.`,
+        `DeviceModeDestinationsPlugin:: The destination ID "${invalidDestinationId}" does not correspond to a custom device mode destination.`,
       );
     });
 
-    it('should not add custom integration when destination is not enabled', () => {
+    it('should add custom integration when destination is not enabled', () => {
       const disabledDestination = {
         ...mockCustomDestination,
         id: 'disabled-dest-456',
@@ -1318,9 +1318,13 @@ describe('DeviceModeDestinations Plugin', () => {
         mockLogger,
       );
 
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'DeviceModeDestinationsPlugin:: The destination ID "disabled-dest-456" does not correspond to an enabled custom device mode destination.',
+      // Verify the destination was updated with the integration
+      const updatedDestination = mockState.nativeDestinations.configuredDestinations.value.find(
+        dest => dest.id === disabledDestination.id,
       );
+      expect(updatedDestination).toBeDefined();
+      expect(updatedDestination!.isCustomIntegration).toBe(true);
+      expect(updatedDestination!.integration).toBeDefined();
     });
 
     it('should not add custom integration when destination display name is not "Custom Device Mode"', () => {
@@ -1339,7 +1343,7 @@ describe('DeviceModeDestinations Plugin', () => {
       );
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'DeviceModeDestinationsPlugin:: The destination ID "regular-dest-789" does not correspond to an enabled custom device mode destination.',
+        'DeviceModeDestinationsPlugin:: The destination ID "regular-dest-789" does not correspond to a custom device mode destination.',
       );
     });
 
@@ -1595,7 +1599,7 @@ describe('DeviceModeDestinations Plugin', () => {
 
       // Should warn about the destination without integration
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'DeviceModeDestinationsPlugin:: No custom integration was added for destination ID "custom-dest-no-integration". Ignoring it.',
+        'DeviceModeDestinationsPlugin:: No valid custom integration was added for destination ID "custom-dest-no-integration". Ignoring it.',
       );
 
       // Should not warn about destination with integration
@@ -1682,9 +1686,12 @@ describe('DeviceModeDestinations Plugin', () => {
 
       // Should only warn about custom-2 (enabled custom destination without integration)
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'DeviceModeDestinationsPlugin:: No custom integration was added for destination ID "custom-2". Ignoring it.',
+        'DeviceModeDestinationsPlugin:: No valid custom integration was added for destination ID "custom-2". Ignoring it.',
       );
-      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'DeviceModeDestinationsPlugin:: No valid custom integration was added for destination ID "custom-3". Ignoring it.',
+      );
+      expect(mockLogger.warn).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
@@ -1684,14 +1684,11 @@ describe('DeviceModeDestinations Plugin', () => {
         mockLogger,
       );
 
-      // Should warn about custom-2 and custom-3 (both enabled and disabled custom destination without integration)
+      // Should only warn about custom-2 (enabled custom destination without integration)
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'DeviceModeDestinationsPlugin:: No valid custom integration was added for destination ID "custom-2". Ignoring it.',
       );
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'DeviceModeDestinationsPlugin:: No valid custom integration was added for destination ID "custom-3". Ignoring it.',
-      );
-      expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeDestinations/index.test.ts
@@ -1684,7 +1684,7 @@ describe('DeviceModeDestinations Plugin', () => {
         mockLogger,
       );
 
-      // Should only warn about custom-2 (enabled custom destination without integration)
+      // Should warn about custom-2 and custom-3 (both enabled and disabled custom destination without integration)
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'DeviceModeDestinationsPlugin:: No valid custom integration was added for destination ID "custom-2". Ignoring it.',
       );

--- a/packages/analytics-js-plugins/__tests__/deviceModeDestinations/utils.test.ts
+++ b/packages/analytics-js-plugins/__tests__/deviceModeDestinations/utils.test.ts
@@ -1765,11 +1765,11 @@ describe('deviceModeDestinations utils', () => {
 
         expect(result).toBeUndefined();
         expect(defaultLogger.error).toHaveBeenCalledWith(
-          'DeviceModeDestinationsPlugin:: The destination ID "non-existent-dest" does not correspond to an enabled custom device mode destination.',
+          'DeviceModeDestinationsPlugin:: The destination ID "non-existent-dest" does not correspond to a custom device mode destination.',
         );
       });
 
-      it('should return undefined for disabled destination', () => {
+      it('should return the destination object for disabled destination', () => {
         const disabledDestination = {
           ...mockCustomDestination,
           id: 'disabled-dest',
@@ -1784,10 +1784,8 @@ describe('deviceModeDestinations utils', () => {
           defaultLogger,
         );
 
-        expect(result).toBeUndefined();
-        expect(defaultLogger.error).toHaveBeenCalledWith(
-          'DeviceModeDestinationsPlugin:: The destination ID "disabled-dest" does not correspond to an enabled custom device mode destination.',
-        );
+        expect(result).toBeDefined();
+        expect(result).toEqual(disabledDestination);
       });
 
       it('should return undefined if no custom destinations are configured', () => {
@@ -1807,7 +1805,7 @@ describe('deviceModeDestinations utils', () => {
 
         expect(result).toBeUndefined();
         expect(defaultLogger.error).toHaveBeenCalledWith(
-          'DeviceModeDestinationsPlugin:: The destination ID "wrong-dest" does not correspond to an enabled custom device mode destination.',
+          'DeviceModeDestinationsPlugin:: The destination ID "wrong-dest" does not correspond to a custom device mode destination.',
         );
       });
     });

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
@@ -72,12 +72,14 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
         state.nativeDestinations.configuredDestinations.value.filter((configDest: Destination) => {
           // Filter enabled or disabled custom destinations that don't have an integration added to them
           if (configDest.isCustomIntegration && isUndefined(configDest.integration)) {
-            logger?.warn(
-              INTEGRATION_NOT_ADDED_TO_CUSTOM_DESTINATION_WARNING(
-                DEVICE_MODE_DESTINATIONS_PLUGIN,
-                configDest.id,
-              ),
-            );
+            if (configDest.enabled) {
+              logger?.warn(
+                INTEGRATION_NOT_ADDED_TO_CUSTOM_DESTINATION_WARNING(
+                  DEVICE_MODE_DESTINATIONS_PLUGIN,
+                  configDest.id,
+                ),
+              );
+            }
             return false;
           }
 

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
@@ -71,11 +71,7 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
       const configSupportedDestinations =
         state.nativeDestinations.configuredDestinations.value.filter((configDest: Destination) => {
           // Filter enabled custom destinations that don't have an integration added to them
-          if (
-            configDest.enabled &&
-            configDest.isCustomIntegration &&
-            isUndefined(configDest.integration)
-          ) {
+          if (configDest.isCustomIntegration && isUndefined(configDest.integration)) {
             logger?.warn(
               INTEGRATION_NOT_ADDED_TO_CUSTOM_DESTINATION_WARNING(
                 DEVICE_MODE_DESTINATIONS_PLUGIN,

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/index.ts
@@ -70,7 +70,7 @@ const DeviceModeDestinations = (): ExtensionPlugin => ({
       // Filter destination that doesn't have mapping config-->Integration names
       const configSupportedDestinations =
         state.nativeDestinations.configuredDestinations.value.filter((configDest: Destination) => {
-          // Filter enabled custom destinations that don't have an integration added to them
+          // Filter enabled or disabled custom destinations that don't have an integration added to them
           if (configDest.isCustomIntegration && isUndefined(configDest.integration)) {
             logger?.warn(
               INTEGRATION_NOT_ADDED_TO_CUSTOM_DESTINATION_WARNING(

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/logMessages.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/logMessages.ts
@@ -22,7 +22,7 @@ const CUSTOM_INTEGRATION_INVALID_DESTINATION_ID_ERROR = (
   context: string,
   destinationId: string,
 ): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}The destination ID "${destinationId}" does not correspond to an enabled custom device mode destination.`;
+  `${context}${LOG_CONTEXT_SEPARATOR}The destination ID "${destinationId}" does not correspond to a custom device mode destination.`;
 
 const CUSTOM_INTEGRATION_ALREADY_EXISTS_ERROR = (context: string, destinationId: string): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}A custom integration with destination ID "${destinationId}" was already added.`;
@@ -34,7 +34,7 @@ const INTEGRATION_NOT_ADDED_TO_CUSTOM_DESTINATION_WARNING = (
   context: string,
   destinationId: string,
 ): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}No custom integration was added for destination ID "${destinationId}". Ignoring it.`;
+  `${context}${LOG_CONTEXT_SEPARATOR}No valid custom integration was added for destination ID "${destinationId}". Ignoring it.`;
 
 export {
   INTEGRATION_NOT_SUPPORTED_ERROR,

--- a/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
+++ b/packages/analytics-js-plugins/src/deviceModeDestinations/utils.ts
@@ -355,9 +355,7 @@ const validateCustomIntegration = (
   const configuredDestinations = state.nativeDestinations.configuredDestinations.value;
   const destination = configuredDestinations.find(
     dest =>
-      dest.id === destinationId &&
-      dest.displayName === CUSTOM_DEVICE_MODE_DESTINATION_DISPLAY_NAME &&
-      dest.enabled,
+      dest.id === destinationId && dest.displayName === CUSTOM_DEVICE_MODE_DESTINATION_DISPLAY_NAME,
   );
 
   if (!destination) {

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -77,7 +77,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (CJS)',
     path: 'dist/npm/modern/bundled/cjs/index.cjs',
     import: '*',
-    limit: '41 KiB',
+    limit: '41.5 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (UMD)',


### PR DESCRIPTION
## PR Description

- Allow disabled custom device mode destinations to be in the configured destinations

## Linear task (optional)

[Linear task link
](https://linear.app/rudderstack/issue/SDK-3529/ensure-custom-integrations-support-the-same-sdk-level-behaviours-as)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and logging for custom device mode destinations, ensuring clearer error and warning messages.
  * Adjusted logic to recognize custom destinations regardless of their enabled status.
  * Enhanced test coverage to reflect updated validation and logging behaviors for custom integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->