### PR TITLE
fix: braze flush alias immediately

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -8,6 +8,7 @@ jest.mock('../../../src/utils/logger', () =>
   jest.fn().mockImplementation(() => ({
     setLogLevel: jest.fn(),
     debug: jest.fn(),
+    warn: jest.fn(),
     error: jest.fn(),
   })),
 );
@@ -45,6 +46,7 @@ const mockBrazeSDK = () => {
     logPurchase: jest.fn(),
     getCachedContentCards: jest.fn(),
     getCachedFeed: jest.fn(),
+    requestImmediateDataFlush: jest.fn(),
     BrazeSdkMetadata: {
       CDN: 'wcd',
       GOOGLE_TAG_MANAGER: 'gg',
@@ -286,6 +288,18 @@ describe('setUserAlias', () => {
     const result = braze.setUserAlias();
     expect(result).toBe(false);
   });
+
+  it('should handle missing requestImmediateDataFlush method gracefully', () => {
+    analytics.getAnonymousId.mockReturnValue('anon123');
+    window.braze.getUser().addAlias.mockReturnValue(true);
+    // Remove the flush method to test defensive behavior
+    delete window.braze.requestImmediateDataFlush;
+
+    const result = braze.setUserAlias();
+    expect(result).toBe(true);
+    expect(window.braze.getUser().addAlias).toHaveBeenCalledWith('anon123', 'rudder_id');
+  });
+
 });
 
 describe('isReady', () => {

--- a/packages/analytics-js-integrations/src/integrations/Braze/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/browser.js
@@ -126,6 +126,21 @@ class Braze {
         return false;
       }
 
+      // Immediately flush the alias to prevent race conditions with cloud mode events
+      // This ensures the alias is sent immediately instead of waiting for the regular
+      // interval (10 seconds with localStorage, 3 seconds without)
+      try {
+        if (window.braze && typeof window.braze.requestImmediateDataFlush === 'function') {
+          window.braze.requestImmediateDataFlush();
+          logger.debug('Braze alias flushed immediately to prevent race conditions');
+        } else {
+          logger.warn('Braze requestImmediateDataFlush method not available');
+        }
+      } catch (flushError) {
+        logger.warn('Failed to flush Braze alias immediately:', flushError);
+        // Don't fail the entire operation if flush fails
+      }
+
       return true;
     } catch (error) {
       this.logAliasError(`Error setting alias: ${stringifyWithoutCircularV1(error, true)}`);


### PR DESCRIPTION
## PR Description

Braze pools events and flushes them every 10 seconds to reduce DDOSing its own services. Because of this, almost always, in context of hybrid mode, events reach braze via rudderstack data plane earlier than braze sdk. This race condition leads to a few edge cases where split profiles are created for braze.

To reduce the chances of this race condition (this PR doesn't completely fix the edge cases), we immediately flush alias call that happens during braze sdk initialisation.

<img width="1721" height="928" alt="image" src="https://github.com/user-attachments/assets/87882d4e-98e2-4f46-968b-eb9618a0d1c1" />


## Linear task (optional)

Partially Resolves INT-4054
Partially Resolves INT-4051

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Braze integration now triggers an immediate data sync after setting a user alias, reducing delays or missed events in cloud-mode.
  * Handles cases where immediate flush isn’t available without failing the alias operation.
  * Improved logging for better visibility during data flush attempts.

* **Tests**
  * Added tests to ensure aliasing succeeds even when immediate data flush is unavailable and to validate related logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->