### PR TITLE
chore: move patch-package to prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "packages/*"
   ],
   "scripts": {
-    "setup": "npm i --include=optional && npm run build:package:modern",
+    "setup": "npm i --include=optional && npm run prepare && npm run build:package:modern",
     "setup:ci": "npm run setup:deps && npm run build:package:modern",
-    "setup:deps": "npm ci --prefer-offline --no-audit",
+    "setup:deps": "npm ci --prefer-offline --no-audit && npm run prepare",
     "clean": "nx run-many -t clean && nx reset && git clean -xdf node_modules",
     "clean:cache": "rimraf -rf ./node_modules/.cache && rimraf -rf ./.nx/cache",
     "start": "nx run-many --targets=start --parallel=3 --projects=@rudderstack/analytics-js-integrations,@rudderstack/analytics-js-plugins,@rudderstack/analytics-js",
@@ -43,7 +43,7 @@
     "check:pub:ci": "nx affected -t check:pub --verbose --base=$BASE_REF",
     "format": "prettier --write .",
     "lint:fix": "nx run-many -t check:lint --fix",
-    "prepare": "husky",
+    "prepare": "husky && patch-package",
     "pre-commit": "npm run test:pre-commit:affected && npm run check:size:build:pre-commit:affected && npm run check:size:json:pre-commit:affected && npx lint-staged",
     "commit-msg": "commitlint --edit",
     "commit": "git-cz",


### PR DESCRIPTION
## PR Description

As the NPM lifecycle scripts have been disabled, the patch-package run has been moved to the prepare script and it is explicitly run.

## Linear task (optional)

N/A

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
