### PR TITLE
Send Rudder eventId/event_id/messageId as TikTok event_id

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/TikTokAds/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/TikTokAds/browser.test.js
@@ -19,8 +19,9 @@ const basicConfig = {
   ],
 };
 
-describe('tiktokads init tests', () => {
+describe('TikTokAds init tests', () => {
   let tiktokads;
+
   test('Testing init call of TiktokAds', () => {
     tiktokads = new TiktokAds(basicConfig, { loglevel: 'debug' });
     tiktokads.init();
@@ -28,7 +29,7 @@ describe('tiktokads init tests', () => {
   });
 });
 
-describe('tiktokads page', () => {
+describe('TikTokAds page', () => {
   let tiktokads;
   beforeEach(() => {
     tiktokads = new TiktokAds(basicConfig, { loglevel: 'debug' });
@@ -36,26 +37,67 @@ describe('tiktokads page', () => {
     window.ttq.page = jest.fn();
   });
 
-  test('send pageview', () => {
+  test('send Pageview with event_id from properties.event_id', () => {
     tiktokads.page({
       message: {
-        context: {},
         properties: {
-          category: 'test cat',
-          path: '/test',
-          url: 'http://localhost',
-          referrer: '',
-          title: 'test page',
-          testDimension: 'abc',
+          event_id: 'pageId',
         },
       },
     });
-    expect(window.ttq.page.mock.calls[0][0]).toEqual();
+    expect(window.ttq.page.mock.calls[0][0]).toEqual({
+      event_id: 'pageId',
+      partner_name: 'RudderStack',
+    });
+  });
+
+  test('send Pageview with event_id from properties.eventId', () => {
+    tiktokads.page({
+      message: {
+        properties: {
+          eventId: 'pageId',
+        },
+      },
+    });
+    expect(window.ttq.page.mock.calls[0][0]).toEqual({
+      event_id: 'pageId',
+      partner_name: 'RudderStack',
+    });
+  });
+
+  test('send Pageview with event_id from messageId fallback', () => {
+    tiktokads.page({
+      message: {
+        messageId: 'pageId',
+        properties: {},
+      },
+    });
+    expect(window.ttq.page.mock.calls[0][0]).toEqual({
+      event_id: 'pageId',
+      partner_name: 'RudderStack',
+    });
+  });
+
+  test('send Pageview with event_id priority: properties.eventId over properties.event_id', () => {
+    tiktokads.page({
+      message: {
+        messageId: 'messageId',
+        properties: {
+          eventId: 'pageId',
+          event_id: 'pageId-lowPrio',
+        },
+      },
+    });
+    expect(window.ttq.page.mock.calls[0][0]).toEqual({
+      event_id: 'pageId',
+      partner_name: 'RudderStack',
+    });
   });
 });
 
 describe('TiktokAds Track event', () => {
   let tiktokads;
+
   test('Testing Track product_added with no content_type in payload', () => {
     tiktokads = new TiktokAds(basicConfig, { loglevel: 'DEBUG' });
     tiktokads.init();
@@ -110,6 +152,7 @@ describe('TiktokAds Track event', () => {
       ],
     });
   });
+
   test('Testing Track product_added with content type in payload and multiple products', () => {
     tiktokads = new TiktokAds(basicConfig, { loglevel: 'DEBUG' });
     tiktokads.init();
@@ -387,8 +430,9 @@ describe('TiktokAds Track event', () => {
   });
 });
 
-describe('TiktokAds Identify event', () => {
+describe('TikTokAds Identify event', () => {
   let tiktokads;
+
   beforeEach(() => {
     tiktokads = new TiktokAds(
       {
@@ -405,6 +449,7 @@ describe('TiktokAds Identify event', () => {
     tiktokads.init();
     window.ttq.identify = jest.fn();
   });
+
   test('Testing Identify Custom Events', () => {
     tiktokads.identify({
       message: {

--- a/packages/analytics-js-integrations/src/integrations/TiktokAds/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/TiktokAds/browser.js
@@ -8,7 +8,7 @@ import {
   getDestinationExternalID,
   getHashFromArrayWithDuplicate,
 } from '../../utils/commonUtils';
-import { getTrackResponse } from './util';
+import { getTrackResponse, getPageResponse } from './util';
 import { loadNativeSdk } from './nativeSdkLoader';
 
 const logger = new Logger(DISPLAY_NAME);
@@ -100,7 +100,9 @@ class TiktokAds {
   }
 
   page(rudderElement) {
-    window.ttq.page();
+    const { message } = rudderElement;
+    const updatedProperties = getPageResponse(message);
+    window.ttq.page(updatedProperties);
   }
 }
 

--- a/packages/analytics-js-integrations/src/integrations/TiktokAds/constants.js
+++ b/packages/analytics-js-integrations/src/integrations/TiktokAds/constants.js
@@ -71,6 +71,13 @@ const trackMapping = [
   },
 ];
 
+const pageMapping = [
+  {
+    destKey: 'event_id',
+    sourceKeys: ['properties.eventId', 'properties.event_id', 'messageId'],
+  },
+];
+
 // We need to remove 'checkout step completed' and 'submitform' from the list of events as per tiktok docs
 // tiktok changed the mapping for 'checkout step completed => purchase' and 'submitform => lead'
 // once all customer migrate to new event we can remove old mapping
@@ -97,4 +104,13 @@ const eventNameMapping = {
   schedule: 'Schedule',
 };
 
-export { NAME, CNameMapping, PARTNER_NAME, trackMapping, eventNameMapping, DISPLAY_NAME, DIR_NAME };
+export {
+  NAME,
+  CNameMapping,
+  PARTNER_NAME,
+  trackMapping,
+  pageMapping,
+  eventNameMapping,
+  DISPLAY_NAME,
+  DIR_NAME,
+};

--- a/packages/analytics-js-integrations/src/integrations/TiktokAds/util.js
+++ b/packages/analytics-js-integrations/src/integrations/TiktokAds/util.js
@@ -1,4 +1,4 @@
-import { PARTNER_NAME, trackMapping } from './constants';
+import { PARTNER_NAME, trackMapping, pageMapping } from './constants';
 import { constructPayload } from '../../utils/utils';
 import { removeUndefinedAndNullValues } from '../../utils/commonUtils';
 
@@ -64,4 +64,13 @@ const getTrackResponse = message => {
     partner_name: PARTNER_NAME,
   });
 };
-export { getTrackResponse };
+
+const getPageResponse = message => {
+  const properties = constructPayload(message, pageMapping);
+  return removeUndefinedAndNullValues({
+    ...properties,
+    partner_name: PARTNER_NAME,
+  });
+};
+
+export { getTrackResponse, getPageResponse };


### PR DESCRIPTION
## PR Description

TikTok `Pageview` events are missing `event_id`, which makes them harder to inspect and correlate to RudderStack `page` calls. 

If the PR is approved, please update the documentation for [TikTok Ads Device Mode Integration](https://www.rudderstack.com/docs/destinations/streaming-destinations/tiktok-ads/device-mode/#page), Page section.

## Linear task (optional)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced TikTok Ads integration with improved page event tracking, properly extracting event_id from multiple sources with priority handling and including partner information.

* **Tests**
  * Added comprehensive test coverage for page event handling and event_id source prioritization to ensure reliable data mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->