### PR TITLE
chore: switch to the main branch for e2e tests

### DIFF
--- a/.github/workflows/run-e2e-regression-test-suites.yml
+++ b/.github/workflows/run-e2e-regression-test-suites.yml
@@ -100,7 +100,7 @@ jobs:
           github_token: ${{ secrets.PAT }}
           target_repo: ${{ env.TARGET_REPO }}
           workflow_file: sdk-team-js-sanity-suite.yaml
-          workflow_ref: chore.temp-remove-api-test
+          workflow_ref: main
           workflow_name: Sanity E2E Regression Tests
           workflow_inputs: ${{ steps.prepare_inputs.outputs.inputs_json }}
           max_wait_time: ${{ env.MAX_WAIT_TIME_FOR_SANITY_TESTS }}
@@ -137,7 +137,7 @@ jobs:
           github_token: ${{ secrets.PAT }}
           target_repo: ${{ env.TARGET_REPO }}
           workflow_file: sdk-team-js-regression.yaml
-          workflow_ref: chore.temp-remove-api-test
+          workflow_ref: main
           workflow_name: Full E2E Regression Tests
           workflow_inputs: ${{ steps.prepare_inputs.outputs.inputs_json }}
           max_wait_time: ${{ env.MAX_WAIT_TIME_FOR_E2E_TESTS }}


### PR DESCRIPTION
## PR Description

I have updated the E2E test workflows to use the main branch.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3847/fix-dmt-feature-failures-in-js-sdk-e2e-automation-tests

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Tests
  - Updated E2E regression test invocations to source workflows from the primary branch, improving consistency across sanity and full test suites.
- Chores
  - Streamlined internal CI configuration to ensure regression tests run against the latest stable workflow definitions, reducing maintenance overhead and potential drift between branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->