### PR TITLE
fix: correctly export destination config type

### DIFF
--- a/packages/analytics-js-common/src/types/IRudderAnalytics.ts
+++ b/packages/analytics-js-common/src/types/IRudderAnalytics.ts
@@ -228,7 +228,7 @@ export type RSAnalytics = Pick<
  * For now, it is the same as the base destination config
  * but in the future, it can be extended to include more properties
  */
-export type CustomDestinationConfig = BaseDestinationConfig;
+export type CustomDestinationConfig = BaseDestinationConfig & {};
 
 /**
  * Type for the custom integration to be used in addCustomIntegration API

--- a/packages/analytics-js/src/index.ts
+++ b/packages/analytics-js/src/index.ts
@@ -20,6 +20,7 @@ export { type IdentifyTraits } from '@rudderstack/analytics-js-common/types/trai
 export {
   type RSAnalytics,
   type RSACustomIntegration,
+  type CustomDestinationConfig,
 } from '@rudderstack/analytics-js-common/types/IRudderAnalytics';
 export { type RSAEvent } from '@rudderstack/analytics-js-common/types/Event';
 export {


### PR DESCRIPTION
## PR Description

I've exported the missing type `CustomDestinationConfig` for custom destination configuration.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3531/manual-testing-custom-device-mode-integrations-round-2

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the set of exported types to include `CustomDestinationConfig` for improved type availability in external integrations. No changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->