### PR TITLE
chore(release): merge hotfix-release/3.97.0-SDK-3974 into main [SDK-3974]

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -163,6 +163,7 @@ jobs:
       trigger_source: ${{ needs.get-deploy-inputs.outputs.trigger_source }}
     secrets:
       RS_PROD_BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -40,6 +40,8 @@ on:
     secrets:
       RS_PROD_BUGSNAG_API_KEY:
         required: true
+      NPM_TOKEN:
+        required: true
       SLACK_BOT_TOKEN:
         required: true
       SLACK_RELEASE_CHANNEL_ID:
@@ -156,12 +158,14 @@ jobs:
       - name: Publish package to NPM
         env:
           HUSKY: 0
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
           # Remove unnecessary fields from package.json before publishing
           ./scripts/make-package-json-publish-ready.sh
 
-          npx nx release publish --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }}
+          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          npx nx release publish --verbose --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} ${{ inputs.environment == 'beta' && '--tag=beta' || '' }}
 
           # Reset the changes made to package.json
           git reset --hard
@@ -202,8 +206,10 @@ jobs:
       - name: Deprecate the legacy SDK NPM package
         continue-on-error: true
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
+          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
 
           npm deprecate rudder-sdk-js "This package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest package, @rudderstack/analytics-js (https://www.npmjs.com/package/@rudderstack/analytics-js), for the latest features, security updates, and improved performance. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/."
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -269,6 +269,7 @@ jobs:
       monorepo_release_version: ${{ needs.get-release-inputs.outputs.release_version }}
       release_ticket_id: ${{ needs.get-release-inputs.outputs.release_ticket_id }}
     secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       RS_PROD_BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -166,12 +166,14 @@ jobs:
       - name: Deprecate the rolled back NPM version
         continue-on-error: true
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
           VERSION_TO_DEPRECATE="${{ env.CURRENT_VERSION_VALUE }}"
           echo "Deprecating NPM version: $VERSION_TO_DEPRECATE"
           
           # Deprecate the specified version with a message
+          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
           npm deprecate "@rudderstack/analytics-js@$VERSION_TO_DEPRECATE" "We've identified issues with this version of the package. Please switch to v${{ env.ROLLBACK_VERSION_VALUE }} or the latest version if available."
 
           # Note: The legacy SDK is not deprecated as it is deprecated by default with every release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rudderstack/analytics-js-monorepo",
-  "version": "3.96.0",
+  "version": "3.97.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rudderstack/analytics-js-monorepo",
-      "version": "3.96.0",
+      "version": "3.97.0",
       "hasInstallScript": true,
       "license": "Elastic-2.0",
       "workspaces": [
@@ -25849,7 +25849,7 @@
     },
     "packages/analytics-js": {
       "name": "@rudderstack/analytics-js",
-      "version": "3.24.0",
+      "version": "3.24.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@preact/signals-core": "1.11.0",
@@ -25989,7 +25989,7 @@
     },
     "packages/analytics-js-plugins": {
       "name": "@rudderstack/analytics-js-plugins",
-      "version": "3.13.1",
+      "version": "3.13.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@rudderstack/analytics-js-common": "*",
@@ -26164,7 +26164,7 @@
     },
     "packages/sanity-suite": {
       "name": "@rudderstack/analytics-js-sanity-suite",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@rudderstack/analytics-js": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-monorepo",
-  "version": "3.96.0",
+  "version": "3.97.0",
   "private": true,
   "description": "Monorepo for RudderStack Analytics JS SDK",
   "workspaces": [

--- a/packages/analytics-js-plugins/CHANGELOG.md
+++ b/packages/analytics-js-plugins/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.13.2](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.13.1...@rudderstack/analytics-js-plugins@3.13.2) (2025-09-25)
+
+
+### Bug Fixes
+
+* switch to in-memory storage for events when necessary ([#2502](https://github.com/rudderlabs/rudder-sdk-js/issues/2502)) ([f859934](https://github.com/rudderlabs/rudder-sdk-js/commit/f859934457196c8c22d96a4edf08cb693f01e353)), closes [#2459](https://github.com/rudderlabs/rudder-sdk-js/issues/2459)
+
 ## [3.13.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.13.0...@rudderstack/analytics-js-plugins@3.13.1) (2025-09-15)
 
 ### Dependency Updates

--- a/packages/analytics-js-plugins/CHANGELOG_LATEST.md
+++ b/packages/analytics-js-plugins/CHANGELOG_LATEST.md
@@ -1,6 +1,7 @@
-## [3.13.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.13.0...@rudderstack/analytics-js-plugins@3.13.1) (2025-09-15)
+## [3.13.2](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.13.1...@rudderstack/analytics-js-plugins@3.13.2) (2025-09-25)
 
-### Dependency Updates
 
-* `@rudderstack/analytics-js-common` updated to version `3.25.0`
-* `@rudderstack/analytics-js-cookies` updated to version `0.5.3`
+### Bug Fixes
+
+* switch to in-memory storage for events when necessary ([#2502](https://github.com/rudderlabs/rudder-sdk-js/issues/2502)) ([f859934](https://github.com/rudderlabs/rudder-sdk-js/commit/f859934457196c8c22d96a4edf08cb693f01e353)), closes [#2459](https://github.com/rudderlabs/rudder-sdk-js/issues/2459)
+

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
@@ -213,6 +213,7 @@ describe('XhrQueue', () => {
         attemptNumber: 1,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
+        reclaimed: undefined,
         id: 'sample_uuid',
         time: 1 + 1000 * 2 ** 1, // this is the delay calculation in RetryQueue
         type: 'Single',
@@ -391,6 +392,7 @@ describe('XhrQueue', () => {
           event: mergeDeepRight(event, { sentAt: 'sample_timestamp' }),
         },
         attemptNumber: 1,
+        reclaimed: undefined,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
         id: 'sample_uuid',
@@ -498,6 +500,7 @@ describe('XhrQueue', () => {
           event: mergeDeepRight(event, { sentAt: 'sample_timestamp' }),
         },
         attemptNumber: 1,
+        reclaimed: undefined,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
         id: 'sample_uuid',

--- a/packages/analytics-js-plugins/package.json
+++ b/packages/analytics-js-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-plugins",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "private": true,
   "description": "RudderStack JavaScript SDK plugins",
   "main": "dist/npm/modern/cjs/index.cjs",

--- a/packages/analytics-js-plugins/project.json
+++ b/packages/analytics-js-plugins/project.json
@@ -51,9 +51,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js-plugins@3.13.1",
-        "title": "@rudderstack/analytics-js-plugins@3.13.1",
-        "discussion-category": "@rudderstack/analytics-js-plugins@3.13.1",
+        "tag": "@rudderstack/analytics-js-plugins@3.13.2",
+        "title": "@rudderstack/analytics-js-plugins@3.13.2",
+        "discussion-category": "@rudderstack/analytics-js-plugins@3.13.2",
         "notesFile": "./packages/analytics-js-plugins/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/analytics-js-plugins/src/xhrQueue/index.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/index.ts
@@ -31,6 +31,7 @@ import {
   isErrRetryable,
   isUndefined,
   LOCAL_STORAGE,
+  MEMORY_STORAGE,
   toBase64,
   validateEventPayloadSize,
 } from '../shared-chunks/common';
@@ -124,7 +125,11 @@ const XhrQueue = (): ExtensionPlugin => ({
           });
         },
         storeManager,
-        LOCAL_STORAGE,
+        // If local storage is available, use it; else, fall back to memory storage.
+        // Note: Memory storage is not persistent across page reloads. 
+        // This means queued events will be lost if the page is refreshed or closed, 
+        // potentially impacting analytics reliability and data completeness.
+        state.capabilities.storage.isLocalStorageAvailable.value ? LOCAL_STORAGE : MEMORY_STORAGE,
         logger,
         (itemData: XHRQueueItemData[]): number => {
           const currentTime = getCurrentTimeFormatted();

--- a/packages/analytics-js/CHANGELOG.md
+++ b/packages/analytics-js/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.24.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.24.0...@rudderstack/analytics-js@3.24.1) (2025-09-25)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js-plugins` updated to version `3.13.2`
 ## [3.24.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.23.2...@rudderstack/analytics-js@3.24.0) (2025-09-15)
 
 ### Dependency Updates

--- a/packages/analytics-js/CHANGELOG_LATEST.md
+++ b/packages/analytics-js/CHANGELOG_LATEST.md
@@ -1,18 +1,5 @@
-## [3.24.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.23.2...@rudderstack/analytics-js@3.24.0) (2025-09-15)
+## [3.24.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.24.0...@rudderstack/analytics-js@3.24.1) (2025-09-25)
 
 ### Dependency Updates
 
-* `@rudderstack/analytics-js-cookies` updated to version `0.5.3`
-* `@rudderstack/analytics-js-common` updated to version `3.25.0`
-* `@rudderstack/analytics-js-plugins` updated to version `3.13.1`
-
-### Features
-
-* optimize page leave events for bfcache ([#2458](https://github.com/rudderlabs/rudder-sdk-js/issues/2458)) ([48c1f20](https://github.com/rudderlabs/rudder-sdk-js/commit/48c1f208efa0edce88fe9bedaafd87511fb0a365))
-* reset api with options ([#2445](https://github.com/rudderlabs/rudder-sdk-js/issues/2445)) ([f739030](https://github.com/rudderlabs/rudder-sdk-js/commit/f73903092e20d45a6cf047cc03fe16f5290fb557))
-
-
-### Bug Fixes
-
-* error handle cookie operation ([#2475](https://github.com/rudderlabs/rudder-sdk-js/issues/2475)) ([e56acdc](https://github.com/rudderlabs/rudder-sdk-js/commit/e56acdc20c07c29dc2f73d8c0a8d14445a9dca22))
-
+* `@rudderstack/analytics-js-plugins` updated to version `3.13.2`

--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js",
-  "version": "3.24.0",
+  "version": "3.24.1",
   "description": "RudderStack JavaScript SDK",
   "main": "dist/npm/modern/cjs/index.cjs",
   "module": "dist/npm/modern/esm/index.mjs",

--- a/packages/analytics-js/project.json
+++ b/packages/analytics-js/project.json
@@ -52,9 +52,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js@3.24.0",
-        "title": "@rudderstack/analytics-js@3.24.0",
-        "discussion-category": "@rudderstack/analytics-js@3.24.0",
+        "tag": "@rudderstack/analytics-js@3.24.1",
+        "title": "@rudderstack/analytics-js@3.24.1",
+        "discussion-category": "@rudderstack/analytics-js@3.24.1",
         "notesFile": "./packages/analytics-js/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/sanity-suite/CHANGELOG.md
+++ b/packages/sanity-suite/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.5.4](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-sanity-suite@3.5.3...@rudderstack/analytics-js-sanity-suite@3.5.4) (2025-09-25)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js` updated to version `3.24.1`
 ## [3.5.3](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-sanity-suite@3.5.2...@rudderstack/analytics-js-sanity-suite@3.5.3) (2025-09-15)
 
 ### Dependency Updates

--- a/packages/sanity-suite/package.json
+++ b/packages/sanity-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-sanity-suite",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "private": true,
   "description": "Sanity suite for testing JS SDK package",
   "main": "./dist/v3/cdn/testBook.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_repo_rudder-sdk-js
 sonar.organization=rudderlabs
 sonar.projectName=rudder-sdk-js
-sonar.projectVersion=3.96.0
+sonar.projectVersion=3.97.0
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-js


### PR DESCRIPTION
:crown: **Automated Release PR**

This pull request was created automatically by the GitHub Actions workflow. It merges the release branch (`hotfix-release/3.97.0-SDK-3974`) into the `main` branch.

This ensures that the latest release branch changes are incorporated into the `main` branch for production.

### Details
- **Monorepo Release Version**: v3.97.0
- **Release Branch**: `hotfix-release/3.97.0-SDK-3974`
- **Related Ticket**: [SDK-3974](https://linear.app/rudderstack/issue/SDK-3974)

### Version updates

| Package | New version |
|---------|-------------|
| @rudderstack/analytics-js-monorepo | 3.97.0 |
| @rudderstack/analytics-js-common | N/A |
| @rudderstack/analytics-js-cookies | N/A |
| @rudderstack/analytics-js-integrations | N/A |
| @rudderstack/analytics-js-legacy-utilities | N/A |
| @rudderstack/analytics-js-plugins | 3.13.2 |
| @rudderstack/analytics-js-service-worker | N/A |
| @rudderstack/analytics-js | 3.24.1 |
| rudder-sdk-js | N/A |
| @rudderstack/analytics-js-loading-scripts | N/A |
| @rudderstack/analytics-js-sanity-suite | 3.5.4 |

---
Please review and merge when ready. :rocket:
