### PR TITLE
chore: skip sanity suite project in affected list

### DIFF
--- a/.github/workflows/security-code-quality-and-bundle-size-checks.yml
+++ b/.github/workflows/security-code-quality-and-bundle-size-checks.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check for affected projects
         id: check_affected
         run: |
-          AFFECTED_PROJECTS=$(npx nx show projects --affected --base=$BASE_REF | paste -sd ',' - | sed 's/,$//')
+          AFFECTED_PROJECTS=$(npx nx show projects --affected --exclude=@rudderstack/analytics-js-sanity-suite --base=$BASE_REF | paste -sd ',' - | sed 's/,$//')
           echo "Affected projects: $AFFECTED_PROJECTS"
           echo "affected_projects=$AFFECTED_PROJECTS" >> $GITHUB_OUTPUT
 
@@ -76,12 +76,12 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           install_script: npm run setup:ci
-          build_script: npm run check:size:build -- --projects=${{ needs.get-affected-projects.outputs.affected_projects }} --exclude=@rudderstack/analytics-js-sanity-suite
-          script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --projects=${{ needs.get-affected-projects.outputs.affected_projects }} --exclude=@rudderstack/analytics-js-sanity-suite
+          build_script: npm run check:size:build -- --projects=${{ needs.get-affected-projects.outputs.affected_projects }}
+          script: npm run check:size:json:ci --silent -- --output-style=static --silent=true --projects=${{ needs.get-affected-projects.outputs.affected_projects }}
           is_monorepo: true
 
   code-quality-checks:
-    name: Security and code quality checks
+    name: Code quality checks
     runs-on: [self-hosted, Linux, X64]
     needs: get-affected-projects
     steps:


### PR DESCRIPTION
## PR Description

I have excluded the sanity suite package from the affected step to avoid issues when it is only package that is modified.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project exclusions for affected project checks.
  * Adjusted bundle size check commands to include all projects.
  * Renamed the code quality check job for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->