### PR TITLE
feat: add support of Platform Specific App Keys for braze

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1,17 +1,7 @@
-/* eslint-disable sonarjs/no-duplicate-string */
 import * as R from 'ramda';
 import { Storage } from '@rudderstack/analytics-js-legacy-utilities/storage';
+import { warnMock } from '../../../__mocks__/logger';
 import Braze from '../../../src/integrations/Braze/browser';
-
-// Mock dependencies
-jest.mock('../../../src/utils/logger', () =>
-  jest.fn().mockImplementation(() => ({
-    setLogLevel: jest.fn(),
-    debug: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  })),
-);
 
 jest.mock('@rudderstack/analytics-js-legacy-utilities/storage', () => ({
   Storage: {
@@ -187,6 +177,40 @@ describe('constructor', () => {
       expect(braze.endPoint).toBe('sdk.fra-01.braze.eu');
     });
   });
+
+  it('should use web app key when platform specific app keys are enabled', () => {
+    const config = {
+      appKey: 'APP_KEY',
+      webAppKey: 'WEB_KEY',
+      usePlatformSpecificAppKeys: true,
+    };
+    const analytics = {};
+    const destinationInfo = {};
+
+    const braze = new Braze(config, analytics, destinationInfo);
+
+    expect(braze.usePlatformSpecificAppKeys).toBe(true);
+    expect(warnMock).not.toHaveBeenCalled();
+    expect(braze.appKey).toBe('WEB_KEY');
+  });
+
+  it('should log warn and fallback to configured app key when web app key is invalid', () => {
+    const config = {
+      appKey: 'APP_KEY',
+      webAppKey: 12345,
+      usePlatformSpecificAppKeys: true,
+    };
+    const analytics = {};
+    const destinationInfo = {};
+
+    const braze = new Braze(config, analytics, destinationInfo);
+
+    expect(warnMock).toHaveBeenCalledWith(
+      'Configured to use platform specific app key but the web app key is not valid:',
+      12345,
+    );
+    expect(braze.appKey).toBe('APP_KEY');
+  });
 });
 
 describe('init', () => {
@@ -299,7 +323,6 @@ describe('setUserAlias', () => {
     expect(result).toBe(true);
     expect(window.braze.getUser().addAlias).toHaveBeenCalledWith('anon123', 'rudder_id');
   });
-
 });
 
 describe('isReady', () => {

--- a/packages/analytics-js-integrations/src/integrations/Braze/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/browser.js
@@ -21,14 +21,21 @@ class Braze {
     }
     this.analytics = analytics;
     this.appKey = config.appKey;
-    this.usePlatformSpecificAppKeys = config.usePlatformSpecificApiKeys || false;
+    this.usePlatformSpecificAppKeys = config.usePlatformSpecificAppKeys === true;
     this.trackAnonymousUser = config.trackAnonymousUser;
     this.enableBrazeLogging = config.enableBrazeLogging || false;
     this.allowUserSuppliedJavascript = config.allowUserSuppliedJavascript || false;
     this.enablePushNotification = config.enablePushNotification || false;
     if (!config.appKey) this.appKey = '';
-    if (this.usePlatformSpecificApiKeys && config.webAppKey) {
-      this.appKey = config.webAppKey;
+    if (this.usePlatformSpecificAppKeys) {
+      if (config.webAppKey && typeof config.webAppKey === 'string') {
+        this.appKey = config.webAppKey;
+      } else {
+        logger.warn(
+          'Configured to use platform specific app key but the web app key is not valid:',
+          config.webAppKey,
+        );
+      }
     }
     this.endPoint = '';
     this.isHybridModeEnabled = config.connectionMode === 'hybrid';


### PR DESCRIPTION
## PR Description

We are adding support of platform specific appKey support for braze destination. It will be a backward compatible change through `usePlatformSpecificApiKeys` key in config. If the customer enabled `usePlatformSpecificApiKeys` key then only we will look for then platform specific appKey i.e. `webAppKey` for Javascript SDK.

## Linear task (optional)

https://linear.app/rudderstack/issue/INT-4362/js-add-support-for-the-braze-multi-app-key-support

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration flag to enable platform-specific app keys for the Braze integration, allowing a web-specific app key to override the default when enabled.
* **Bug Fixes**
  * When a provided platform-specific key is invalid, a warning is emitted and the integration falls back to the default key.
* **Tests**
  * Added tests covering the new flag behavior and the invalid-key warning/fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->