### PR TITLE
chore: automatically deprecate beta versions in npm

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -273,3 +273,22 @@ jobs:
       RS_PROD_BUGSNAG_API_KEY: ${{ secrets.RS_PROD_BUGSNAG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+
+  deprecate-closed-pr-betas:
+    needs: [publish-npm-packages]
+    name: Deprecate Beta NPM Packages from Closed PRs
+    runs-on: [self-hosted, Linux, X64]
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run beta package deprecation
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          chmod +x scripts/deprecate-beta-packages.sh
+          ./scripts/deprecate-beta-packages.sh

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -279,6 +279,8 @@ jobs:
     name: Deprecate Beta NPM Packages from Closed PRs
     runs-on: [self-hosted, Linux, X64]
     continue-on-error: true
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -286,7 +288,7 @@ jobs:
       - name: Run beta package deprecation
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |

--- a/scripts/deprecate-beta-packages.sh
+++ b/scripts/deprecate-beta-packages.sh
@@ -23,8 +23,8 @@ declare -A PR_STATUSES
 echo "🚀 Starting beta package deprecation for closed PRs"
 
 # Validate required environment variables
-if [[ -z "${GITHUB_TOKEN:-}" || -z "${NPM_TOKEN:-}" ]]; then
-  echo "❌ Missing required environment variables: GITHUB_TOKEN, NPM_TOKEN"
+if [[ -z "${GH_TOKEN:-}" || -z "${NPM_TOKEN:-}" ]]; then
+  echo "❌ Missing required environment variables: GH_TOKEN, NPM_TOKEN"
   exit 1
 fi
 
@@ -32,6 +32,8 @@ fi
 npm set //registry.npmjs.org/:_authToken="$NPM_TOKEN"
 
 # Extract PR number from beta version
+# Beta version format: <version>-beta.pr.<pr_number>.<short_sha>
+# Example: 3.0.0-beta.pr.1234.abc1234
 extract_pr_number() {
   local version=$1
   echo "$version" | grep -oE 'beta\.pr\.([0-9]+)\.' | grep -oE '[0-9]+' | head -n1 || echo ""
@@ -52,8 +54,7 @@ check_pr_status() {
   repo_name=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f2)
 
   local response
-  response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    "https://api.github.com/repos/$repo_owner/$repo_name/pulls/$pr_number")
+  response=$(gh pr view "$pr_number" --repo "$repo_owner/$repo_name" --json state,merged)
 
   local state merged
   state=$(echo "$response" | jq -r '.state // "unknown"')
@@ -69,7 +70,7 @@ for package_name in "${PACKAGES[@]}"; do
   echo "📦 Processing: $package_name"
 
   # Get beta versions
-  versions=$(npm view "$package_name" versions --json 2>/dev/null | jq -r '.[] | select(contains("-beta.pr."))' || true)
+  versions=$(npm view "$package_name" versions --json 2>/dev/null | jq -r 'if type == "array" then .[] else . end | select(contains("-beta.pr."))' || true)
 
   if [[ -z "$versions" ]]; then
     echo "  No beta versions found"
@@ -107,11 +108,11 @@ for package_name in "${PACKAGES[@]}"; do
 
       echo "  Deprecation message: $deprecation_message"
 
-      if ! npm deprecate "$package_name@$version" "$deprecation_message" 2>&1; then
-        echo "  ❌ Failed to deprecate $version"
+      if ! npm_output=$(npm deprecate "$package_name@$version" "$deprecation_message" 2>&1); then
+        echo "  ❌ Failed to deprecate $package_name@$version: $npm_output"
       fi
     else
-      echo "  ⏭️  Skipping $version (PR #$pr_number is $state)"
+      echo "  ⏭️  Skipping $package_name@$version (PR #$pr_number is $state)"
     fi
 
     sleep 0.1

--- a/scripts/deprecate-beta-packages.sh
+++ b/scripts/deprecate-beta-packages.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+#
+# Deprecate Beta NPM Packages from Closed PRs
+#
+# This script deprecates beta NPM packages from closed PRs that are
+# potentially part of the recent release.
+# It is meant to be run after the release is published to NPM.
+#
+
+set -euo pipefail
+
+# Configuration
+PACKAGES=(
+  "@rudderstack/analytics-js"
+  "@rudderstack/analytics-js-service-worker"
+  "@rudderstack/analytics-js-cookies"
+)
+
+# Track processed PRs to avoid duplicate API calls
+declare -A PR_STATUSES
+
+echo "🚀 Starting beta package deprecation for closed PRs"
+
+# Validate required environment variables
+if [[ -z "${GITHUB_TOKEN:-}" || -z "${NPM_TOKEN:-}" ]]; then
+  echo "❌ Missing required environment variables: GITHUB_TOKEN, NPM_TOKEN"
+  exit 1
+fi
+
+# Setup NPM authentication
+npm set //registry.npmjs.org/:_authToken="$NPM_TOKEN"
+
+# Extract PR number from beta version
+extract_pr_number() {
+  local version=$1
+  echo "$version" | grep -oE 'beta\.pr\.([0-9]+)\.' | grep -oE '[0-9]+' | head -n1 || echo ""
+}
+
+# Check PR status using GitHub API (with caching)
+check_pr_status() {
+  local pr_number=$1
+
+  # Return cached result if already checked
+  if [[ -n "${PR_STATUSES[$pr_number]:-}" ]]; then
+    echo "${PR_STATUSES[$pr_number]}"
+    return
+  fi
+
+  local repo_owner repo_name
+  repo_owner=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1)
+  repo_name=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f2)
+
+  local response
+  response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/repos/$repo_owner/$repo_name/pulls/$pr_number")
+
+  local state merged
+  state=$(echo "$response" | jq -r '.state // "unknown"')
+  merged=$(echo "$response" | jq -r '.merged // false')
+
+  local result="$state:$merged"
+  PR_STATUSES[$pr_number]="$result"
+  echo "$result"
+}
+
+# Process each package
+for package_name in "${PACKAGES[@]}"; do
+  echo "📦 Processing: $package_name"
+
+  # Get beta versions
+  versions=$(npm view "$package_name" versions --json 2>/dev/null | jq -r '.[] | select(contains("-beta.pr."))' || true)
+
+  if [[ -z "$versions" ]]; then
+    echo "  No beta versions found"
+    continue
+  fi
+
+  echo "  Beta versions found: $versions"
+
+  # Process each version
+  while IFS= read -r version; do
+    [[ -z "$version" ]] && continue
+
+    pr_number=$(extract_pr_number "$version")
+    if [[ -z "$pr_number" ]]; then
+      echo "  ⚠️  Skipping $version - could not extract PR number"
+      continue
+    fi
+
+    echo "  PR number: $pr_number"
+
+    pr_status=$(check_pr_status "$pr_number")
+    state=$(echo "$pr_status" | cut -d':' -f1)
+    merged=$(echo "$pr_status" | cut -d':' -f2)
+
+    echo "  PR status: $state"
+    echo "  PR merged: $merged"
+
+    if [[ "$state" == "closed" ]]; then
+      status_text="merged"
+      [[ "$merged" == "false" ]] && status_text="closed (not merged)"
+
+      deprecation_message="This beta version is no longer valid. Use the latest version of the package."
+
+      echo "  🗑️  Deprecating $version (PR #$pr_number $status_text)"
+
+      echo "  Deprecation message: $deprecation_message"
+
+      if ! npm deprecate "$package_name@$version" "$deprecation_message" 2>&1; then
+        echo "  ❌ Failed to deprecate $version"
+      fi
+    else
+      echo "  ⏭️  Skipping $version (PR #$pr_number is $state)"
+    fi
+
+    sleep 0.1
+  done <<< "$versions"
+done
+
+echo "✅ Beta package deprecation completed"


### PR DESCRIPTION
## PR Description

I've updated the release workflow to add a new job to automatically deprecate the beta versions of the NPM packages when they are absorbed into the release or discarded.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4034/automatically-deprecated-beta-npm-packages-when-those-prs-are-released

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release step to deprecate outdated beta npm package versions tied to closed pull requests.
  * Step runs after package publication and is allowed to continue on error to avoid disrupting releases.
  * Introduced a companion script to detect beta versions, check PR status, and deprecate affected versions.
  * Improved logging, retry resilience, and safe handling so stable releases remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->