### PR TITLE
chore: disable npm scripts in sample apps

### DIFF
--- a/examples/angular/sample-app/.npmrc
+++ b/examples/angular/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/angular/sample-app/.npmrc
+++ b/examples/angular/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/gatsby/sample-gatsby-plugin-usage/.npmrc
+++ b/examples/gatsby/sample-gatsby-plugin-usage/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/gatsby/sample-gatsby-plugin-usage/.npmrc
+++ b/examples/gatsby/sample-gatsby-plugin-usage/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/gatsby/sample-gatsby-site/.npmrc
+++ b/examples/gatsby/sample-gatsby-site/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/gatsby/sample-gatsby-site/.npmrc
+++ b/examples/gatsby/sample-gatsby-site/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/integrations/Ninetailed/sample-apps/app-using-npm/.npmrc
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-npm/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/integrations/Ninetailed/sample-apps/app-using-npm/.npmrc
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-npm/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/integrations/Ninetailed/sample-apps/app-using-v1.1-cdn/.npmrc
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-v1.1-cdn/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/integrations/Ninetailed/sample-apps/app-using-v1.1-cdn/.npmrc
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-v1.1-cdn/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/.npmrc
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/.npmrc
+++ b/examples/integrations/Ninetailed/sample-apps/app-using-v3-cdn/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/nextjs/hooks/sample-app/.npmrc
+++ b/examples/nextjs/hooks/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/nextjs/hooks/sample-app/.npmrc
+++ b/examples/nextjs/hooks/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/nextjs/js/sample-app/.npmrc
+++ b/examples/nextjs/js/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/nextjs/js/sample-app/.npmrc
+++ b/examples/nextjs/js/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/nextjs/page-router/sample-app/.npmrc
+++ b/examples/nextjs/page-router/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/nextjs/page-router/sample-app/.npmrc
+++ b/examples/nextjs/page-router/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/nextjs/ts/sample-app/.npmrc
+++ b/examples/nextjs/ts/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/nextjs/ts/sample-app/.npmrc
+++ b/examples/nextjs/ts/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/reactjs/hooks/sample-app/.npmrc
+++ b/examples/reactjs/hooks/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/reactjs/hooks/sample-app/.npmrc
+++ b/examples/reactjs/hooks/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/reactjs/js/sample-app/.npmrc
+++ b/examples/reactjs/js/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/reactjs/js/sample-app/.npmrc
+++ b/examples/reactjs/js/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/reactjs/ts/sample-app/.npmrc
+++ b/examples/reactjs/ts/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/reactjs/ts/sample-app/.npmrc
+++ b/examples/reactjs/ts/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/reactjs/vite/sample-app/.npmrc
+++ b/examples/reactjs/vite/sample-app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/reactjs/vite/sample-app/.npmrc
+++ b/examples/reactjs/vite/sample-app/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/serverless/cloudflare-worker/.npmrc
+++ b/examples/serverless/cloudflare-worker/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/serverless/cloudflare-worker/.npmrc
+++ b/examples/serverless/cloudflare-worker/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/serverless/vercel-edge/.npmrc
+++ b/examples/serverless/vercel-edge/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/serverless/vercel-edge/.npmrc
+++ b/examples/serverless/vercel-edge/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/symfony/sample/.npmrc
+++ b/examples/symfony/sample/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/symfony/sample/.npmrc
+++ b/examples/symfony/sample/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+

--- a/examples/utils/mock-servers/.npmrc
+++ b/examples/utils/mock-servers/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/examples/utils/mock-servers/.npmrc
+++ b/examples/utils/mock-servers/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
+# Rationale: Disabling all npm lifecycle scripts for security hardening and CI reproducibility.
 ignore-scripts=true
+


### PR DESCRIPTION
## PR Description

Disabled NPM lifecyle scripts for additional safety in sample apps too.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added per-project npm configuration to example apps, pinning the registry to npmjs.org and disabling lifecycle scripts.
  - Improves reproducible installs and reduces side effects when running examples locally or in CI.
  - Affects examples for Angular, Gatsby (plugin and site), Next.js (hooks/js/ts/page-router), React (hooks/js/ts/vite), Ninetailed integrations, Serverless (Cloudflare Worker, Vercel Edge), Symfony sample, and mock servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->