### PR TITLE
chore(release): merge hotfix-release/3.94.0-SDK-3780 into main [SDK-3780]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rudderstack/analytics-js-monorepo",
-  "version": "3.93.0",
+  "version": "3.94.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rudderstack/analytics-js-monorepo",
-      "version": "3.93.0",
+      "version": "3.94.0",
       "hasInstallScript": true,
       "license": "Elastic-2.0",
       "workspaces": [
@@ -26678,7 +26678,7 @@
     },
     "packages/analytics-js": {
       "name": "@rudderstack/analytics-js",
-      "version": "3.23.0",
+      "version": "3.23.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@preact/signals-core": "1.11.0",
@@ -26716,7 +26716,7 @@
     },
     "packages/analytics-js-integrations": {
       "name": "@rudderstack/analytics-js-integrations",
-      "version": "3.16.1",
+      "version": "3.17.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@lukeed/uuid": "2.0.1",
@@ -26777,7 +26777,7 @@
     },
     "packages/analytics-js-plugins": {
       "name": "@rudderstack/analytics-js-plugins",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@rudderstack/analytics-js-common": "*",
@@ -26844,7 +26844,7 @@
     },
     "packages/analytics-v1.1": {
       "name": "rudder-sdk-js",
-      "version": "2.52.2",
+      "version": "2.52.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@lukeed/uuid": "2.0.1",
@@ -26868,7 +26868,7 @@
     },
     "packages/sanity-suite": {
       "name": "@rudderstack/analytics-js-sanity-suite",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@rudderstack/analytics-js": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-monorepo",
-  "version": "3.93.0",
+  "version": "3.94.0",
   "private": true,
   "description": "Monorepo for RudderStack Analytics JS SDK",
   "workspaces": [

--- a/packages/analytics-js-integrations/CHANGELOG.md
+++ b/packages/analytics-js-integrations/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.17.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-integrations@3.16.1...@rudderstack/analytics-js-integrations@3.17.0) (2025-08-27)
+
+
+### Features
+
+* add default consent granted to Bing Ads integration ([#2441](https://github.com/rudderlabs/rudder-sdk-js/issues/2441)) ([#2446](https://github.com/rudderlabs/rudder-sdk-js/issues/2446)) ([fee4081](https://github.com/rudderlabs/rudder-sdk-js/commit/fee4081d057c84cd17e8d0b976236bd8b1ce5725))
+
 ## [3.16.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-integrations@3.16.0...@rudderstack/analytics-js-integrations@3.16.1) (2025-08-11)
 
 

--- a/packages/analytics-js-integrations/CHANGELOG_LATEST.md
+++ b/packages/analytics-js-integrations/CHANGELOG_LATEST.md
@@ -1,8 +1,7 @@
-## [3.16.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-integrations@3.16.0...@rudderstack/analytics-js-integrations@3.16.1) (2025-08-11)
+## [3.17.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-integrations@3.16.1...@rudderstack/analytics-js-integrations@3.17.0) (2025-08-27)
 
 
-### Bug Fixes
+### Features
 
-* is loaded function for heap integration ([#2420](https://github.com/rudderlabs/rudder-sdk-js/issues/2420)) ([dae3607](https://github.com/rudderlabs/rudder-sdk-js/commit/dae3607f435579c80cc20bbac63d2f39dca886ec))
-* prevent null/undefined object conversion error in facebook pixel ([#2297](https://github.com/rudderlabs/rudder-sdk-js/issues/2297)) ([83287e3](https://github.com/rudderlabs/rudder-sdk-js/commit/83287e36f4ba8d54d61d3af0282d284650df2bfd))
+* add default consent granted to Bing Ads integration ([#2441](https://github.com/rudderlabs/rudder-sdk-js/issues/2441)) ([#2446](https://github.com/rudderlabs/rudder-sdk-js/issues/2446)) ([fee4081](https://github.com/rudderlabs/rudder-sdk-js/commit/fee4081d057c84cd17e8d0b976236bd8b1ce5725))
 

--- a/packages/analytics-js-integrations/__tests__/integrations/BingAds/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/BingAds/browser.test.js
@@ -83,7 +83,7 @@ describe('BingAds Track event', () => {
         },
       },
     });
-    expect(output[0]).toEqual({
+    expect(output[1]).toEqual({
       event: 'button_click',
       event_label: event,
       event_category: 'Food',
@@ -118,7 +118,7 @@ describe('BingAds Track event', () => {
         },
       },
     });
-    expect(output[1]).toEqual({
+    expect(output[3]).toEqual({
       event: 'button_click',
       event_label: event,
       event_category: 'Food',
@@ -152,7 +152,7 @@ describe('BingAds Track event', () => {
         },
       },
     });
-    expect(output[2]).toEqual({
+    expect(output[5]).toEqual({
       event: 'button_click',
       event_label: event,
       event_category: 'Food',
@@ -172,7 +172,7 @@ describe('BingAds Track event', () => {
       },
     });
 
-    expect(output[3]).toEqual({
+    expect(output[7]).toEqual({
       event: 'track',
       event_label: event,
       ecomm_pagetype: 'other',
@@ -233,7 +233,7 @@ describe('BingAds Track event', () => {
         },
       },
     });
-    expect(output[4]).toEqual({
+    expect(output[11]).toEqual({
       event: 'button_click',
       event_label: event,
       event_category: 'Food',
@@ -278,7 +278,7 @@ describe('BingAds Track event', () => {
         },
       },
     });
-    expect(output[5]).toEqual({
+    expect(output[14]).toEqual({
       event: 'button_click',
       event_label: event,
       event_category: 'Food',

--- a/packages/analytics-js-integrations/package.json
+++ b/packages/analytics-js-integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-integrations",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "private": true,
   "type": "module",
   "description": "RudderStack JavaScript SDK device mode integrations",

--- a/packages/analytics-js-integrations/project.json
+++ b/packages/analytics-js-integrations/project.json
@@ -51,9 +51,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js-integrations@3.16.1",
-        "title": "@rudderstack/analytics-js-integrations@3.16.1",
-        "discussion-category": "@rudderstack/analytics-js-integrations@3.16.1",
+        "tag": "@rudderstack/analytics-js-integrations@3.17.0",
+        "title": "@rudderstack/analytics-js-integrations@3.17.0",
+        "discussion-category": "@rudderstack/analytics-js-integrations@3.17.0",
         "notesFile": "./packages/analytics-js-integrations/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/analytics-js-integrations/src/integrations/BingAds/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/BingAds/browser.js
@@ -32,6 +32,10 @@ class BingAds {
 
   init() {
     loadNativeSdk(this.uniqueId, this.tagID);
+    // Add consent as "granted" immediately when integration initializes
+    // If execution reaches here, user has consented or consent is not required
+    window[this.uniqueId] = window[this.uniqueId] || [];
+    window[this.uniqueId].push('consent', 'default', { ad_storage: 'granted' });
   }
 
   isLoaded() {

--- a/packages/analytics-js-plugins/CHANGELOG.md
+++ b/packages/analytics-js-plugins/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.12.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.12.0...@rudderstack/analytics-js-plugins@3.12.1) (2025-08-27)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js-integrations` updated to version `3.17.0`
 ## [3.12.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.11.1...@rudderstack/analytics-js-plugins@3.12.0) (2025-08-11)
 
 ### Dependency Updates

--- a/packages/analytics-js-plugins/CHANGELOG_LATEST.md
+++ b/packages/analytics-js-plugins/CHANGELOG_LATEST.md
@@ -1,12 +1,5 @@
-## [3.12.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.11.1...@rudderstack/analytics-js-plugins@3.12.0) (2025-08-11)
+## [3.12.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.12.0...@rudderstack/analytics-js-plugins@3.12.1) (2025-08-27)
 
 ### Dependency Updates
 
-* `@rudderstack/analytics-js-common` updated to version `3.23.0`
-* `@rudderstack/analytics-js-cookies` updated to version `0.5.1`
-* `@rudderstack/analytics-js-integrations` updated to version `3.16.1`
-
-### Features
-
-* add custom device mode integrations support ([#2309](https://github.com/rudderlabs/rudder-sdk-js/issues/2309)) ([db078e6](https://github.com/rudderlabs/rudder-sdk-js/commit/db078e6bae9ab57a18003ac3fa231be8d94cdcaa)), closes [#2295](https://github.com/rudderlabs/rudder-sdk-js/issues/2295) [#2299](https://github.com/rudderlabs/rudder-sdk-js/issues/2299)
-
+* `@rudderstack/analytics-js-integrations` updated to version `3.17.0`

--- a/packages/analytics-js-plugins/package.json
+++ b/packages/analytics-js-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-plugins",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "private": true,
   "description": "RudderStack JavaScript SDK plugins",
   "main": "dist/npm/modern/cjs/index.cjs",

--- a/packages/analytics-js-plugins/project.json
+++ b/packages/analytics-js-plugins/project.json
@@ -51,9 +51,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js-plugins@3.12.0",
-        "title": "@rudderstack/analytics-js-plugins@3.12.0",
-        "discussion-category": "@rudderstack/analytics-js-plugins@3.12.0",
+        "tag": "@rudderstack/analytics-js-plugins@3.12.1",
+        "title": "@rudderstack/analytics-js-plugins@3.12.1",
+        "discussion-category": "@rudderstack/analytics-js-plugins@3.12.1",
         "notesFile": "./packages/analytics-js-plugins/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/analytics-js/CHANGELOG.md
+++ b/packages/analytics-js/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.23.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.23.0...@rudderstack/analytics-js@3.23.1) (2025-08-27)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js-plugins` updated to version `3.12.1`
 ## [3.23.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.22.1...@rudderstack/analytics-js@3.23.0) (2025-08-11)
 
 ### Dependency Updates

--- a/packages/analytics-js/CHANGELOG_LATEST.md
+++ b/packages/analytics-js/CHANGELOG_LATEST.md
@@ -1,12 +1,5 @@
-## [3.23.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.22.1...@rudderstack/analytics-js@3.23.0) (2025-08-11)
+## [3.23.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.23.0...@rudderstack/analytics-js@3.23.1) (2025-08-27)
 
 ### Dependency Updates
 
-* `@rudderstack/analytics-js-cookies` updated to version `0.5.1`
-* `@rudderstack/analytics-js-common` updated to version `3.23.0`
-* `@rudderstack/analytics-js-plugins` updated to version `3.12.0`
-
-### Features
-
-* add custom device mode integrations support ([#2309](https://github.com/rudderlabs/rudder-sdk-js/issues/2309)) ([db078e6](https://github.com/rudderlabs/rudder-sdk-js/commit/db078e6bae9ab57a18003ac3fa231be8d94cdcaa)), closes [#2295](https://github.com/rudderlabs/rudder-sdk-js/issues/2295) [#2299](https://github.com/rudderlabs/rudder-sdk-js/issues/2299)
-
+* `@rudderstack/analytics-js-plugins` updated to version `3.12.1`

--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "RudderStack JavaScript SDK",
   "main": "dist/npm/modern/cjs/index.cjs",
   "module": "dist/npm/modern/esm/index.mjs",

--- a/packages/analytics-js/project.json
+++ b/packages/analytics-js/project.json
@@ -52,9 +52,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js@3.23.0",
-        "title": "@rudderstack/analytics-js@3.23.0",
-        "discussion-category": "@rudderstack/analytics-js@3.23.0",
+        "tag": "@rudderstack/analytics-js@3.23.1",
+        "title": "@rudderstack/analytics-js@3.23.1",
+        "discussion-category": "@rudderstack/analytics-js@3.23.1",
         "notesFile": "./packages/analytics-js/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/analytics-v1.1/CHANGELOG.md
+++ b/packages/analytics-v1.1/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [2.52.3](https://github.com/rudderlabs/rudder-sdk-js/compare/rudder-sdk-js@2.52.2...rudder-sdk-js@2.52.3) (2025-08-27)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js-integrations` updated to version `3.17.0`
 ## [2.52.2](https://github.com/rudderlabs/rudder-sdk-js/compare/rudder-sdk-js@2.52.1...rudder-sdk-js@2.52.2) (2025-08-11)
 
 ### Dependency Updates

--- a/packages/analytics-v1.1/CHANGELOG_LATEST.md
+++ b/packages/analytics-v1.1/CHANGELOG_LATEST.md
@@ -1,5 +1,5 @@
-## [2.52.2](https://github.com/rudderlabs/rudder-sdk-js/compare/rudder-sdk-js@2.52.1...rudder-sdk-js@2.52.2) (2025-08-11)
+## [2.52.3](https://github.com/rudderlabs/rudder-sdk-js/compare/rudder-sdk-js@2.52.2...rudder-sdk-js@2.52.3) (2025-08-27)
 
 ### Dependency Updates
 
-* `@rudderstack/analytics-js-integrations` updated to version `3.16.1`
+* `@rudderstack/analytics-js-integrations` updated to version `3.17.0`

--- a/packages/analytics-v1.1/package.json
+++ b/packages/analytics-v1.1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-sdk-js",
-  "version": "2.52.2",
+  "version": "2.52.3",
   "description": "RudderStack JavaScript SDK",
   "main": "dist/npm/index.js",
   "module": "dist/npm/index.es.js",

--- a/packages/analytics-v1.1/project.json
+++ b/packages/analytics-v1.1/project.json
@@ -59,9 +59,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "rudder-sdk-js@2.52.2",
-        "title": "rudder-sdk-js@2.52.2",
-        "discussion-category": "rudder-sdk-js@2.52.2",
+        "tag": "rudder-sdk-js@2.52.3",
+        "title": "rudder-sdk-js@2.52.3",
+        "discussion-category": "rudder-sdk-js@2.52.3",
         "notesFile": "./packages/analytics-v1.1/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/sanity-suite/CHANGELOG.md
+++ b/packages/sanity-suite/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.5.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-sanity-suite@3.5.0...@rudderstack/analytics-js-sanity-suite@3.5.1) (2025-08-27)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js` updated to version `3.23.1`
 ## [3.5.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-sanity-suite@3.4.1...@rudderstack/analytics-js-sanity-suite@3.5.0) (2025-08-11)
 
 ### Dependency Updates

--- a/packages/sanity-suite/package.json
+++ b/packages/sanity-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-sanity-suite",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": true,
   "description": "Sanity suite for testing JS SDK package",
   "main": "./dist/v3/cdn/testBook.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_repo_rudder-sdk-js
 sonar.organization=rudderlabs
 sonar.projectName=rudder-sdk-js
-sonar.projectVersion=3.93.0
+sonar.projectVersion=3.94.0
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-js


### PR DESCRIPTION
:crown: **Automated Release PR**

This pull request was created automatically by the GitHub Actions workflow. It merges the release branch (`hotfix-release/3.94.0-SDK-3780`) into the `main` branch.

This ensures that the latest release branch changes are incorporated into the `main` branch for production.

### Details
- **Monorepo Release Version**: v3.94.0
- **Release Branch**: `hotfix-release/3.94.0-SDK-3780`
- **Related Ticket**: [SDK-3780](https://linear.app/rudderstack/issue/SDK-3780)

### Version updates

| Package | New version |
|---------|-------------|
| @rudderstack/analytics-js-monorepo | 3.94.0 |
| @rudderstack/analytics-js-common | N/A |
| @rudderstack/analytics-js-cookies | N/A |
| @rudderstack/analytics-js-integrations | 3.17.0 |
| @rudderstack/analytics-js-legacy-utilities | N/A |
| @rudderstack/analytics-js-plugins | 3.12.1 |
| @rudderstack/analytics-js-service-worker | N/A |
| @rudderstack/analytics-js | 3.23.1 |
| rudder-sdk-js | 2.52.3 |
| @rudderstack/analytics-js-loading-scripts | N/A |
| @rudderstack/analytics-js-sanity-suite | 3.5.1 |

---
Please review and merge when ready. :rocket:
