### PR TITLE
fix: use hasOwnProperty instead hasOwn

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/utils.js
@@ -119,7 +119,7 @@ const buildPayLoad = (
   const payload = Object.entries(properties).reduce((acc, [currPropName, currPropValue]) => {
     const isPropertyPii =
       defaultPiiProperties.includes(currPropName) ||
-      Object.hasOwn(shouldPropBeHashedMap, currPropName);
+      Object.prototype.hasOwnProperty.call(shouldPropBeHashedMap, currPropName);
 
     const isProperyWhiteListed = whitelistPiiPropertiesNames.includes(currPropName);
 
@@ -153,14 +153,17 @@ const merge = (obj1, obj2) => {
 
   // All properties of obj1
   Object.keys(safeObj1).forEach(propObj1 => {
-    if (Object.hasOwn(safeObj1, propObj1)) {
+    if (Object.prototype.hasOwnProperty.call(safeObj1, propObj1)) {
       res[propObj1] = safeObj1[propObj1];
     }
   });
 
   // Extra properties of obj2
   Object.keys(safeObj2).forEach(propObj2 => {
-    if (Object.hasOwn(safeObj2, propObj2) && !Object.hasOwn(res, propObj2)) {
+    if (
+      Object.prototype.hasOwnProperty.call(safeObj2, propObj2) &&
+      !Object.prototype.hasOwnProperty.call(res, propObj2)
+    ) {
       res[propObj2] = safeObj2[propObj2];
     }
   });

--- a/packages/analytics-js-integrations/src/integrations/MoEngage/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/MoEngage/browser.js
@@ -144,7 +144,7 @@ class MoEngage {
         if (key === 'name') {
           window.Moengage.add_user_name(value);
         }
-        if (Object.hasOwn(TraitsMap, key)) {
+        if (Object.prototype.hasOwnProperty.call(TraitsMap, key)) {
           const method = `add_${TraitsMap[key]}`;
           window.Moengage[method](value);
         } else {

--- a/packages/analytics-js-integrations/src/integrations/MoEngage/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/MoEngage/browser.js
@@ -185,7 +185,7 @@ class MoEngage {
 
     const userAttributes = {};
     each((value, key) => {
-      if (Object.hasOwn(IdentifyUserPropertiesMap, key)) {
+      if (Object.prototype.hasOwnProperty.call(IdentifyUserPropertiesMap, key)) {
         const method = IdentifyUserPropertiesMap[key];
         userAttributes[method] = value;
       } else {


### PR DESCRIPTION
## PR Description

This pull request updates several utility functions in the FacebookPixel and MoEngage integrations to use a safer method for checking object property ownership. Specifically, it replaces `Object.hasOwn()` with `Object.prototype.hasOwnProperty.call()` to ensure compatibility across environments and avoid potential issues with objects that may not inherit from `Object.prototype`.

Improvements to property checks for robustness:

* Replaced `Object.hasOwn()` with `Object.prototype.hasOwnProperty.call()` in the `buildPayLoad` function to safely check for property existence in the `shouldPropBeHashedMap` object.
* Updated property existence checks in the `merge` function for both source objects and the result object, using `Object.prototype.hasOwnProperty.call()` for all cases.

MoEngage integration updates:

* Changed property existence checks in the MoEngage integration (`browser.js`) to use `Object.prototype.hasOwnProperty.call()` for the `TraitsMap` and `IdentifyUserPropertiesMap` objects, ensuring correct mapping of user traits and properties. [[1]](diffhunk://#diff-50d29403c6a7d3595095d7efce8556d6f7c10f9e5ac00f1556c718a0b093ee42L147-R147) [[2]](diffhunk://#diff-50d29403c6a7d3595095d7efce8556d6f7c10f9e5ac00f1556c718a0b093ee42L188-R188)

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability by updating property checks to use a standard method, ensuring consistent behavior across different environments. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->