### PR TITLE
feat: optimize page leave events for bfcache

### DIFF
--- a/packages/analytics-js-common/__tests__/utilities/detect.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/detect.test.ts
@@ -1,10 +1,11 @@
-import { isSDKRunningInChromeExtension } from '../../src/utilities/detect';
+import { isIE11, isSDKRunningInChromeExtension } from '../../src/utilities/detect';
 
 describe('Detect env/feature/capabilities', () => {
   const reset = () => {
     (window as any).chrome = undefined;
   };
   afterEach(reset);
+
   describe('isSDKRunningInChromeExtension', () => {
     it('should return true if SDK is running inside chrome extension', () => {
       (window as any).chrome = {
@@ -17,6 +18,25 @@ describe('Detect env/feature/capabilities', () => {
         runtime: { id: undefined },
       };
       expect(isSDKRunningInChromeExtension()).toBeFalsy();
+    });
+  });
+
+  describe('isIE11', () => {
+    const testCases = [
+      {
+        userAgent:
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36',
+        expected: false,
+      },
+      {
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko',
+        expected: true,
+      },
+    ];
+
+    it.each(testCases)('should return $expected for $userAgent', ({ userAgent, expected }) => {
+      (globalThis.navigator as any).userAgent = userAgent;
+      expect(isIE11()).toBe(expected);
     });
   });
 });

--- a/packages/analytics-js-common/__tests__/utilities/page.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/page.test.ts
@@ -16,9 +16,15 @@ describe('onPageLeave', () => {
     });
   };
 
+  const originalUserAgent = (globalThis.navigator as any).userAgent;
+
   beforeEach(() => {
     jest.useFakeTimers();
     setVisibilityState('visible');
+  });
+
+  afterEach(() => {
+    (globalThis.navigator as any).userAgent = originalUserAgent;
   });
 
   it('should fire the callback on pagehide event', () => {
@@ -40,7 +46,9 @@ describe('onPageLeave', () => {
     expect(evCallback).toHaveBeenCalledWith(true);
   });
 
-  it('should fire the callback on beforeunload event', () => {
+  it('should fire the callback on beforeunload event for IE11', () => {
+    (globalThis.navigator as any).userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
     const evCallback = jest.fn();
     onPageLeave(evCallback);
 
@@ -95,7 +103,9 @@ describe('onPageLeave', () => {
     expect(evCallback).toHaveBeenCalledWith(false);
   });
 
-  it('should not fire the callback twice on beforeunload event', () => {
+  it('should not fire the callback twice on beforeunload event for IE11', () => {
+    (globalThis.navigator as any).userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
     const evCallback = jest.fn();
     onPageLeave(evCallback);
 
@@ -106,6 +116,8 @@ describe('onPageLeave', () => {
   });
 
   it('should fire the callback only once if even multiple events are fired', () => {
+    (globalThis.navigator as any).userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
     const evCallback = jest.fn();
     onPageLeave(evCallback);
 
@@ -166,7 +178,9 @@ describe('onPageLeave', () => {
     expect(evCallback).toHaveBeenNthCalledWith(2, false);
   });
 
-  it('should fire the callback on beforeunload event even after multiple visibility changes happen', () => {
+  it('should fire the callback on beforeunload event even after multiple visibility changes happen for IE11', () => {
+    (globalThis.navigator as any).userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
     const evCallback = jest.fn();
     onPageLeave(evCallback);
 
@@ -184,7 +198,9 @@ describe('onPageLeave', () => {
     expect(evCallback).toHaveBeenNthCalledWith(2, false);
   });
 
-  it('should fire the callback on beforeunload event on the next tick even when the tab is inactive', () => {
+  it('should fire the callback on beforeunload event on the next tick even when the tab is inactive for IE11', () => {
+    (globalThis.navigator as any).userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
     const evCallback = jest.fn();
     onPageLeave(evCallback);
 

--- a/packages/analytics-js-common/__tests__/utilities/page.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/page.test.ts
@@ -25,6 +25,7 @@ describe('onPageLeave', () => {
 
   afterEach(() => {
     (globalThis.navigator as any).userAgent = originalUserAgent;
+    jest.useRealTimers();
   });
 
   it('should fire the callback on pagehide event', () => {

--- a/packages/analytics-js-common/src/utilities/detect.ts
+++ b/packages/analytics-js-common/src/utilities/detect.ts
@@ -4,4 +4,6 @@
  */
 const isSDKRunningInChromeExtension = (): boolean => !!(window as any).chrome?.runtime?.id;
 
-export { isSDKRunningInChromeExtension };
+const isIE11 = (): boolean => Boolean(globalThis.navigator.userAgent.match(/Trident.*rv:11\./));
+
+export { isSDKRunningInChromeExtension, isIE11 };

--- a/packages/analytics-js-common/src/utilities/detect.ts
+++ b/packages/analytics-js-common/src/utilities/detect.ts
@@ -1,9 +1,13 @@
+import { isString } from './checks';
+
 /**
  * Determines if the SDK is running inside a chrome extension
  * @returns boolean
  */
 const isSDKRunningInChromeExtension = (): boolean => !!(window as any).chrome?.runtime?.id;
 
-const isIE11 = (): boolean => Boolean(globalThis.navigator.userAgent.match(/Trident.*rv:11\./));
+const isIE11 = (): boolean =>
+  isString(globalThis.navigator.userAgent) &&
+  /Trident.*rv:11\./.test(globalThis.navigator.userAgent);
 
 export { isSDKRunningInChromeExtension, isIE11 };

--- a/packages/analytics-js-common/src/utilities/page.ts
+++ b/packages/analytics-js-common/src/utilities/page.ts
@@ -1,3 +1,5 @@
+import { isIE11 } from './detect';
+
 const onPageLeave = (callback: (isAccessible: boolean) => void) => {
   // To ensure the callback is only called once even if more than one events
   // are fired at once.
@@ -25,12 +27,18 @@ const onPageLeave = (callback: (isAccessible: boolean) => void) => {
   // Includes user actions like clicking a link, entering a new URL,
   // refreshing the page, or closing the browser tab
   // Note that 'pagehide' is not supported in IE.
-  // So, this is a fallback.
-  (globalThis as typeof window).addEventListener('beforeunload', () => {
-    isAccessible = false;
-    handleOnLeave();
-  });
+  // Registering this event conditionally for IE11 also because
+  // it affects bfcache optimization on modern browsers otherwise.
+  if (isIE11()) {
+    (globalThis as typeof window).addEventListener('beforeunload', () => {
+      isAccessible = false;
+      handleOnLeave();
+    });
+  }
 
+  // This is important for iOS Safari browser as it does not
+  // fire the regular pagehide and visibilitychange events
+  // when user goes to tablist view and closes the tab.
   (globalThis as typeof window).addEventListener('blur', () => {
     isAccessible = true;
     handleOnLeave();

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -113,7 +113,7 @@ export default [
     name: 'Core (Content Script) - Modern - NPM (CJS)',
     path: 'dist/npm/modern/content-script/cjs/index.cjs',
     import: '*',
-    limit: '41 KiB',
+    limit: '41.5 KiB',
   },
   {
     name: 'Core (Content Script) - Modern - NPM (UMD)',

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -801,8 +801,8 @@ describe('Core - Rudder Analytics Facade', () => {
     const simulatePageBeingUnloadedAfterSDKLoad = (sdkLoaded = true) => {
       // Simulate page being unloaded
       state.lifecycle.loaded.value = sdkLoaded;
-      const event = new Event('beforeunload');
-      window.dispatchEvent(event);
+      const event = new Event('pagehide');
+      document.dispatchEvent(event);
     };
 
     it('should inherit properties of autoTrack for page lifecycle events', () => {

--- a/packages/analytics-js/src/components/capabilitiesManager/CapabilitiesManager.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/CapabilitiesManager.ts
@@ -13,6 +13,7 @@ import { getTimezone } from '@rudderstack/analytics-js-common/utilities/timezone
 import { isValidURL } from '@rudderstack/analytics-js-common/utilities/url';
 import { isDefinedAndNotNull } from '@rudderstack/analytics-js-common/utilities/checks';
 import type { IHttpClient } from '@rudderstack/analytics-js-common/types/HttpClient';
+import { isIE11 } from '@rudderstack/analytics-js-common/utilities/detect';
 import {
   INVALID_POLYFILL_URL_WARNING,
   POLYFILL_SCRIPT_LOAD_ERROR,
@@ -28,7 +29,6 @@ import {
   hasBeacon,
   hasCrypto,
   hasUAClientHints,
-  isIE11,
   isLegacyJSEngine,
   isStorageAvailable,
 } from './detection';

--- a/packages/analytics-js/src/components/capabilitiesManager/detection/browser.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/detection/browser.ts
@@ -20,6 +20,4 @@ const hasBeacon = (): boolean =>
   !isNullOrUndefined(globalThis.navigator.sendBeacon) &&
   isFunction(globalThis.navigator.sendBeacon);
 
-const isIE11 = (): boolean => Boolean(globalThis.navigator.userAgent.match(/Trident.*rv:11\./));
-
-export { isBrowser, isNode, hasCrypto, hasUAClientHints, hasBeacon, isIE11 };
+export { isBrowser, isNode, hasCrypto, hasUAClientHints, hasBeacon };

--- a/packages/analytics-js/src/components/capabilitiesManager/detection/index.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/detection/index.ts
@@ -1,5 +1,5 @@
 export { detectAdBlockers } from './adBlockers';
-export { isBrowser, isNode, hasCrypto, hasUAClientHints, hasBeacon, isIE11 } from './browser';
+export { isBrowser, isNode, hasCrypto, hasUAClientHints, hasBeacon } from './browser';
 export { getUserAgentClientHint } from './clientHint';
 export { isDatasetAvailable, legacyJSEngineRequiredPolyfills, isLegacyJSEngine } from './dom';
 export { getScreenDetails } from './screen';


### PR DESCRIPTION
## PR Description

As `beforeunload` event registration impacts bfcache optimisation on modern browsers, so restricting it to only IE 11.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3739/spike-investigate-if-we-can-get-away-with-beforeunload-event-handler

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of page leave/unload handling across browsers; IE11-specific listener behavior prevents duplicate or missed callbacks.

- Refactor
  - Moved IE11 detection into a shared utility so capability checks are consistent across packages.

- Tests
  - Expanded IE11 and page lifecycle tests covering beforeunload/pagehide, visibility changes, and multiple-event scenarios.

- Chores
  - Updated bundle size limit to reflect current build size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->