### PR TITLE
feat: add default consent granted to Bing Ads integration

### DIFF
--- a/packages/analytics-js-integrations/src/integrations/BingAds/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/BingAds/browser.js
@@ -32,6 +32,10 @@ class BingAds {
 
   init() {
     loadNativeSdk(this.uniqueId, this.tagID);
+    // Add consent as "granted" immediately when integration initializes
+    // If execution reaches here, user has consented or consent is not required
+    window[this.uniqueId] = window[this.uniqueId] || [];
+    window[this.uniqueId].push('consent', 'default', { ad_storage: 'granted' });
   }
 
   isLoaded() {

--- a/packages/analytics-js-integrations/src/integrations/BingAds/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/BingAds/nativeSdkLoader.js
@@ -1,12 +1,6 @@
 import { LOAD_ORIGIN } from '@rudderstack/analytics-js-legacy-utilities/constants';
 
 function loadNativeSdk(uniqueId, tagID) {
-  // Add consent as "granted" immediately when integration initializes
-  // If execution reaches here, user has consented or consent is not required
-  // UET script will process this consent and set the consent status accordingly
-  window[uniqueId] = window[uniqueId] || [];
-  window[uniqueId].push('consent', 'default', { ad_storage: 'granted' });
-
   ((w, d, t, r, u) => {
     let f;
     let n;


### PR DESCRIPTION
## PR Description

# Add Consent Management to Bing Ads Integration

## Summary
Implements Microsoft's consent compliance requirements by setting default consent state as "granted" when Bing Ads integration initializes

## Changes
- Added consent setting in `init`
- Updated test

## Consent Management
- **Default**: Consent is set to `'granted'` for `'ad_storage'` on initialization  <img width="981" height="566" alt="Screenshot 2025-08-18 at 5 45 40 PM" src="https://github.com/user-attachments/assets/cd7ce262-41c8-4ac2-8337-219a16e28657" />

- **Mid-session changes**: Use `window.bing{{tagId}}.push('consent', 'default', { 'ad_storage': 'granted' })` or `'denied'` <img width="1042" height="508" alt="Screenshot 2025-08-18 at 5 40 57 PM" src="https://github.com/user-attachments/assets/f83d1bea-b3e9-4508-85c3-9c9b55c8303f" />


## Testing
- ✅ Fixed test setup to handle consent calls
- ✅ Verified existing functionality preserved

## Impact
- No breaking changes
- Automatic consent compliance for customers
- Meets Microsoft's requirements

## Default

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-3975/support-consent-parameters-update-for-bingads

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bing Ads integration now sends a default consent signal on initialization, granting ad storage to enable immediate operation of the SDK.

* **Tests**
  * Updated Bing Ads tracking tests to account for additional emitted events, adjusting expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->