### PR TITLE
feat: check storage type availability for events persistence

### DIFF
--- a/packages/analytics-js-common/__tests__/utilities/storage.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/storage.test.ts
@@ -1,5 +1,6 @@
 import { defaultLogger } from '@rudderstack/analytics-js-common/__mocks__/Logger';
 import { isStorageQuotaExceeded, isStorageAvailable } from '../../src/utilities/storage';
+import { IStorage } from '../../src/types/Store';
 
 describe('Storage Utilities', () => {
   it('should detect localstorage size limit errors', () => {
@@ -50,8 +51,23 @@ describe('Storage Utilities', () => {
   it('should detect if localstorage is available', () => {
     expect(isStorageAvailable()).toBeTruthy();
   });
+
+  it('should detect if cookie storage is available', () => {
+    const mockCookieStorage = {
+      getItem: jest.fn(() => 'test-value'),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    } as unknown as IStorage;
+
+    expect(isStorageAvailable('cookieStorage', mockCookieStorage)).toBeTruthy();
+  });
+
   it('should detect if memoryStorage is available', () => {
     expect(isStorageAvailable('memoryStorage')).toBeTruthy();
+  });
+
+  it('should return false if storage type is not supported', () => {
+    expect(isStorageAvailable('unsupported-storage-type')).toBeFalsy();
   });
 
   it('should log a warning when storage is unavailable', () => {

--- a/packages/analytics-js-common/__tests__/utilities/storage.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/storage.test.ts
@@ -1,11 +1,7 @@
 import { defaultLogger } from '@rudderstack/analytics-js-common/__mocks__/Logger';
-import {
-  isStorageQuotaExceeded,
-  isStorageAvailable,
-} from '../../../../src/components/capabilitiesManager/detection/storage';
-import { CookieStorage, InMemoryStorage } from '../../../../src/services/StoreManager/storages';
+import { isStorageQuotaExceeded, isStorageAvailable } from '../../src/utilities/storage';
 
-describe('Capabilities Detection - Storage', () => {
+describe('Storage Utilities', () => {
   it('should detect localstorage size limit errors', () => {
     expect(
       isStorageQuotaExceeded(new DOMException('StorageQuotaExceeded', 'QuotaExceededError')),
@@ -54,11 +50,8 @@ describe('Capabilities Detection - Storage', () => {
   it('should detect if localstorage is available', () => {
     expect(isStorageAvailable()).toBeTruthy();
   });
-  it('should detect if cookieStorage is available', () => {
-    expect(isStorageAvailable('cookieStorage', new CookieStorage())).toBeTruthy();
-  });
   it('should detect if memoryStorage is available', () => {
-    expect(isStorageAvailable('memoryStorage', new InMemoryStorage())).toBeTruthy();
+    expect(isStorageAvailable('memoryStorage')).toBeTruthy();
   });
 
   it('should log a warning when storage is unavailable', () => {

--- a/packages/analytics-js-common/__tests__/utilities/storage.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/storage.test.ts
@@ -49,7 +49,7 @@ describe('Storage Utilities', () => {
   });
 
   it('should detect if localstorage is available', () => {
-    expect(isStorageAvailable()).toBeTruthy();
+    expect(isStorageAvailable('localStorage')).toBeTruthy();
   });
 
   it('should detect if cookie storage is available', () => {
@@ -67,7 +67,7 @@ describe('Storage Utilities', () => {
   });
 
   it('should return false if storage type is not supported', () => {
-    expect(isStorageAvailable('unsupported-storage-type')).toBeFalsy();
+    expect(isStorageAvailable('unsupported-storage-type' as any)).toBeFalsy();
   });
 
   it('should log a warning when storage is unavailable', () => {

--- a/packages/analytics-js-common/src/constants/logMessages.ts
+++ b/packages/analytics-js-common/src/constants/logMessages.ts
@@ -1,3 +1,4 @@
+import type { StorageType } from '../types/Storage';
 import { isString } from '../utilities/checks';
 
 const LOG_CONTEXT_SEPARATOR = ':: ';
@@ -21,6 +22,9 @@ const BAD_DATA_WARNING = (context: string, key: string): string =>
 
 const COOKIE_DATA_ENCODING_ERROR = `Failed to encode the cookie data.`;
 
+const STORAGE_UNAVAILABILITY_ERROR_PREFIX = (context: string, storageType: StorageType): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The "${storageType}" storage type is `;
+
 export {
   LOG_CONTEXT_SEPARATOR,
   SCRIPT_ALREADY_EXISTS_ERROR,
@@ -30,4 +34,5 @@ export {
   JSON_STRINGIFY_WARNING,
   BAD_DATA_WARNING,
   COOKIE_DATA_ENCODING_ERROR,
+  STORAGE_UNAVAILABILITY_ERROR_PREFIX,
 };

--- a/packages/analytics-js-common/src/constants/storages.ts
+++ b/packages/analytics-js-common/src/constants/storages.ts
@@ -6,4 +6,17 @@ const SESSION_STORAGE: StorageType = 'sessionStorage';
 const MEMORY_STORAGE: StorageType = 'memoryStorage';
 const NO_STORAGE: StorageType = 'none';
 
-export { COOKIE_STORAGE, LOCAL_STORAGE, SESSION_STORAGE, MEMORY_STORAGE, NO_STORAGE };
+const STORAGE_TEST_COOKIE = 'test_rudder_cookie';
+const STORAGE_TEST_LOCAL_STORAGE = 'test_rudder_ls';
+const STORAGE_TEST_SESSION_STORAGE = 'test_rudder_ss';
+
+export {
+  COOKIE_STORAGE,
+  LOCAL_STORAGE,
+  SESSION_STORAGE,
+  MEMORY_STORAGE,
+  NO_STORAGE,
+  STORAGE_TEST_COOKIE,
+  STORAGE_TEST_LOCAL_STORAGE,
+  STORAGE_TEST_SESSION_STORAGE,
+};

--- a/packages/analytics-js-common/src/utilities/storage.ts
+++ b/packages/analytics-js-common/src/utilities/storage.ts
@@ -6,13 +6,11 @@ import {
   LOCAL_STORAGE,
   MEMORY_STORAGE,
   SESSION_STORAGE,
-} from '../constants/storages';
-import type { ILogger } from '../types/Logger';
-import {
   STORAGE_TEST_COOKIE,
   STORAGE_TEST_LOCAL_STORAGE,
   STORAGE_TEST_SESSION_STORAGE,
 } from '../constants/storages';
+import type { ILogger } from '../types/Logger';
 import { STORAGE_UNAVAILABILITY_ERROR_PREFIX } from '../constants/logMessages';
 
 const isStorageQuotaExceeded = (e: unknown): boolean => {

--- a/packages/analytics-js-common/src/utilities/storage.ts
+++ b/packages/analytics-js-common/src/utilities/storage.ts
@@ -1,19 +1,19 @@
-import { CAPABILITIES_MANAGER } from '@rudderstack/analytics-js-common/constants/loggerContexts';
-import type { IStorage } from '@rudderstack/analytics-js-common/types/Store';
-import type { StorageType } from '@rudderstack/analytics-js-common/types/Storage';
+import { CAPABILITIES_MANAGER } from '../constants/loggerContexts';
+import type { IStorage } from '../types/Store';
+import type { StorageType } from '../types/Storage';
 import {
   COOKIE_STORAGE,
   LOCAL_STORAGE,
   MEMORY_STORAGE,
   SESSION_STORAGE,
-} from '@rudderstack/analytics-js-common/constants/storages';
-import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+} from '../constants/storages';
+import type { ILogger } from '../types/Logger';
 import {
   STORAGE_TEST_COOKIE,
   STORAGE_TEST_LOCAL_STORAGE,
   STORAGE_TEST_SESSION_STORAGE,
-} from '../../../constants/storage';
-import { STORAGE_UNAVAILABILITY_ERROR_PREFIX } from '../../../constants/logMessages';
+} from '../constants/storages';
+import { STORAGE_UNAVAILABILITY_ERROR_PREFIX } from '../constants/logMessages';
 
 const isStorageQuotaExceeded = (e: unknown): boolean => {
   const matchingNames = ['QuotaExceededError', 'NS_ERROR_DOM_QUOTA_REACHED'];

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/eventsDelivery.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/eventsDelivery.test.ts
@@ -1,0 +1,284 @@
+import { defaultLogger } from '@rudderstack/analytics-js-common/__mocks__/Logger';
+import {
+  LOCAL_STORAGE,
+  MEMORY_STORAGE,
+  SESSION_STORAGE,
+} from '@rudderstack/analytics-js-common/constants/storages';
+import * as storageUtils from '@rudderstack/analytics-js-common/utilities/storage';
+import { getStorageTypeForEventsPersistence } from '../../src/utilities/eventsDelivery';
+
+jest.mock('@rudderstack/analytics-js-common/utilities/storage');
+
+describe('Events Delivery Utilities', () => {
+  describe('getStorageTypeForEventsPersistence', () => {
+    const mockIsStorageAvailable = storageUtils.isStorageAvailable as jest.MockedFunction<
+      typeof storageUtils.isStorageAvailable
+    >;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
+
+    it('should return LOCAL_STORAGE when local storage is available', () => {
+      mockIsStorageAvailable.mockReturnValueOnce(true);
+
+      const result = getStorageTypeForEventsPersistence();
+
+      expect(result).toBe(LOCAL_STORAGE);
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(1);
+      expect(mockIsStorageAvailable).toHaveBeenCalledWith(LOCAL_STORAGE, undefined, undefined);
+    });
+
+    it('should return LOCAL_STORAGE when local storage is available with logger', () => {
+      mockIsStorageAvailable.mockReturnValueOnce(true);
+
+      const result = getStorageTypeForEventsPersistence(defaultLogger);
+
+      expect(result).toBe(LOCAL_STORAGE);
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(1);
+      expect(mockIsStorageAvailable).toHaveBeenCalledWith(
+        LOCAL_STORAGE,
+        undefined,
+        defaultLogger,
+      );
+    });
+
+    it('should fall back to SESSION_STORAGE when local storage is unavailable but session storage is available', () => {
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage check fails
+        .mockReturnValueOnce(true); // sessionStorage check succeeds
+
+      const result = getStorageTypeForEventsPersistence();
+
+      expect(result).toBe(SESSION_STORAGE);
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(2);
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(1, LOCAL_STORAGE, undefined, undefined);
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(
+        2,
+        SESSION_STORAGE,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should fall back to SESSION_STORAGE when local storage is unavailable but session storage is available with logger', () => {
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage check fails
+        .mockReturnValueOnce(true); // sessionStorage check succeeds
+
+      const result = getStorageTypeForEventsPersistence(defaultLogger);
+
+      expect(result).toBe(SESSION_STORAGE);
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(2);
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(
+        1,
+        LOCAL_STORAGE,
+        undefined,
+        defaultLogger,
+      );
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(
+        2,
+        SESSION_STORAGE,
+        undefined,
+        defaultLogger,
+      );
+    });
+
+    it('should fall back to MEMORY_STORAGE when both local storage and session storage are unavailable', () => {
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage check fails
+        .mockReturnValueOnce(false); // sessionStorage check fails
+
+      const result = getStorageTypeForEventsPersistence();
+
+      expect(result).toBe(MEMORY_STORAGE);
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(2);
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(1, LOCAL_STORAGE, undefined, undefined);
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(
+        2,
+        SESSION_STORAGE,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should fall back to MEMORY_STORAGE when both local storage and session storage are unavailable with logger', () => {
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage check fails
+        .mockReturnValueOnce(false); // sessionStorage check fails
+
+      const result = getStorageTypeForEventsPersistence(defaultLogger);
+
+      expect(result).toBe(MEMORY_STORAGE);
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(2);
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(
+        1,
+        LOCAL_STORAGE,
+        undefined,
+        defaultLogger,
+      );
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(
+        2,
+        SESSION_STORAGE,
+        undefined,
+        defaultLogger,
+      );
+    });
+
+    it('should not check session storage if local storage is available', () => {
+      mockIsStorageAvailable.mockReturnValueOnce(true); // localStorage check succeeds
+
+      const result = getStorageTypeForEventsPersistence();
+
+      expect(result).toBe(LOCAL_STORAGE);
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(1);
+      // Should only check localStorage, not sessionStorage
+      expect(mockIsStorageAvailable).toHaveBeenCalledWith(LOCAL_STORAGE, undefined, undefined);
+    });
+
+    it('should follow the priority order: localStorage > sessionStorage > memoryStorage', () => {
+      // Test case 1: All available - should return localStorage
+      mockIsStorageAvailable.mockReturnValueOnce(true);
+      let result = getStorageTypeForEventsPersistence();
+      expect(result).toBe(LOCAL_STORAGE);
+
+      jest.clearAllMocks();
+
+      // Test case 2: Only sessionStorage available - should return sessionStorage
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage unavailable
+        .mockReturnValueOnce(true); // sessionStorage available
+      result = getStorageTypeForEventsPersistence();
+      expect(result).toBe(SESSION_STORAGE);
+
+      jest.clearAllMocks();
+
+      // Test case 3: None available - should return memoryStorage
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage unavailable
+        .mockReturnValueOnce(false); // sessionStorage unavailable
+      result = getStorageTypeForEventsPersistence();
+      expect(result).toBe(MEMORY_STORAGE);
+    });
+
+    it('should handle storage availability check throwing errors gracefully', () => {
+      // isStorageAvailable should handle errors internally and return false
+      // but we test that the function still works if it throws
+      mockIsStorageAvailable
+        .mockImplementationOnce(() => {
+          throw new Error('Unexpected error');
+        })
+        .mockReturnValueOnce(true); // sessionStorage check succeeds
+
+      expect(() => getStorageTypeForEventsPersistence()).toThrow('Unexpected error');
+    });
+
+    it('should return MEMORY_STORAGE when all storage checks return false without logger', () => {
+      mockIsStorageAvailable.mockReturnValue(false);
+
+      const result = getStorageTypeForEventsPersistence();
+
+      expect(result).toBe(MEMORY_STORAGE);
+      // No logger passed, so logger parameter should be undefined
+      expect(mockIsStorageAvailable).toHaveBeenCalledWith(LOCAL_STORAGE, undefined, undefined);
+      expect(mockIsStorageAvailable).toHaveBeenCalledWith(SESSION_STORAGE, undefined, undefined);
+    });
+
+    it('should pass logger instance to all storage availability checks', () => {
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage check fails
+        .mockReturnValueOnce(false); // sessionStorage check fails
+
+      getStorageTypeForEventsPersistence(defaultLogger);
+
+      // Verify logger was passed to both checks
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(
+        1,
+        LOCAL_STORAGE,
+        undefined,
+        defaultLogger,
+      );
+      expect(mockIsStorageAvailable).toHaveBeenNthCalledWith(
+        2,
+        SESSION_STORAGE,
+        undefined,
+        defaultLogger,
+      );
+    });
+
+    it('should not invoke isStorageAvailable for memory storage', () => {
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage check fails
+        .mockReturnValueOnce(false); // sessionStorage check fails
+
+      const result = getStorageTypeForEventsPersistence();
+
+      expect(result).toBe(MEMORY_STORAGE);
+      // Should only check localStorage and sessionStorage, never memoryStorage
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(2);
+      expect(mockIsStorageAvailable).not.toHaveBeenCalledWith(
+        MEMORY_STORAGE,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('should handle undefined logger correctly', () => {
+      mockIsStorageAvailable.mockReturnValueOnce(true);
+
+      const result = getStorageTypeForEventsPersistence(undefined);
+
+      expect(result).toBe(LOCAL_STORAGE);
+      expect(mockIsStorageAvailable).toHaveBeenCalledWith(LOCAL_STORAGE, undefined, undefined);
+    });
+
+    it('should return correct storage type when localStorage is blocked (e.g., in cross-origin iframe)', () => {
+      // Simulating scenario where localStorage is blocked (common in iframes)
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage blocked
+        .mockReturnValueOnce(true); // sessionStorage available
+
+      const result = getStorageTypeForEventsPersistence(defaultLogger);
+
+      expect(result).toBe(SESSION_STORAGE);
+    });
+
+    it('should return correct storage type when both localStorage and sessionStorage are blocked', () => {
+      // Simulating scenario where all persistence storage is blocked
+      mockIsStorageAvailable
+        .mockReturnValueOnce(false) // localStorage blocked
+        .mockReturnValueOnce(false); // sessionStorage blocked
+
+      const result = getStorageTypeForEventsPersistence(defaultLogger);
+
+      expect(result).toBe(MEMORY_STORAGE);
+    });
+
+    it('should work correctly with multiple consecutive calls', () => {
+      // First call: localStorage available
+      mockIsStorageAvailable.mockReturnValueOnce(true);
+      expect(getStorageTypeForEventsPersistence()).toBe(LOCAL_STORAGE);
+
+      // Second call: only sessionStorage available
+      mockIsStorageAvailable.mockReturnValueOnce(false).mockReturnValueOnce(true);
+      expect(getStorageTypeForEventsPersistence()).toBe(SESSION_STORAGE);
+
+      // Third call: none available
+      mockIsStorageAvailable.mockReturnValueOnce(false).mockReturnValueOnce(false);
+      expect(getStorageTypeForEventsPersistence()).toBe(MEMORY_STORAGE);
+
+      expect(mockIsStorageAvailable).toHaveBeenCalledTimes(5);
+    });
+
+    it('should never return cookie storage type', () => {
+      // Even if all checks fail, should return memory storage, not cookie storage
+      mockIsStorageAvailable.mockReturnValue(false);
+
+      const result = getStorageTypeForEventsPersistence();
+
+      expect(result).toBe(MEMORY_STORAGE);
+      expect(result).not.toBe('cookieStorage');
+    });
+  });
+});

--- a/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
+++ b/packages/analytics-js-plugins/__tests__/xhrQueue/index.test.ts
@@ -213,7 +213,6 @@ describe('XhrQueue', () => {
         attemptNumber: 1,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
-        reclaimed: undefined,
         id: 'sample_uuid',
         time: 1 + 1000 * 2 ** 1, // this is the delay calculation in RetryQueue
         type: 'Single',
@@ -392,7 +391,6 @@ describe('XhrQueue', () => {
           event: mergeDeepRight(event, { sentAt: 'sample_timestamp' }),
         },
         attemptNumber: 1,
-        reclaimed: undefined,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
         id: 'sample_uuid',
@@ -500,7 +498,6 @@ describe('XhrQueue', () => {
           event: mergeDeepRight(event, { sentAt: 'sample_timestamp' }),
         },
         attemptNumber: 1,
-        reclaimed: undefined,
         lastAttemptedAt: expect.any(Number),
         firstAttemptedAt: expect.any(Number),
         id: 'sample_uuid',

--- a/packages/analytics-js-plugins/src/beaconQueue/index.ts
+++ b/packages/analytics-js-plugins/src/beaconQueue/index.ts
@@ -31,6 +31,7 @@ import {
   LOCAL_STORAGE,
   validateEventPayloadSize,
 } from '../shared-chunks/common';
+import { getStorageTypeForEventsPersistence } from '../utilities/eventsDelivery';
 
 const pluginName: PluginName = 'BeaconQueue';
 
@@ -126,7 +127,7 @@ const BeaconQueue = (): ExtensionPlugin => ({
         } as QueueOpts,
         queueProcessCallback,
         storeManager,
-        LOCAL_STORAGE,
+        getStorageTypeForEventsPersistence(logger),
         logger,
         (itemData: BeaconQueueItemData[]): number => {
           const currentTime = getCurrentTimeFormatted();

--- a/packages/analytics-js-plugins/src/utilities/eventsDelivery.ts
+++ b/packages/analytics-js-plugins/src/utilities/eventsDelivery.ts
@@ -6,6 +6,13 @@ import { LOG_CONTEXT_SEPARATOR } from '@rudderstack/analytics-js-common/constant
 import { stringifyWithoutCircular } from '@rudderstack/analytics-js-common/utilities/json';
 import { EVENT_PAYLOAD_SIZE_BYTES_LIMIT } from './constants';
 import type { TransformationRequestPayload } from '../deviceModeTransformation/types';
+import {
+  LOCAL_STORAGE,
+  MEMORY_STORAGE,
+  SESSION_STORAGE,
+} from '@rudderstack/analytics-js-common/constants/storages';
+import { isStorageAvailable } from '@rudderstack/analytics-js-common/utilities/storage';
+import type { StorageType } from '@rudderstack/analytics-js-common/types/Storage';
 
 const EVENT_PAYLOAD_SIZE_CHECK_FAIL_WARNING = (
   context: string,
@@ -77,9 +84,32 @@ const getFinalEventForDeliveryMutator = (event: RudderEvent, currentTime: string
   return finalEvent;
 };
 
+/**
+ * Utility to get the storage type for events persistence
+ * If local storage is available, use it; else, fall back to session storage; else, fall back to memory storage.
+ * On some browsers, persistence storage is blocked for the JS SDK that is loaded from RS domains.
+ * In such cases, we need to verify all the storage types and use the first one that is available.
+ * @param logger Logger instance for logging storage availability warnings
+ * @returns StorageType
+ */
+const getStorageTypeForEventsPersistence = (logger?: ILogger): StorageType => {
+  if (isStorageAvailable(LOCAL_STORAGE, undefined, logger)) {
+    return LOCAL_STORAGE;
+  }
+
+  if (isStorageAvailable(SESSION_STORAGE, undefined, logger)) {
+    return SESSION_STORAGE;
+  }
+
+  // Don't use cookie storage as it can potentially cause overhead with the network requests.
+  // Note that events will not be persisted across page reloads in this case.
+  return MEMORY_STORAGE;
+};
+
 export {
   getDeliveryPayload,
   validateEventPayloadSize,
   getFinalEventForDeliveryMutator,
   getDMTDeliveryPayload,
+  getStorageTypeForEventsPersistence,
 };

--- a/packages/analytics-js-plugins/src/xhrQueue/index.ts
+++ b/packages/analytics-js-plugins/src/xhrQueue/index.ts
@@ -30,12 +30,11 @@ import {
   isDefined,
   isErrRetryable,
   isUndefined,
-  LOCAL_STORAGE,
-  MEMORY_STORAGE,
   toBase64,
   validateEventPayloadSize,
 } from '../shared-chunks/common';
 import { DEFAULT_RETRY_REASON, RETRY_REASON_CLIENT_TIMEOUT } from '../utilities/constants';
+import { getStorageTypeForEventsPersistence } from '../utilities/eventsDelivery';
 
 const pluginName: PluginName = 'XhrQueue';
 
@@ -125,11 +124,7 @@ const XhrQueue = (): ExtensionPlugin => ({
           });
         },
         storeManager,
-        // If local storage is available, use it; else, fall back to memory storage.
-        // Note: Memory storage is not persistent across page reloads. 
-        // This means queued events will be lost if the page is refreshed or closed, 
-        // potentially impacting analytics reliability and data completeness.
-        state.capabilities.storage.isLocalStorageAvailable.value ? LOCAL_STORAGE : MEMORY_STORAGE,
+        getStorageTypeForEventsPersistence(logger),
         logger,
         (itemData: XHRQueueItemData[]): number => {
           const currentTime = getCurrentTimeFormatted();

--- a/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
+++ b/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
@@ -72,6 +72,8 @@ import { detectAdBlockers } from '../../../src/components/capabilitiesManager/de
 import { getUserAgent, getLanguage } from '../../../src/components/utilities/page';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { POLYFILL_URL } from '../../../src/components/capabilitiesManager/polyfill';
+import { getStorageEngine } from '../../../src/services/StoreManager/storages/storageEngine';
+import { COOKIE_STORAGE } from '@rudderstack/analytics-js-common/src/constants/storages';
 
 // Mock function references
 const mockHasBeacon = hasBeacon as jest.MockedFunction<typeof hasBeacon>;
@@ -185,6 +187,22 @@ describe('CapabilitiesManager', () => {
       expect(state.capabilities.isBeaconAvailable.value).toBe(false);
       expect(state.capabilities.isCryptoAvailable.value).toBe(false);
       expect(state.capabilities.storage.isCookieStorageAvailable.value).toBe(false);
+    });
+
+    it('should detect cookie storage availability', () => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+
+      // Use the actual implementation for this test
+      const { isStorageAvailable: actualIsStorageAvailable } = jest.requireActual(
+        '@rudderstack/analytics-js-common/utilities/storage',
+      );
+      const isCookieStorageAvailable = actualIsStorageAvailable(
+        COOKIE_STORAGE,
+        getStorageEngine('cookieStorage'),
+        mockLogger,
+      );
+      expect(isCookieStorageAvailable).toBe(true);
     });
 
     it('should detect ad blockers when configured', () => {

--- a/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
+++ b/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
@@ -189,22 +189,6 @@ describe('CapabilitiesManager', () => {
       expect(state.capabilities.storage.isCookieStorageAvailable.value).toBe(false);
     });
 
-    it('should detect cookie storage availability', () => {
-      jest.clearAllMocks();
-      jest.resetAllMocks();
-
-      // Use the actual implementation for this test
-      const { isStorageAvailable: actualIsStorageAvailable } = jest.requireActual(
-        '@rudderstack/analytics-js-common/utilities/storage',
-      );
-      const isCookieStorageAvailable = actualIsStorageAvailable(
-        COOKIE_STORAGE,
-        getStorageEngine('cookieStorage'),
-        mockLogger,
-      );
-      expect(isCookieStorageAvailable).toBe(true);
-    });
-
     it('should detect ad blockers when configured', () => {
       state.loadOptions.value.sendAdblockPage = true;
       state.lifecycle.sourceConfigUrl.value = 'https://api.rudderstack.com';

--- a/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
+++ b/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
@@ -1,15 +1,15 @@
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { IHttpClient } from '@rudderstack/analytics-js-common/types/HttpClient';
 import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/ErrorHandler';
+import { isStorageAvailable } from '@rudderstack/analytics-js-common/utilities/storage';
+import { getTimezone } from '@rudderstack/analytics-js-common/utilities/timezone';
 import { defaultHttpClient } from '../../../src/services/HttpClient';
 import {
   isLegacyJSEngine,
   hasBeacon,
   hasCrypto,
   hasUAClientHints,
-  isIE11,
   getScreenDetails,
-  isStorageAvailable,
 } from '../../../src/components/capabilitiesManager/detection';
 import type { ICapabilitiesManager } from '../../../src/components/capabilitiesManager/types';
 import { defaultErrorHandler } from '../../../src/services/ErrorHandler';
@@ -38,7 +38,6 @@ jest.mock('../../../src/components/capabilitiesManager/detection', () => {
       innerWidth: 1920,
       innerHeight: 1080,
     })),
-    isStorageAvailable: jest.fn(() => true),
   };
 });
 
@@ -65,17 +64,19 @@ jest.mock('../../../src/components/capabilitiesManager/polyfill', () => {
   };
 });
 
+jest.mock('@rudderstack/analytics-js-common/utilities/storage', () => ({
+  isStorageAvailable: jest.fn(() => true),
+}));
+
 import { detectAdBlockers } from '../../../src/components/capabilitiesManager/detection/adBlockers';
 import { getUserAgent, getLanguage } from '../../../src/components/utilities/page';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { POLYFILL_URL } from '../../../src/components/capabilitiesManager/polyfill';
-import { getTimezone } from '@rudderstack/analytics-js-common/utilities/timezone';
 
 // Mock function references
 const mockHasBeacon = hasBeacon as jest.MockedFunction<typeof hasBeacon>;
 const mockHasCrypto = hasCrypto as jest.MockedFunction<typeof hasCrypto>;
 const mockHasUAClientHints = hasUAClientHints as jest.MockedFunction<typeof hasUAClientHints>;
-const mockIsIE11 = isIE11 as jest.MockedFunction<typeof isIE11>;
 const mockIsLegacyJSEngine = isLegacyJSEngine as jest.MockedFunction<typeof isLegacyJSEngine>;
 const mockGetScreenDetails = getScreenDetails as jest.MockedFunction<typeof getScreenDetails>;
 const mockIsStorageAvailable = isStorageAvailable as jest.MockedFunction<typeof isStorageAvailable>;
@@ -111,7 +112,6 @@ describe('CapabilitiesManager', () => {
     mockHasBeacon.mockReturnValue(true);
     mockHasCrypto.mockReturnValue(true);
     mockHasUAClientHints.mockReturnValue(false);
-    mockIsIE11.mockReturnValue(false);
     mockIsLegacyJSEngine.mockReturnValue(false);
     mockGetScreenDetails.mockReturnValue({
       width: 1920,

--- a/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
+++ b/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
@@ -72,8 +72,6 @@ import { detectAdBlockers } from '../../../src/components/capabilitiesManager/de
 import { getUserAgent, getLanguage } from '../../../src/components/utilities/page';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { POLYFILL_URL } from '../../../src/components/capabilitiesManager/polyfill';
-import { getStorageEngine } from '../../../src/services/StoreManager/storages/storageEngine';
-import { COOKIE_STORAGE } from '@rudderstack/analytics-js-common/src/constants/storages';
 
 // Mock function references
 const mockHasBeacon = hasBeacon as jest.MockedFunction<typeof hasBeacon>;

--- a/packages/analytics-js/src/components/capabilitiesManager/CapabilitiesManager.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/CapabilitiesManager.ts
@@ -14,6 +14,7 @@ import { isValidURL } from '@rudderstack/analytics-js-common/utilities/url';
 import { isDefinedAndNotNull } from '@rudderstack/analytics-js-common/utilities/checks';
 import type { IHttpClient } from '@rudderstack/analytics-js-common/types/HttpClient';
 import { isIE11 } from '@rudderstack/analytics-js-common/utilities/detect';
+import { isStorageAvailable } from '@rudderstack/analytics-js-common/utilities/storage';
 import {
   INVALID_POLYFILL_URL_WARNING,
   POLYFILL_SCRIPT_LOAD_ERROR,
@@ -30,7 +31,6 @@ import {
   hasCrypto,
   hasUAClientHints,
   isLegacyJSEngine,
-  isStorageAvailable,
 } from './detection';
 import { detectAdBlockers } from './detection/adBlockers';
 import { debounce } from '../utilities/globals';

--- a/packages/analytics-js/src/components/capabilitiesManager/detection/index.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/detection/index.ts
@@ -3,4 +3,3 @@ export { isBrowser, isNode, hasCrypto, hasUAClientHints, hasBeacon } from './bro
 export { getUserAgentClientHint } from './clientHint';
 export { isDatasetAvailable, legacyJSEngineRequiredPolyfills, isLegacyJSEngine } from './dom';
 export { getScreenDetails } from './screen';
-export { isStorageAvailable, isStorageQuotaExceeded } from './storage';

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -65,9 +65,6 @@ const PLUGIN_INVOCATION_ERROR = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}Failed to invoke the "${extPoint}" extension point of plugin "${pluginName}".`;
 
-const STORAGE_UNAVAILABILITY_ERROR_PREFIX = (context: string, storageType: StorageType): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}The "${storageType}" storage type is `;
-
 const SOURCE_CONFIG_FETCH_ERROR = 'Failed to fetch the source config';
 
 const WRITE_KEY_VALIDATION_ERROR = (context: string, writeKey: string): string =>
@@ -292,7 +289,6 @@ export {
   PLUGIN_INVOCATION_ERROR,
   STORAGE_QUOTA_EXCEEDED_WARNING,
   STORAGE_UNAVAILABLE_WARNING,
-  STORAGE_UNAVAILABILITY_ERROR_PREFIX,
   SOURCE_CONFIG_FETCH_ERROR,
   SOURCE_CONFIG_OPTION_ERROR,
   DATA_PLANE_URL_ERROR,

--- a/packages/analytics-js/src/constants/storage.ts
+++ b/packages/analytics-js/src/constants/storage.ts
@@ -1,8 +1,5 @@
 import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
 
-const STORAGE_TEST_COOKIE = 'test_rudder_cookie';
-const STORAGE_TEST_LOCAL_STORAGE = 'test_rudder_ls';
-const STORAGE_TEST_SESSION_STORAGE = 'test_rudder_ss';
 const STORAGE_TEST_TOP_LEVEL_DOMAIN = '__tld__';
 const STOREJS_IS_INCOGNITO = '_Is_Incognit';
 
@@ -26,9 +23,6 @@ const USER_SESSION_KEYS: UserSessionKey[] = [
 ];
 
 export {
-  STORAGE_TEST_COOKIE,
-  STORAGE_TEST_LOCAL_STORAGE,
-  STORAGE_TEST_SESSION_STORAGE,
   STORAGE_TEST_TOP_LEVEL_DOMAIN,
   STOREJS_IS_INCOGNITO,
   CLIENT_DATA_STORE_NAME,

--- a/packages/analytics-js/src/services/StoreManager/Store.ts
+++ b/packages/analytics-js/src/services/StoreManager/Store.ts
@@ -7,7 +7,7 @@ import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { IPluginsManager } from '@rudderstack/analytics-js-common/types/PluginsManager';
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 import { MEMORY_STORAGE } from '@rudderstack/analytics-js-common/constants/storages';
-import { isStorageQuotaExceeded } from '../../components/capabilitiesManager/detection';
+import { isStorageQuotaExceeded } from '@rudderstack/analytics-js-common/utilities/storage';
 import {
   STORAGE_QUOTA_EXCEEDED_WARNING,
   STORE_DATA_FETCH_ERROR,

--- a/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/CookieStorage.ts
@@ -5,7 +5,7 @@ import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import { COOKIE_STORAGE } from '@rudderstack/analytics-js-common/constants/storages';
 import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/object';
 import { cookie } from '@rudderstack/analytics-js-common/component-cookie';
-import { isStorageAvailable } from '../../../components/capabilitiesManager/detection';
+import { isStorageAvailable } from '@rudderstack/analytics-js-common/utilities/storage';
 import { getDefaultCookieOptions } from './defaultOptions';
 import { defaultLogger } from '../../Logger';
 

--- a/packages/analytics-js/src/services/StoreManager/storages/LocalStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/LocalStorage.ts
@@ -5,7 +5,7 @@ import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/objec
 import { isUndefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import { LOCAL_STORAGE } from '@rudderstack/analytics-js-common/constants/storages';
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
-import { isStorageAvailable } from '../../../components/capabilitiesManager/detection';
+import { isStorageAvailable } from '@rudderstack/analytics-js-common/utilities/storage';
 import { defaultLogger } from '../../Logger';
 import { getDefaultLocalStorageOptions } from './defaultOptions';
 

--- a/packages/analytics-js/src/services/StoreManager/storages/sessionStorage.ts
+++ b/packages/analytics-js/src/services/StoreManager/storages/sessionStorage.ts
@@ -7,7 +7,7 @@ import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/objec
 import { isUndefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import { SESSION_STORAGE } from '@rudderstack/analytics-js-common/constants/storages';
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
-import { isStorageAvailable } from '../../../components/capabilitiesManager/detection';
+import { isStorageAvailable } from '@rudderstack/analytics-js-common/utilities/storage';
 import { defaultLogger } from '../../Logger';
 import { getDefaultSessionStorageOptions } from './defaultOptions';
 


### PR DESCRIPTION
## PR Description

Explicitly checking for different storage types in the events processing plugins before initialising the queues.
If browsers block access to the storage, we fallback to the in-memory storage in the worst case.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4199/determine-storage-type-in-the-events-processing-plugins

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11
- [x] Safari

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event persistence with intelligent storage fallback strategy—prioritizing LocalStorage, falling back to SessionStorage, then Memory storage when needed for better reliability across browser contexts.

* **Tests**
  * Enhanced test coverage for storage availability detection and event delivery persistence logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->