### PR TITLE
fix: braze sdkmetadata race condition

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -29,6 +29,7 @@ const mockBrazeSDK = () => {
       }
     }),
     addAlias: jest.fn(),
+    addSdkMetadata: jest.fn(),
     openSession: jest.fn(),
     getUser: jest.fn().mockReturnThis(),
     setCountry: jest.fn(),
@@ -44,6 +45,16 @@ const mockBrazeSDK = () => {
     logPurchase: jest.fn(),
     getCachedContentCards: jest.fn(),
     getCachedFeed: jest.fn(),
+    BrazeSdkMetadata: {
+      CDN: 'wcd',
+      GOOGLE_TAG_MANAGER: 'gg',
+      MANUAL: 'manu',
+      MPARTICLE: 'mp',
+      NPM: 'npm',
+      SEGMENT: 'sg',
+      SHOPIFY: 'shp',
+      TEALIUM: 'tl',
+    },
     User: {
       Genders: {
         OTHER: 'o',
@@ -52,6 +63,8 @@ const mockBrazeSDK = () => {
       },
     },
   };
+  // Mock brazeQueue as null to simulate loaded state by default
+  window.brazeQueue = null;
 };
 
 beforeEach(() => {
@@ -295,19 +308,83 @@ describe('isReady', () => {
   });
 
   it('should return true when loaded and alias set successfully', () => {
+    mockBrazeSDK();
     jest.spyOn(braze, 'isLoaded').mockReturnValue(true);
     jest.spyOn(braze, 'setUserAlias').mockReturnValue(true);
+    jest.spyOn(braze, 'addSdkMetadata');
 
     const result = braze.isReady();
     expect(result).toBe(true);
+    expect(braze.addSdkMetadata).toHaveBeenCalledTimes(1);
+    expect(braze.sdkMetadataAdded).toBe(true);
   });
 
   it('should return false when loaded but alias setting fails', () => {
+    mockBrazeSDK();
     jest.spyOn(braze, 'isLoaded').mockReturnValue(true);
     jest.spyOn(braze, 'setUserAlias').mockReturnValue(false);
+    jest.spyOn(braze, 'addSdkMetadata');
 
     const result = braze.isReady();
     expect(result).toBe(false);
+    expect(braze.addSdkMetadata).toHaveBeenCalledTimes(1);
+    expect(braze.sdkMetadataAdded).toBe(true);
+  });
+
+  it('should only add SDK metadata once even when called multiple times', () => {
+    mockBrazeSDK();
+    jest.spyOn(braze, 'isLoaded').mockReturnValue(true);
+    jest.spyOn(braze, 'setUserAlias').mockReturnValue(true);
+    jest.spyOn(braze, 'addSdkMetadata');
+
+    // Call isReady multiple times
+    braze.isReady();
+    braze.isReady();
+    braze.isReady();
+
+    // SDK metadata should only be added once
+    expect(braze.addSdkMetadata).toHaveBeenCalledTimes(1);
+    expect(braze.sdkMetadataAdded).toBe(true);
+  });
+});
+
+describe('addSdkMetadata', () => {
+  let braze;
+  let config;
+  let analytics;
+
+  beforeEach(() => {
+    config = { appKey: 'APP_KEY' };
+    analytics = { getAnonymousId: jest.fn() };
+    braze = new Braze(config, analytics, {});
+    mockBrazeSDK();
+  });
+
+  it('should call window.braze.addSdkMetadata with CDN metadata', () => {
+    braze.addSdkMetadata();
+
+    expect(window.braze.addSdkMetadata).toHaveBeenCalledWith([window.braze.BrazeSdkMetadata.CDN]);
+  });
+
+  it('should handle errors gracefully when addSdkMetadata fails', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+    window.braze.addSdkMetadata.mockImplementation(() => {
+      throw new Error('SDK metadata error');
+    });
+
+    // Should not throw an error
+    expect(() => braze.addSdkMetadata()).not.toThrow();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should log debug message on successful metadata addition', () => {
+    const consoleSpy = jest.spyOn(console, 'debug').mockImplementation(() => { });
+
+    braze.addSdkMetadata();
+
+    expect(window.braze.addSdkMetadata).toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 });
 

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -364,6 +364,7 @@ describe('addSdkMetadata', () => {
     braze.addSdkMetadata();
 
     expect(window.braze.addSdkMetadata).toHaveBeenCalledWith([window.braze.BrazeSdkMetadata.CDN]);
+    expect(braze.sdkMetadataAdded).toBe(true);
   });
 
   it('should handle errors gracefully when addSdkMetadata fails', () => {
@@ -374,6 +375,9 @@ describe('addSdkMetadata', () => {
 
     // Should not throw an error
     expect(() => braze.addSdkMetadata()).not.toThrow();
+
+    // Flag should not be set when there's an error
+    expect(braze.sdkMetadataAdded).toBe(false);
 
     consoleSpy.mockRestore();
   });

--- a/packages/analytics-js-integrations/src/integrations/Braze/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/browser.js
@@ -31,6 +31,7 @@ class Braze {
     this.isReadyStatus = {
       hasLoggedErrorForAlias: false,
     };
+    this.sdkMetadataAdded = false;
 
     if (config.dataCenter) {
       // ref: https://www.braze.com/docs/user_guide/administrative/access_braze/braze_instances
@@ -71,6 +72,15 @@ class Braze {
     }
   }
 
+  addSdkMetadata() {
+    try {
+      window.braze.addSdkMetadata([window.braze.BrazeSdkMetadata.CDN]);
+      logger.debug('Successfully added Braze SDK metadata');
+    } catch (error) {
+      logger.error('Failed to add SDK metadata:', error);
+    }
+  }
+
   init() {
     loadNativeSdk();
     window.braze.initialize(this.appKey, {
@@ -78,7 +88,7 @@ class Braze {
       baseUrl: this.endPoint,
       allowUserSuppliedJavascript: this.allowUserSuppliedJavascript,
     });
-    window.braze.addSdkMetadata([window.braze.BrazeSdkMetadata.CDN, 'rud']);
+
     window.braze.automaticallyShowInAppMessages();
     const { userId } = this.analytics;
     // send userId if you have it https://js.appboycdn.com/web-sdk/latest/doc/module-appboy.html#.changeUser
@@ -126,6 +136,13 @@ class Braze {
     if (!this.isLoaded()) {
       return false;
     }
+
+    // Add SDK metadata when the integration becomes ready (only once)
+    if (!this.sdkMetadataAdded) {
+      this.addSdkMetadata();
+      this.sdkMetadataAdded = true;
+    }
+
     return this.setUserAlias();
   }
 

--- a/packages/analytics-js-integrations/src/integrations/Braze/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/browser.js
@@ -75,6 +75,7 @@ class Braze {
   addSdkMetadata() {
     try {
       window.braze.addSdkMetadata([window.braze.BrazeSdkMetadata.CDN]);
+      this.sdkMetadataAdded = true;
       logger.debug('Successfully added Braze SDK metadata');
     } catch (error) {
       logger.error('Failed to add SDK metadata:', error);
@@ -140,7 +141,6 @@ class Braze {
     // Add SDK metadata when the integration becomes ready (only once)
     if (!this.sdkMetadataAdded) {
       this.addSdkMetadata();
-      this.sdkMetadataAdded = true;
     }
 
     return this.setUserAlias();


### PR DESCRIPTION
## PR Description

**Problem:**
Customers were experiencing "Braze SDK Error: sdkMetadata contained an invalid value" specifically in HYBRID mode. The error occurred due to a timing issue where  addSdkMetadata was called immediately after SDK initialization, before the Braze SDK was fully loaded.

**Root Cause:**
Race Condition:  addSdkMetadata was called in init() before the SDK finished loading
Timing Issue: The SDK's validation logic wasn't ready when metadata was added
Hybrid Mode Visibility: Error was more noticeable in hybrid mode since other methods do minimal work

**Solution:**
Implemented an event-based approach that integrates with RudderStack's existing integration lifecycle:

**Key Changes:**
Moved metadata addition to isReady(): SDK metadata is now added when the integration becomes ready, ensuring the Braze SDK is fully loaded
Added one-time execution flag: Prevents multiple metadata additions with sdkMetadataAdded flag
Removed premature metadata call: Cleaned up init() method to avoid timing issues
Enhanced error handling: Added proper logging and graceful error handling

**Code Changes:**
Modified isReady() to call addSdkMetadata() when SDK is loaded
Added addSdkMetadata() method with error handling
Updated test coverage with comprehensive mocks and test cases

## Linear task (optional)

[Resolves INT-3963](https://linear.app/rudderstack/issue/INT-3963/investigate-braze-client-initialization-error-with-rudderstack-sdk)


## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved reliability of the Braze integration by ensuring SDK metadata is added only once when the integration is ready.
  * Enhanced error handling and logging for SDK metadata addition.

* **Tests**
  * Expanded test coverage for the Braze integration, including new tests for SDK metadata handling and improved verification of readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->