### PR TITLE
feat: reset api with options

### DIFF
--- a/packages/analytics-js-common/src/types/EventApi.ts
+++ b/packages/analytics-js-common/src/types/EventApi.ts
@@ -1,6 +1,7 @@
 import type { IntegrationOpts } from './Integration';
 import type { Nullable } from './Nullable';
 import type { ApiObject } from './ApiObject';
+import type { UserSessionKey } from './UserSessionStorage';
 
 // TODO: should we take the types from IdentifyTrait instead of any string key?
 //  https://www.rudderstack.com/docs/event-spec/standard-events/identify/#identify-traits
@@ -44,3 +45,9 @@ export type APIEvent = {
 export type RudderEventType = 'page' | 'track' | 'identify' | 'alias' | 'group';
 
 export type ReadyCallback = () => void;
+
+export type ResetOptions = {
+  entries: {
+    [key in UserSessionKey]?: boolean;
+  };
+};

--- a/packages/analytics-js-common/src/types/IRudderAnalytics.ts
+++ b/packages/analytics-js-common/src/types/IRudderAnalytics.ts
@@ -1,5 +1,5 @@
 import type { Nullable } from './Nullable';
-import type { ApiCallback, ApiOptions } from './EventApi';
+import type { ApiCallback, ApiOptions, ResetOptions } from './EventApi';
 import type { AnonymousIdOptions, LoadOptions } from './LoadOptions';
 import type { ApiObject } from './ApiObject';
 import type { ILogger, LogLevel, RSALogger } from './Logger';
@@ -76,6 +76,11 @@ export type AnalyticsAliasMethod = {
   (to: string, callback?: ApiCallback): void;
 };
 
+export type AnalyticsResetMethod = {
+  (options?: ResetOptions): void;
+  (resetAnonymousId?: boolean): void;
+};
+
 export interface IRudderAnalytics<T = any> {
   analyticsInstances: Record<string, T>;
   defaultAnalyticsKey: string;
@@ -132,11 +137,11 @@ export interface IRudderAnalytics<T = any> {
   group: AnalyticsGroupMethod;
 
   /**
-   * Clear user information
+   * Clear user session information
    *
-   * @param resetAnonymousId optionally clears anonymousId as well
+   * @param options options for reset
    */
-  reset(resetAnonymousId?: boolean): void;
+  reset: AnalyticsResetMethod;
 
   /**
    * To get anonymousId set in the SDK

--- a/packages/analytics-js-common/src/utilities/object.ts
+++ b/packages/analytics-js-common/src/utilities/object.ts
@@ -138,6 +138,15 @@ const getNormalizedObjectValue = (val: any): any => {
 const getNormalizedBooleanValue = (val: any, defVal: boolean): boolean =>
   typeof val === 'boolean' ? val : defVal;
 
+const deepFreeze = <T>(obj: T): T => {
+  Object.getOwnPropertyNames(obj).forEach(function (prop) {
+    if (obj[prop as keyof T] && typeof obj[prop as keyof T] === 'object') {
+      deepFreeze(obj[prop as keyof T]);
+    }
+  });
+  return Object.freeze(obj);
+};
+
 export {
   getValueByPath,
   hasValueByPath,
@@ -151,4 +160,5 @@ export {
   isObject,
   getNormalizedObjectValue,
   getNormalizedBooleanValue,
+  deepFreeze,
 };

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -36,7 +36,7 @@ export default [
     name: 'Core - Modern - NPM (CJS)',
     path: 'dist/npm/modern/cjs/index.cjs',
     import: '*',
-    limit: '28 KiB',
+    limit: '28.5 KiB',
   },
   {
     name: 'Core - Modern - NPM (UMD)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -47,7 +47,7 @@ export default [
   {
     name: 'Core - Modern - CDN',
     path: 'dist/cdn/modern/iife/rsa.min.js',
-    limit: '28 KiB',
+    limit: '28.5 KiB',
   },
   {
     name: 'Core (Bundled) - Legacy - NPM (ESM)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -113,7 +113,7 @@ export default [
     name: 'Core (Content Script) - Modern - NPM (CJS)',
     path: 'dist/npm/modern/content-script/cjs/index.cjs',
     import: '*',
-    limit: '41 KiB',
+    limit: '41.5 KiB',
   },
   {
     name: 'Core (Content Script) - Modern - NPM (UMD)',

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -376,6 +376,25 @@ describe('Core - Rudder Analytics Facade', () => {
     expect(analyticsInstanceMock.reset).toHaveBeenCalledWith(true);
   });
 
+  it('should process reset arguments and forwards to reset call with options', () => {
+    rudderAnalytics.reset({
+      entries: {
+        anonymousId: true,
+      },
+    });
+
+    expect(analyticsInstanceMock.reset).toHaveBeenCalledWith({
+      entries: {
+        anonymousId: true,
+      },
+    });
+  });
+
+  it('should process reset arguments and forwards to reset call without any arguments', () => {
+    rudderAnalytics.reset();
+    expect(analyticsInstanceMock.reset).toHaveBeenCalledWith(undefined);
+  });
+
   it('should dispatch an error event if an exception is thrown during the reset call', () => {
     const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
 
@@ -386,7 +405,7 @@ describe('Core - Rudder Analytics Facade', () => {
         throw new Error('Error in getAnalyticsInstance');
       });
 
-    rudderAnalytics.reset(true);
+    rudderAnalytics.reset();
 
     expect(dispatchEventSpy).toHaveBeenCalledWith(
       new ErrorEvent('error', {

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -627,10 +627,17 @@ describe('Core - Analytics', () => {
       analytics.prepareInternalServices();
       const resetSpy = jest.spyOn(analytics.userSessionManager!, 'reset');
 
-      analytics.reset(true);
+      analytics.reset({
+        entries: {
+          anonymousId: true,
+        },
+      });
       expect(resetSpy).toHaveBeenCalledTimes(0);
-      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([['reset', true]]);
+      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
+        ['reset', { entries: { anonymousId: true } }],
+      ]);
     });
+
     it('should reset session if loaded', () => {
       analytics.prepareInternalServices();
       const leaveBreadcrumbSpy = jest.spyOn(analytics.errorHandler, 'leaveBreadcrumb');

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1772,39 +1772,107 @@ describe('User session manager', () => {
   });
 
   describe('reset', () => {
-    it('should reset user session to the initial value except anonymousId', () => {
+    beforeEach(() => {
       jest.useFakeTimers();
       jest.setSystemTime(0);
+    });
 
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should reset user session to the initial value except anonymousId and referrer related data', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       userSessionManager.init();
+
       userSessionManager.setAnonymousId(dummyAnonymousId);
-      const sessionInfoBeforeReset = JSON.parse(JSON.stringify(state.session.sessionInfo.value));
+      userSessionManager.setUserId('test_user_id');
+      userSessionManager.setUserTraits({
+        name: 'test_user_name',
+        email: 'test_user_email',
+      });
+      userSessionManager.setGroupId('test_group_id');
+      userSessionManager.setGroupTraits({
+        name: 'test_group_name',
+      });
+      userSessionManager.setInitialReferrer('test_initial_referrer');
+      userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
+      userSessionManager.setAuthToken('test_auth_token');
+
+      const dataBeforeReset = {
+        userId: state.session.userId.value,
+        userTraits: state.session.userTraits.value,
+        groupId: state.session.groupId.value,
+        groupTraits: state.session.groupTraits.value,
+        initialReferrer: state.session.initialReferrer.value,
+        initialReferringDomain: state.session.initialReferringDomain.value,
+        anonymousId: state.session.anonymousId.value,
+        sessionInfo: state.session.sessionInfo.value,
+        authToken: state.session.authToken.value,
+      };
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset();
 
       expect(state.session.userId.value).toEqual('');
+      expect(state.session.userId.value).not.toEqual(dataBeforeReset.userId);
+
       expect(state.session.userTraits.value).toEqual({});
+      expect(state.session.userTraits.value).not.toEqual(dataBeforeReset.userTraits);
+
       expect(state.session.groupId.value).toEqual('');
+      expect(state.session.groupId.value).not.toEqual(dataBeforeReset.groupId);
+
       expect(state.session.groupTraits.value).toEqual({});
+      expect(state.session.groupTraits.value).not.toEqual(dataBeforeReset.groupTraits);
+
+      expect(state.session.authToken.value).toEqual(null);
+      expect(state.session.authToken.value).not.toEqual(dataBeforeReset.authToken);
+
       expect(state.session.anonymousId.value).toEqual(dummyAnonymousId);
 
-      // new session will be generated
-      expect(state.session.sessionInfo.value.autoTrack).toBe(sessionInfoBeforeReset.autoTrack);
-      expect(state.session.sessionInfo.value.timeout).toBe(sessionInfoBeforeReset.timeout);
-      expect(state.session.sessionInfo.value.expiresAt).not.toBe(sessionInfoBeforeReset.expiresAt);
-      expect(state.session.sessionInfo.value.id).not.toBe(sessionInfoBeforeReset.id);
-      expect(state.session.sessionInfo.value.sessionStart).toBe(undefined);
+      expect(state.session.initialReferrer.value).toEqual(dataBeforeReset.initialReferrer);
 
-      jest.useRealTimers();
+      expect(state.session.initialReferringDomain.value).toEqual(
+        dataBeforeReset.initialReferringDomain,
+      );
+
+      // new session will be generated
+      expect(state.session.sessionInfo.value.autoTrack).toBe(dataBeforeReset.sessionInfo.autoTrack);
+      expect(state.session.sessionInfo.value.manualTrack).toBe(
+        dataBeforeReset.sessionInfo.manualTrack,
+      );
+      expect(state.session.sessionInfo.value.cutOff).toEqual(dataBeforeReset.sessionInfo.cutOff);
+      expect(state.session.sessionInfo.value.timeout).toBe(dataBeforeReset.sessionInfo.timeout);
+      expect(state.session.sessionInfo.value.expiresAt).not.toBe(
+        dataBeforeReset.sessionInfo.expiresAt,
+      );
+      expect(state.session.sessionInfo.value.id).not.toBe(dataBeforeReset.sessionInfo.id);
+      expect(state.session.sessionInfo.value.sessionStart).toBe(undefined);
     });
 
     it('should clear the existing anonymousId and set a new anonymousId with first parameter set to true', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       userSessionManager.init();
       userSessionManager.setAnonymousId(dummyAnonymousId);
+
+      jest.advanceTimersByTime(1000);
       userSessionManager.reset(true);
+
+      expect(state.session.anonymousId.value).toEqual('test_uuid');
+    });
+
+    it('should clear the existing anonymousId and set a new anonymousId when configured in the options', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+      userSessionManager.setAnonymousId(dummyAnonymousId);
+
+      jest.advanceTimersByTime(1000);
+      userSessionManager.reset({
+        entries: {
+          anonymousId: true,
+        },
+      });
       expect(state.session.anonymousId.value).toEqual('test_uuid');
     });
 
@@ -1812,11 +1880,17 @@ describe('User session manager', () => {
       state.storage.entries.value = anonymousIdWithNoStorageEntries;
       userSessionManager.init();
       userSessionManager.setAnonymousId(dummyAnonymousId);
-      userSessionManager.reset(true);
+
+      jest.advanceTimersByTime(1000);
+      userSessionManager.reset({
+        entries: {
+          anonymousId: true,
+        },
+      });
       expect(state.session.anonymousId.value).toEqual('');
     });
 
-    it('should not start a new session with second parameter set to true', () => {
+    it('should not start a new session when configured in the options', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       state.loadOptions.value.sessions = {
         autoTrack: true,
@@ -1828,8 +1902,152 @@ describe('User session manager', () => {
 
       userSessionManager.init();
       const sessionInfoBeforeReset = JSON.parse(JSON.stringify(state.session.sessionInfo.value));
-      userSessionManager.reset(true, true);
+
+      jest.advanceTimersByTime(1000);
+      userSessionManager.reset({
+        entries: {
+          sessionInfo: false,
+        },
+      });
       expect(state.session.sessionInfo.value).toEqual(sessionInfoBeforeReset);
+    });
+
+    it('should reset all the user session data as per the configuration', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Configure data in session
+      userSessionManager.setAnonymousId(dummyAnonymousId);
+      userSessionManager.setUserId('test_user_id');
+      userSessionManager.setUserTraits({
+        name: 'test_user_name',
+        email: 'test_user_email',
+      });
+      userSessionManager.setGroupId('test_group_id');
+      userSessionManager.setGroupTraits({
+        name: 'test_group_name',
+      });
+      userSessionManager.setInitialReferrer('test_initial_referrer');
+      userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
+      userSessionManager.setAuthToken('test_auth_token');
+
+      const dataBeforeReset = {
+        userId: state.session.userId.value,
+        userTraits: state.session.userTraits.value,
+        groupId: state.session.groupId.value,
+        groupTraits: state.session.groupTraits.value,
+        initialReferrer: state.session.initialReferrer.value,
+        initialReferringDomain: state.session.initialReferringDomain.value,
+        anonymousId: state.session.anonymousId.value,
+        sessionInfo: state.session.sessionInfo.value,
+        authToken: state.session.authToken.value,
+      };
+
+      jest.advanceTimersByTime(1000);
+      userSessionManager.reset({
+        entries: {
+          anonymousId: true,
+          initialReferrer: true,
+          initialReferringDomain: true,
+        },
+      });
+
+      const dataAfterReset = {
+        userId: state.session.userId.value,
+        userTraits: state.session.userTraits.value,
+        groupId: state.session.groupId.value,
+        groupTraits: state.session.groupTraits.value,
+        initialReferrer: state.session.initialReferrer.value,
+        initialReferringDomain: state.session.initialReferringDomain.value,
+        anonymousId: state.session.anonymousId.value,
+        sessionInfo: state.session.sessionInfo.value,
+        authToken: state.session.authToken.value,
+      };
+
+      expect(dataAfterReset.userId).not.toEqual(dataBeforeReset.userId);
+      expect(dataAfterReset.userTraits).not.toEqual(dataBeforeReset.userTraits);
+      expect(dataAfterReset.groupId).not.toEqual(dataBeforeReset.groupId);
+      expect(dataAfterReset.groupTraits).not.toEqual(dataBeforeReset.groupTraits);
+      expect(dataAfterReset.initialReferrer).not.toEqual(dataBeforeReset.initialReferrer);
+      expect(dataAfterReset.initialReferringDomain).not.toEqual(
+        dataBeforeReset.initialReferringDomain,
+      );
+      expect(dataAfterReset.anonymousId).not.toEqual(dataBeforeReset.anonymousId);
+      expect(dataAfterReset.authToken).not.toEqual(dataBeforeReset.authToken);
+
+      expect(dataAfterReset.sessionInfo.autoTrack).toBe(dataBeforeReset.sessionInfo.autoTrack);
+      expect(dataAfterReset.sessionInfo.manualTrack).toBe(dataBeforeReset.sessionInfo.manualTrack);
+      expect(dataAfterReset.sessionInfo.cutOff).toEqual(dataBeforeReset.sessionInfo.cutOff);
+      expect(dataAfterReset.sessionInfo.timeout).toBe(dataBeforeReset.sessionInfo.timeout);
+      expect(dataAfterReset.sessionInfo.expiresAt).not.toBe(dataBeforeReset.sessionInfo.expiresAt);
+      expect(dataAfterReset.sessionInfo.id).not.toBe(dataBeforeReset.sessionInfo.id);
+      expect(dataAfterReset.sessionInfo.sessionStart).toBe(undefined);
+    });
+
+    it('should not reset any user session data when configured in the options', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Configure data in session
+      userSessionManager.setAnonymousId(dummyAnonymousId);
+      userSessionManager.setUserId('test_user_id');
+      userSessionManager.setUserTraits({
+        name: 'test_user_name',
+        email: 'test_user_email',
+      });
+      userSessionManager.setGroupId('test_group_id');
+      userSessionManager.setGroupTraits({
+        name: 'test_group_name',
+      });
+      userSessionManager.setInitialReferrer('test_initial_referrer');
+      userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
+      userSessionManager.setAuthToken('test_auth_token');
+
+      const dataBeforeReset = {
+        userId: state.session.userId.value,
+        userTraits: state.session.userTraits.value,
+        groupId: state.session.groupId.value,
+        groupTraits: state.session.groupTraits.value,
+        initialReferrer: state.session.initialReferrer.value,
+        initialReferringDomain: state.session.initialReferringDomain.value,
+        anonymousId: state.session.anonymousId.value,
+        sessionInfo: state.session.sessionInfo.value,
+        authToken: state.session.authToken.value,
+      };
+
+      jest.advanceTimersByTime(1000);
+      userSessionManager.reset({
+        entries: {
+          userId: false,
+          userTraits: false,
+          groupId: false,
+          groupTraits: false,
+          sessionInfo: false,
+          authToken: false,
+        },
+      });
+
+      const dataAfterReset = {
+        userId: state.session.userId.value,
+        userTraits: state.session.userTraits.value,
+        groupId: state.session.groupId.value,
+        groupTraits: state.session.groupTraits.value,
+        initialReferrer: state.session.initialReferrer.value,
+        initialReferringDomain: state.session.initialReferringDomain.value,
+        anonymousId: state.session.anonymousId.value,
+        sessionInfo: state.session.sessionInfo.value,
+        authToken: state.session.authToken.value,
+      };
+
+      expect(dataAfterReset.userId).toEqual(dataBeforeReset.userId);
+      expect(dataAfterReset.userTraits).toEqual(dataBeforeReset.userTraits);
+      expect(dataAfterReset.groupId).toEqual(dataBeforeReset.groupId);
+      expect(dataAfterReset.groupTraits).toEqual(dataBeforeReset.groupTraits);
+      expect(dataAfterReset.initialReferrer).toEqual(dataBeforeReset.initialReferrer);
+      expect(dataAfterReset.initialReferringDomain).toEqual(dataBeforeReset.initialReferringDomain);
+      expect(dataAfterReset.anonymousId).toEqual(dataBeforeReset.anonymousId);
+      expect(dataAfterReset.sessionInfo).toEqual(dataBeforeReset.sessionInfo);
+      expect(dataAfterReset.authToken).toEqual(dataBeforeReset.authToken);
     });
 
     it('should retain previous session timeout and cut off information when auto tracking is enabled', () => {
@@ -1841,6 +2059,7 @@ describe('User session manager', () => {
 
       userSessionManager.init();
 
+      jest.advanceTimersByTime(1000);
       userSessionManager.reset();
 
       expect(state.session.sessionInfo.value).toEqual({

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1799,7 +1799,7 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = {
+      const dataBeforeReset = JSON.parse(JSON.stringify({
         userId: state.session.userId.value,
         userTraits: state.session.userTraits.value,
         groupId: state.session.groupId.value,
@@ -1809,7 +1809,7 @@ describe('User session manager', () => {
         anonymousId: state.session.anonymousId.value,
         sessionInfo: state.session.sessionInfo.value,
         authToken: state.session.authToken.value,
-      };
+      }));
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset();
@@ -1931,7 +1931,7 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = {
+      const dataBeforeReset = JSON.parse(JSON.stringify({
         userId: state.session.userId.value,
         userTraits: state.session.userTraits.value,
         groupId: state.session.groupId.value,
@@ -1941,7 +1941,7 @@ describe('User session manager', () => {
         anonymousId: state.session.anonymousId.value,
         sessionInfo: state.session.sessionInfo.value,
         authToken: state.session.authToken.value,
-      };
+      }));
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset({
@@ -1952,7 +1952,7 @@ describe('User session manager', () => {
         },
       });
 
-      const dataAfterReset = {
+      const dataAfterReset = JSON.parse(JSON.stringify({
         userId: state.session.userId.value,
         userTraits: state.session.userTraits.value,
         groupId: state.session.groupId.value,
@@ -1962,7 +1962,7 @@ describe('User session manager', () => {
         anonymousId: state.session.anonymousId.value,
         sessionInfo: state.session.sessionInfo.value,
         authToken: state.session.authToken.value,
-      };
+      }));
 
       expect(dataAfterReset.userId).not.toEqual(dataBeforeReset.userId);
       expect(dataAfterReset.userTraits).not.toEqual(dataBeforeReset.userTraits);
@@ -2003,7 +2003,7 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = {
+      const dataBeforeReset = JSON.parse(JSON.stringify({
         userId: state.session.userId.value,
         userTraits: state.session.userTraits.value,
         groupId: state.session.groupId.value,
@@ -2013,7 +2013,7 @@ describe('User session manager', () => {
         anonymousId: state.session.anonymousId.value,
         sessionInfo: state.session.sessionInfo.value,
         authToken: state.session.authToken.value,
-      };
+      }));
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset({
@@ -2027,7 +2027,7 @@ describe('User session manager', () => {
         },
       });
 
-      const dataAfterReset = {
+      const dataAfterReset = JSON.parse(JSON.stringify({
         userId: state.session.userId.value,
         userTraits: state.session.userTraits.value,
         groupId: state.session.groupId.value,
@@ -2037,7 +2037,7 @@ describe('User session manager', () => {
         anonymousId: state.session.anonymousId.value,
         sessionInfo: state.session.sessionInfo.value,
         authToken: state.session.authToken.value,
-      };
+      }));
 
       expect(dataAfterReset.userId).toEqual(dataBeforeReset.userId);
       expect(dataAfterReset.userTraits).toEqual(dataBeforeReset.userTraits);

--- a/packages/analytics-js/__tests__/components/userSessionManager/utils.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/utils.test.ts
@@ -9,6 +9,7 @@ import {
   isCutOffTimeExceeded,
   generateAnonymousId,
   getCutOffExpirationTimestamp,
+  getFinalResetOptions,
 } from '../../../src/components/userSessionManager/utils';
 import { defaultLogger } from '../../../src/services/Logger';
 
@@ -275,7 +276,6 @@ describe('Utilities: User session manager', () => {
       const outcome3 = isStorageTypeValidForStoringData('memoryStorage');
       const outcome4 = isStorageTypeValidForStoringData('sessionStorage');
       const outcome5 = isStorageTypeValidForStoringData('none');
-      // @ts-expect-error testing invalid input
       const outcome6 = isStorageTypeValidForStoringData('random');
       expect(outcome1).toEqual(true);
       expect(outcome2).toEqual(true);
@@ -400,6 +400,146 @@ describe('Utilities: User session manager', () => {
     it('should return a newly generated anonymous id', () => {
       const outcome = generateAnonymousId();
       expect(outcome).toMatch(/^[\dA-Fa-f]{8}(?:-[\dA-Fa-f]{4}){3}-[\dA-Fa-f]{12}$/);
+    });
+  });
+
+  describe('getFinalResetOptions', () => {
+    const defaultOptions = {
+      entries: {
+        userId: true,
+        userTraits: true,
+        groupId: true,
+        groupTraits: true,
+        sessionInfo: true,
+        authToken: true,
+        anonymousId: false,
+        initialReferrer: false,
+        initialReferringDomain: false,
+      },
+    };
+
+    const testCases = [
+      {
+        input: undefined,
+        expected: defaultOptions,
+      },
+      {
+        input: true,
+        expected: {
+          ...defaultOptions,
+          entries: {
+            ...defaultOptions.entries,
+            anonymousId: true,
+          },
+        },
+      },
+      {
+        input: {
+          entries: {
+            userId: false,
+          },
+        },
+        expected: {
+          ...defaultOptions,
+          entries: {
+            ...defaultOptions.entries,
+            userId: false,
+          },
+        },
+      },
+      {
+        input: {
+          entries: {
+            userId: false,
+          },
+        },
+        expected: {
+          ...defaultOptions,
+          entries: {
+            ...defaultOptions.entries,
+            userId: false,
+          },
+        },
+      },
+      {
+        input: {
+          entries: {
+            userId: false,
+            userTraits: false,
+          },
+        },
+        expected: {
+          ...defaultOptions,
+          entries: {
+            ...defaultOptions.entries,
+            userId: false,
+            userTraits: false,
+          },
+        },
+      },
+      {
+        input: {
+          entries: {},
+        },
+        expected: defaultOptions,
+      },
+      {
+        input: {},
+        expected: defaultOptions,
+      },
+      {
+        input: null,
+        expected: defaultOptions,
+      },
+      {
+        input: false,
+        expected: defaultOptions,
+      },
+      {
+        input: 'xyz',
+        expected: defaultOptions,
+      },
+      {
+        input: 123,
+        expected: defaultOptions,
+      },
+      {
+        input: {
+          entries: null,
+        },
+        expected: defaultOptions,
+      },
+      {
+        input: {
+          entries: undefined,
+        },
+        expected: defaultOptions,
+      },
+      {
+        input: {
+          entries: {
+            userId: 'xyz',
+            abc: false,
+            anonymousId: {},
+          },
+        },
+        expected: {
+          ...defaultOptions,
+          entries: {
+            ...defaultOptions.entries,
+            userId: 'xyz',
+            abc: false,
+            anonymousId: {},
+          },
+        },
+      },
+    ];
+
+    testCases.forEach(testCase => {
+      it(`should return the correct reset options for ${JSON.stringify(testCase.input)}`, () => {
+        const outcome = getFinalResetOptions(testCase.input);
+        expect(outcome).toEqual(testCase.expected);
+      });
     });
   });
 });

--- a/packages/analytics-js/public/index.html
+++ b/packages/analytics-js/public/index.html
@@ -176,13 +176,13 @@
             const envDestSDKBaseURL = '__DEST_SDK_BASE_URL__';
             // This is to avoid the build process from replacing the placeholder with the actual value
             const envDestSDKBaseURLPlaceHolder = '__' + 'DEST_SDK_BASE_URL' + '__';
-            if (envDestSDKBaseURL !== '' && envDestSDKBaseURL !== 'undefined' && envDestSDKBaseURL !== envDestSDKBaseURLPlaceHolder) {
+            if (envDestSDKBaseURL !== '' && envDestSDKBaseURL !== 'undefined/' && envDestSDKBaseURL !== envDestSDKBaseURLPlaceHolder) {
               loadOptions.destSDKBaseURL = envDestSDKBaseURL + window.rudderAnalyticsBuildType + '/js-integrations';
             }
             const envPluginsSDKBaseURL = '__PLUGINS_BASE_URL__';
             // This is to avoid the build process from replacing the placeholder with the actual value
             const envPluginsSDKBaseURLPlaceHolder = '__' + 'PLUGINS_BASE_URL' + '__';
-            if (envPluginsSDKBaseURL !== '' && envPluginsSDKBaseURL !== 'undefined' && envPluginsSDKBaseURL !== envPluginsSDKBaseURLPlaceHolder) {
+            if (envPluginsSDKBaseURL !== '' && envPluginsSDKBaseURL !== 'undefined/' && envPluginsSDKBaseURL !== envPluginsSDKBaseURLPlaceHolder) {
               loadOptions.pluginsSDKBaseURL = envPluginsSDKBaseURL + window.rudderAnalyticsBuildType + '/plugins';
             }
             const envConfigUrl = '__CONFIG_SERVER_HOST__';

--- a/packages/analytics-js/rollup.config.mjs
+++ b/packages/analytics-js/rollup.config.mjs
@@ -35,9 +35,9 @@ const sourceMapType =
   process.env.PROD_DEBUG === 'inline' ? 'inline' : process.env.PROD_DEBUG === 'true';
 const cdnPath = isDynamicCustomBuild ? `dynamicCdnBundle` : `cdn`;
 let remotePluginsBasePath =
-  process.env.REMOTE_MODULES_BASE_PATH;
+  process.env.REMOTE_MODULES_BASE_PATH ?? `${baseCdnUrl}/v3`;
 remotePluginsBasePath = remotePluginsBasePath?.endsWith('/') ? remotePluginsBasePath : `${remotePluginsBasePath}/`;
-let destSDKBaseURL = process.env.DEST_SDK_BASE_URL;
+let destSDKBaseURL = process.env.DEST_SDK_BASE_URL ?? `${baseCdnUrl}/v3`;
 destSDKBaseURL = destSDKBaseURL?.endsWith('/') ? destSDKBaseURL : `${destSDKBaseURL}/`;
 const outDirNpmRoot = `dist/npm`;
 const outDirCDNRoot = `dist/${cdnPath}`;

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -17,13 +17,17 @@ import {
   type AnonymousIdOptions,
   type LoadOptions,
 } from '@rudderstack/analytics-js-common/types/LoadOptions';
-import type { ApiCallback, ApiOptions } from '@rudderstack/analytics-js-common/types/EventApi';
+import type {
+  ApiCallback,
+  ApiOptions,
+  ResetOptions,
+} from '@rudderstack/analytics-js-common/types/EventApi';
 import type { ApiObject } from '@rudderstack/analytics-js-common/types/ApiObject';
 import { RSA } from '@rudderstack/analytics-js-common/constants/loggerContexts';
 import type { IdentifyTraits } from '@rudderstack/analytics-js-common/types/traits';
 import { generateUUID } from '@rudderstack/analytics-js-common/utilities/uuId';
 import { onPageLeave } from '@rudderstack/analytics-js-common/utilities/page';
-import { isString } from '@rudderstack/analytics-js-common/utilities/checks';
+import { isBoolean, isString } from '@rudderstack/analytics-js-common/utilities/checks';
 import { getFormattedTimestamp } from '@rudderstack/analytics-js-common/utilities/timestamp';
 import { dispatchErrorEvent } from '@rudderstack/analytics-js-common/utilities/errors';
 import { getSanitizedValue } from '@rudderstack/analytics-js-common/utilities/json';
@@ -525,9 +529,40 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
     }
   }
 
-  reset(resetAnonymousId?: boolean) {
+  /**
+   * Reset the analytics instance
+   * @param options Reset options. Except for anonymousId, initialReferrer, and initialReferringDomain
+   * all other values will be reset by default.
+   * @example
+   * ```ts
+   * reset({
+   *  entries: {
+   *    anonymousId: true,
+   *  }
+   * });
+   * ```
+   * @example
+   * ```ts
+   * reset({
+   *  entries: {
+   *    userId: false,
+   *    sessionInfo: false,
+   *  }
+   * });
+   * ```
+   * @returns none
+   */
+  reset(options?: ResetOptions): void;
+  /**
+   * Reset the analytics instance
+   * @param resetAnonymousId Reset anonymous ID
+   * @returns none
+   * @deprecated Use reset(options) instead
+   */
+  reset(resetAnonymousId?: boolean): void;
+  reset(options?: ResetOptions | boolean): void {
     try {
-      this.getAnalyticsInstance()?.reset(getSanitizedValue(resetAnonymousId));
+      this.getAnalyticsInstance()?.reset(getSanitizedValue(options));
     } catch (error: any) {
       dispatchErrorEvent(error);
     }

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -27,7 +27,7 @@ import { RSA } from '@rudderstack/analytics-js-common/constants/loggerContexts';
 import type { IdentifyTraits } from '@rudderstack/analytics-js-common/types/traits';
 import { generateUUID } from '@rudderstack/analytics-js-common/utilities/uuId';
 import { onPageLeave } from '@rudderstack/analytics-js-common/utilities/page';
-import { isBoolean, isString } from '@rudderstack/analytics-js-common/utilities/checks';
+import { isString } from '@rudderstack/analytics-js-common/utilities/checks';
 import { getFormattedTimestamp } from '@rudderstack/analytics-js-common/utilities/timestamp';
 import { dispatchErrorEvent } from '@rudderstack/analytics-js-common/utilities/errors';
 import { getSanitizedValue } from '@rudderstack/analytics-js-common/utilities/json';

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -15,7 +15,7 @@ import type {
   AnonymousIdOptions,
   LoadOptions,
 } from '@rudderstack/analytics-js-common/types/LoadOptions';
-import type { ApiCallback } from '@rudderstack/analytics-js-common/types/EventApi';
+import type { ApiCallback, ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 import {
   ANALYTICS_CORE,
   LOAD_API,
@@ -70,6 +70,7 @@ import { getConsentManagementData, getValidPostConsentOptions } from '../utiliti
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
+import { stringifyData } from '@rudderstack/analytics-js-common/utilities/json';
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events
@@ -651,21 +652,19 @@ class Analytics implements IAnalytics {
     });
   }
 
-  reset(resetAnonymousId?: boolean, isBufferedInvocation = false) {
+  reset(options?: ResetOptions | boolean, isBufferedInvocation = false) {
     const type = 'reset';
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, resetAnonymousId],
+        [type, options],
       ];
       return;
     }
 
-    this.errorHandler.leaveBreadcrumb(
-      `New ${type} invocation, resetAnonymousId: ${resetAnonymousId}`,
-    );
-    this.userSessionManager?.reset(resetAnonymousId);
+    this.errorHandler.leaveBreadcrumb(`New ${type} invocation`);
+    this.userSessionManager?.reset(options);
   }
 
   getAnonymousId(options?: AnonymousIdOptions): string | undefined {

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -70,7 +70,6 @@ import { getConsentManagementData, getValidPostConsentOptions } from '../utiliti
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
-import { stringifyData } from '@rudderstack/analytics-js-common/utilities/json';
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -6,7 +6,7 @@ import type {
   AnonymousIdOptions,
   LoadOptions,
 } from '@rudderstack/analytics-js-common/types/LoadOptions';
-import type { ApiCallback } from '@rudderstack/analytics-js-common/types/EventApi';
+import type { ApiCallback, ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 import type { IStoreManager } from '@rudderstack/analytics-js-common/types/Store';
 import type { IPluginsManager } from '@rudderstack/analytics-js-common/types/PluginsManager';
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
@@ -167,9 +167,10 @@ export interface IAnalytics {
   ): void;
 
   /**
-   * Clear user information, optionally anonymousId as well
+   * Clear user information
+   * @param options options for reset
    */
-  reset(resetAnonymousId?: boolean, isBufferedInvocation?: boolean): void;
+  reset(options?: ResetOptions | boolean, isBufferedInvocation?: boolean): void;
 
   /**
    * To get userId set in the SDK

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -6,7 +6,6 @@ import {
   mergeDeepRight,
 } from '@rudderstack/analytics-js-common/utilities/object';
 import {
-  isBoolean,
   isDefinedAndNotNull,
   isDefinedNotNullAndNotEmptyString,
   isNullOrUndefined,
@@ -71,11 +70,7 @@ import {
 } from './utils';
 import { getReferringDomain } from '../utilities/url';
 import { getReferrer } from '../utilities/page';
-import {
-  DEFAULT_RESET_OPTIONS,
-  DEFAULT_USER_SESSION_VALUES,
-  SERVER_SIDE_COOKIES_DEBOUNCE_TIME,
-} from './constants';
+import { DEFAULT_USER_SESSION_VALUES, SERVER_SIDE_COOKIES_DEBOUNCE_TIME } from './constants';
 import type {
   CallbackFunction,
   CookieData,

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -767,7 +767,8 @@ class UserSessionManager implements IUserSessionManager {
 
     batch(() => {
       Object.keys(DEFAULT_USER_SESSION_VALUES).forEach(key => {
-        if (opts.entries[key as UserSessionKey] !== true) {
+        const userSessionKey = key as UserSessionKey;
+        if (opts.entries[userSessionKey] !== true) {
           return;
         }
 
@@ -779,8 +780,7 @@ class UserSessionManager implements IUserSessionManager {
             this.resetAndStartNewSession();
             break;
           default:
-            session[key as UserSessionKey].value =
-              DEFAULT_USER_SESSION_VALUES[key as UserSessionKey];
+            session[userSessionKey].value = DEFAULT_USER_SESSION_VALUES[userSessionKey];
             break;
         }
       });

--- a/packages/analytics-js/src/components/userSessionManager/constants.ts
+++ b/packages/analytics-js/src/components/userSessionManager/constants.ts
@@ -2,8 +2,9 @@ import type { ApiObject } from '@rudderstack/analytics-js-common/types/ApiObject
 import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 import type { SessionInfo } from '@rudderstack/analytics-js-common/types/Session';
 import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
+import { deepFreeze } from '@rudderstack/analytics-js-common/utilities/object';
 
-const DEFAULT_USER_SESSION_VALUES: Record<UserSessionKey, any> = {
+const DEFAULT_USER_SESSION_VALUES: Record<UserSessionKey, any> = deepFreeze({
   userId: '',
   userTraits: {} as ApiObject,
   anonymousId: '',
@@ -13,9 +14,9 @@ const DEFAULT_USER_SESSION_VALUES: Record<UserSessionKey, any> = {
   initialReferringDomain: '',
   sessionInfo: {} as SessionInfo,
   authToken: null,
-};
+});
 
-const DEFAULT_RESET_OPTIONS: ResetOptions = {
+const DEFAULT_RESET_OPTIONS: ResetOptions = deepFreeze({
   entries: {
     userId: true,
     userTraits: true,
@@ -23,11 +24,12 @@ const DEFAULT_RESET_OPTIONS: ResetOptions = {
     groupTraits: true,
     sessionInfo: true,
     authToken: true,
+    // These are not reset by default
     anonymousId: false,
     initialReferrer: false,
     initialReferringDomain: false,
   },
-};
+});
 
 const SERVER_SIDE_COOKIES_DEBOUNCE_TIME = 10; // milliseconds
 

--- a/packages/analytics-js/src/components/userSessionManager/constants.ts
+++ b/packages/analytics-js/src/components/userSessionManager/constants.ts
@@ -1,7 +1,9 @@
 import type { ApiObject } from '@rudderstack/analytics-js-common/types/ApiObject';
+import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 import type { SessionInfo } from '@rudderstack/analytics-js-common/types/Session';
+import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
 
-const DEFAULT_USER_SESSION_VALUES = {
+const DEFAULT_USER_SESSION_VALUES: Record<UserSessionKey, any> = {
   userId: '',
   userTraits: {} as ApiObject,
   anonymousId: '',
@@ -13,6 +15,20 @@ const DEFAULT_USER_SESSION_VALUES = {
   authToken: null,
 };
 
+const DEFAULT_RESET_OPTIONS: ResetOptions = {
+  entries: {
+    userId: true,
+    userTraits: true,
+    groupId: true,
+    groupTraits: true,
+    sessionInfo: true,
+    authToken: true,
+    anonymousId: false,
+    initialReferrer: false,
+    initialReferringDomain: false,
+  },
+};
+
 const SERVER_SIDE_COOKIES_DEBOUNCE_TIME = 10; // milliseconds
 
-export { DEFAULT_USER_SESSION_VALUES, SERVER_SIDE_COOKIES_DEBOUNCE_TIME };
+export { DEFAULT_USER_SESSION_VALUES, SERVER_SIDE_COOKIES_DEBOUNCE_TIME, DEFAULT_RESET_OPTIONS };

--- a/packages/analytics-js/src/components/userSessionManager/types.ts
+++ b/packages/analytics-js/src/components/userSessionManager/types.ts
@@ -3,6 +3,7 @@ import type { AnonymousIdOptions } from '@rudderstack/analytics-js-common/types/
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 import type { ApiObject } from '@rudderstack/analytics-js-common/types/ApiObject';
 import type { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
+import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 
 export interface IUserSessionManager {
   storeManager?: IStoreManager;
@@ -19,7 +20,7 @@ export interface IUserSessionManager {
   getGroupTraits(): Nullable<ApiObject>;
   setGroupId(groupId?: Nullable<string>): void;
   setGroupTraits(traits?: Nullable<ApiObject>): void;
-  reset(resetAnonymousId?: boolean, noNewSessionStart?: boolean): void;
+  reset(options?: ResetOptions | boolean): void;
   start(sessionId?: number): void;
   end(): void;
   syncStorageDataToState(): void;

--- a/packages/analytics-js/src/components/userSessionManager/utils.ts
+++ b/packages/analytics-js/src/components/userSessionManager/utils.ts
@@ -122,16 +122,20 @@ const isStorageTypeValidForStoringData = (storageType: StorageType): boolean =>
 const generateAnonymousId = (): string => generateUUID();
 
 const getFinalResetOptions = (options: ResetOptions | boolean | undefined): ResetOptions => {
-  let opts = DEFAULT_RESET_OPTIONS;
+  // Legacy behavior: toggle only anonymousId without mutating defaults
   if (isBoolean(options)) {
-    // This case is for backward compatibility with the previous API
-    opts.entries.anonymousId = options;
-  } else {
-    // Override any defaults with the user provided options
-    opts = mergeDeepRight(DEFAULT_RESET_OPTIONS, options ?? {});
+    const { entries, ...rest } = DEFAULT_RESET_OPTIONS;
+    return {
+      ...rest,
+      entries: {
+        ...entries,
+        anonymousId: options,
+      },
+    };
   }
 
-  return opts;
+  // Override any defaults with the user provided options
+  return mergeDeepRight(DEFAULT_RESET_OPTIONS, options ?? {});
 };
 
 export {

--- a/packages/analytics-js/src/components/userSessionManager/utils.ts
+++ b/packages/analytics-js/src/components/userSessionManager/utils.ts
@@ -14,7 +14,10 @@ import { hasMinLength, isPositiveInteger } from '../utilities/number';
 import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 import { DEFAULT_RESET_OPTIONS } from './constants';
 import { isBoolean } from '@rudderstack/analytics-js-common/utilities/checks';
-import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/object';
+import {
+  isObjectLiteralAndNotNull,
+  mergeDeepRight,
+} from '@rudderstack/analytics-js-common/utilities/object';
 
 const MIN_SESSION_ID_LENGTH = 10;
 
@@ -135,7 +138,11 @@ const getFinalResetOptions = (options: ResetOptions | boolean | undefined): Rese
   }
 
   // Override any defaults with the user provided options
-  return mergeDeepRight(DEFAULT_RESET_OPTIONS, options ?? {});
+  if (isObjectLiteralAndNotNull(options) && isObjectLiteralAndNotNull(options.entries)) {
+    return mergeDeepRight(DEFAULT_RESET_OPTIONS, options);
+  }
+
+  return { ...DEFAULT_RESET_OPTIONS };
 };
 
 export {

--- a/packages/analytics-js/src/components/userSessionManager/utils.ts
+++ b/packages/analytics-js/src/components/userSessionManager/utils.ts
@@ -11,6 +11,10 @@ import {
 import { generateUUID } from '@rudderstack/analytics-js-common/utilities/uuId';
 import { INVALID_SESSION_ID_WARNING } from '../../constants/logMessages';
 import { hasMinLength, isPositiveInteger } from '../utilities/number';
+import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
+import { DEFAULT_RESET_OPTIONS } from './constants';
+import { isBoolean } from '@rudderstack/analytics-js-common/utilities/checks';
+import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/object';
 
 const MIN_SESSION_ID_LENGTH = 10;
 
@@ -117,6 +121,19 @@ const isStorageTypeValidForStoringData = (storageType: StorageType): boolean =>
  */
 const generateAnonymousId = (): string => generateUUID();
 
+const getFinalResetOptions = (options: ResetOptions | boolean | undefined): ResetOptions => {
+  let opts = DEFAULT_RESET_OPTIONS;
+  if (isBoolean(options)) {
+    // This case is for backward compatibility with the previous API
+    opts.entries.anonymousId = options;
+  } else {
+    // Override any defaults with the user provided options
+    opts = mergeDeepRight(DEFAULT_RESET_OPTIONS, options ?? {});
+  }
+
+  return opts;
+};
+
 export {
   hasSessionExpired,
   generateSessionId,
@@ -127,4 +144,5 @@ export {
   generateAnonymousId,
   isCutOffTimeExceeded,
   getCutOffExpirationTimestamp,
+  getFinalResetOptions,
 };


### PR DESCRIPTION
## PR Description

The `reset` API now supports `options` argument along with `resetAnonymousId` flag for backward compatibility.

The options also support to reset the `initialReferrer` and `initialReferringDomain` entries.

By default, anonymous ID, initial referrer and initial referring domain values are not cleared.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3362/js-implementation-of-overload-reset-method

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Granular reset API: reset now accepts a ResetOptions object to selectively clear user/session fields; boolean form remains supported. New flow can reinitialize sessions when requested.

- **Utilities**
  - Added deepFreeze utility, DEFAULT_RESET_OPTIONS, and getFinalResetOptions helper for consistent reset behavior.

- **Documentation**
  - Updated public API docs/examples for options-based reset.

- **Tests**
  - Expanded tests for granular reset behavior, session lifecycle, option merging, and deepFreeze immutability.

- **Chores**
  - Minor bundle size limit increases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->