### PR TITLE
fix: switch to in-memory storage for events when necessary

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -69,8 +69,8 @@ jobs:
               
               // Check if PR is in draft state
               if (pr.draft) {
-                core.setFailed(`PR #${prNumber} is in draft state. Please mark it as ready for review before deploying.`);
-                return;
+                // core.setFailed(`PR #${prNumber} is in draft state. Please mark it as ready for review before deploying.`);
+                // return;
               }
               
               // Get detailed PR information including mergeable state
@@ -82,8 +82,8 @@ jobs:
               
               // Check if PR is mergeable and all requirements are satisfied
               if (prDetails.mergeable === false) {
-                core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
-                return;
+                // core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
+                // return;
               }
               
               // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
@@ -102,8 +102,8 @@ jobs:
                   reason = `the mergeable state is "${prDetails.mergeable_state}"`;
                 }
                 
-                core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
-                return;
+                // core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
+                // return;
               }
               
               console.log(`PR #${prNumber} is in a clean mergeable state. All requirements satisfied. Proceeding with beta deployment.`);

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -163,6 +163,7 @@ jobs:
       trigger_source: ${{ needs.get-deploy-inputs.outputs.trigger_source }}
     secrets:
       RS_PROD_BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -130,6 +130,7 @@ jobs:
           echo "beta_identifier_for_automation_tests=pr-${{ steps.pr-info.outputs.pr_number }}-$SHA_SHORT" >> $GITHUB_OUTPUT
 
   deploy-cdn:
+    if: false
     name: Deploy to CDN
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
@@ -167,6 +168,7 @@ jobs:
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 
   deploy-sanity-suite:
+    if: false
     name: Deploy sanity suite
     needs: [get-deploy-inputs]
     uses: ./.github/workflows/deploy-sanity-suite.yml

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -69,8 +69,8 @@ jobs:
               
               // Check if PR is in draft state
               if (pr.draft) {
-                // core.setFailed(`PR #${prNumber} is in draft state. Please mark it as ready for review before deploying.`);
-                // return;
+                core.setFailed(`PR #${prNumber} is in draft state. Please mark it as ready for review before deploying.`);
+                return;
               }
               
               // Get detailed PR information including mergeable state
@@ -82,8 +82,8 @@ jobs:
               
               // Check if PR is mergeable and all requirements are satisfied
               if (prDetails.mergeable === false) {
-                // core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
-                // return;
+                core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
+                return;
               }
               
               // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
@@ -102,8 +102,8 @@ jobs:
                   reason = `the mergeable state is "${prDetails.mergeable_state}"`;
                 }
                 
-                // core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
-                // return;
+                core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
+                return;
               }
               
               console.log(`PR #${prNumber} is in a clean mergeable state. All requirements satisfied. Proceeding with beta deployment.`);
@@ -130,7 +130,6 @@ jobs:
           echo "beta_identifier_for_automation_tests=pr-${{ steps.pr-info.outputs.pr_number }}-$SHA_SHORT" >> $GITHUB_OUTPUT
 
   deploy-cdn:
-    if: false
     name: Deploy to CDN
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
@@ -168,7 +167,6 @@ jobs:
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 
   deploy-sanity-suite:
-    if: false
     name: Deploy sanity suite
     needs: [get-deploy-inputs]
     uses: ./.github/workflows/deploy-sanity-suite.yml

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -161,7 +161,7 @@ jobs:
           # Remove unnecessary fields from package.json before publishing
           ./scripts/make-package-json-publish-ready.sh
 
-          npx nx release publish --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }}
+          npx nx release publish --verbose --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }}
 
           # Reset the changes made to package.json
           git reset --hard

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -40,6 +40,8 @@ on:
     secrets:
       RS_PROD_BUGSNAG_API_KEY:
         required: true
+      NPM_TOKEN:
+        required: true
       SLACK_BOT_TOKEN:
         required: true
       SLACK_RELEASE_CHANNEL_ID:
@@ -156,11 +158,13 @@ jobs:
       - name: Publish package to NPM
         env:
           HUSKY: 0
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
           # Remove unnecessary fields from package.json before publishing
           ./scripts/make-package-json-publish-ready.sh
 
+          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
           npx nx release publish --verbose --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }}
 
           # Reset the changes made to package.json
@@ -202,8 +206,10 @@ jobs:
       - name: Deprecate the legacy SDK NPM package
         continue-on-error: true
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
+          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
 
           npm deprecate rudder-sdk-js "This package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest package, @rudderstack/analytics-js (https://www.npmjs.com/package/@rudderstack/analytics-js), for the latest features, security updates, and improved performance. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/."
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -269,6 +269,7 @@ jobs:
       monorepo_release_version: ${{ needs.get-release-inputs.outputs.release_version }}
       release_ticket_id: ${{ needs.get-release-inputs.outputs.release_ticket_id }}
     secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       RS_PROD_BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -166,12 +166,14 @@ jobs:
       - name: Deprecate the rolled back NPM version
         continue-on-error: true
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
           VERSION_TO_DEPRECATE="${{ env.CURRENT_VERSION_VALUE }}"
           echo "Deprecating NPM version: $VERSION_TO_DEPRECATE"
           
           # Deprecate the specified version with a message
+          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
           npm deprecate "@rudderstack/analytics-js@$VERSION_TO_DEPRECATE" "We've identified issues with this version of the package. Please switch to v${{ env.ROLLBACK_VERSION_VALUE }} or the latest version if available."
 
           # Note: The legacy SDK is not deprecated as it is deprecated by default with every release.

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
@@ -213,6 +213,7 @@ describe('XhrQueue', () => {
         attemptNumber: 1,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
+        reclaimed: undefined,
         id: 'sample_uuid',
         time: 1 + 1000 * 2 ** 1, // this is the delay calculation in RetryQueue
         type: 'Single',
@@ -391,6 +392,7 @@ describe('XhrQueue', () => {
           event: mergeDeepRight(event, { sentAt: 'sample_timestamp' }),
         },
         attemptNumber: 1,
+        reclaimed: undefined,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
         id: 'sample_uuid',
@@ -498,6 +500,7 @@ describe('XhrQueue', () => {
           event: mergeDeepRight(event, { sentAt: 'sample_timestamp' }),
         },
         attemptNumber: 1,
+        reclaimed: undefined,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
         id: 'sample_uuid',

--- a/packages/analytics-js-plugins/src/xhrQueue/index.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/index.ts
@@ -125,7 +125,10 @@ const XhrQueue = (): ExtensionPlugin => ({
           });
         },
         storeManager,
-        // If local storage is available, use it, else use memory storage
+        // If local storage is available, use it; else, fall back to memory storage.
+        // Note: Memory storage is not persistent across page reloads. 
+        // This means queued events will be lost if the page is refreshed or closed, 
+        // potentially impacting analytics reliability and data completeness.
         state.capabilities.storage.isLocalStorageAvailable.value ? LOCAL_STORAGE : MEMORY_STORAGE,
         logger,
         (itemData: XHRQueueItemData[]): number => {

--- a/packages/analytics-js-plugins/src/xhrQueue/index.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/index.ts
@@ -31,6 +31,7 @@ import {
   isErrRetryable,
   isUndefined,
   LOCAL_STORAGE,
+  MEMORY_STORAGE,
   toBase64,
   validateEventPayloadSize,
 } from '../shared-chunks/common';
@@ -124,7 +125,8 @@ const XhrQueue = (): ExtensionPlugin => ({
           });
         },
         storeManager,
-        LOCAL_STORAGE,
+        // If local storage is available, use it, else use memory storage
+        state.capabilities.storage.isLocalStorageAvailable.value ? LOCAL_STORAGE : MEMORY_STORAGE,
         logger,
         (itemData: XHRQueueItemData[]): number => {
           const currentTime = getCurrentTimeFormatted();


### PR DESCRIPTION
## PR Description

Switched to in-memory storage for storing events when local storage is unavailable. This is needed in restrictive environments like Safari v26 and above where the storage access is silently blocked.

Additionally, I've restored the usage of NPM token for publishing the packages.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-3972/switch-to-in-memory-storage-for-storing-events-when-persistent-storage

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] Safari

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
