### PR TITLE
chore: allow manual deployments to dev

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,6 +1,7 @@
 name: Deploy to Development Environment
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: ['develop']
     types:


### PR DESCRIPTION
## PR Description

Added `workflow_dispatch` trigger for dev deployment.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3237/implement-a-poc-regrading-cloudfront-continuous-deployment

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manual trigger to the development deployment workflow, enabling on-demand runs alongside the existing pull request trigger.
  * Retained all existing automation; no changes to jobs, steps, concurrency, or secrets.
  * PR-based deployments remain intact and operate as before.
  * No user-facing changes; this update affects internal deployment processes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->