### PR TITLE
fix: avoid bfcache optimisation for page unloaded events

### DIFF
--- a/packages/analytics-js-common/__tests__/utilities/page.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/page.test.ts
@@ -13,6 +13,7 @@ describe('onPageLeave', () => {
     Object.defineProperty(document, 'visibilityState', {
       value: state,
       writable: true,
+      configurable: true,
     });
   };
 
@@ -21,6 +22,7 @@ describe('onPageLeave', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     setVisibilityState('visible');
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
@@ -28,194 +30,407 @@ describe('onPageLeave', () => {
     jest.useRealTimers();
   });
 
-  it('should fire the callback on pagehide event', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+  describe('basic event handling', () => {
+    it('should fire callback on pagehide event with visible state', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
 
-    dispatchDocumentEvent('pagehide');
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenCalledWith(false);
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should fire callback on pagehide event with hidden state', () => {
+      setVisibilityState('hidden');
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(true);
+    });
+
+    it('should fire callback on beforeunload event for IE11', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchWindowEvent('beforeunload');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should fire callback on visibilitychange to hidden', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(true);
+    });
+
+    it('should not fire callback on visibilitychange to visible', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('visible');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).not.toHaveBeenCalled();
+    });
+
+    it('should fire callback on blur event', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchWindowEvent('blur');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(true);
+    });
+
+    it('should not fire callback on focus event', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchWindowEvent('focus');
+      expect(evCallback).not.toHaveBeenCalled();
+    });
   });
 
-  it('should fire the callback on pagehide event based on visibility state', () => {
-    setVisibilityState('hidden');
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+  describe('deduplication behavior', () => {
+    it('should fire callback only once when multiple events fire simultaneously', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
 
-    dispatchDocumentEvent('pagehide');
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenCalledWith(true);
+      dispatchDocumentEvent('pagehide');
+      dispatchWindowEvent('beforeunload');
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should not fire callback twice on duplicate beforeunload events for IE11', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchWindowEvent('beforeunload');
+      dispatchWindowEvent('beforeunload');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(false);
+    });
   });
 
-  it('should fire the callback on beforeunload event for IE11', () => {
-    (globalThis.navigator as any).userAgent =
-      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+  describe('multiple event cycles', () => {
+    it('should fire callback on each visibility change cycle', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
 
-    dispatchWindowEvent('beforeunload');
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenCalledWith(false);
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+
+      setVisibilityState('visible');
+      dispatchDocumentEvent('visibilitychange');
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenCalledTimes(2);
+
+      expect(evCallback).toHaveBeenNthCalledWith(1, true);
+      expect(evCallback).toHaveBeenNthCalledWith(2, true);
+    });
+
+    it('should fire callback on each blur/focus cycle', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchWindowEvent('blur');
+      dispatchWindowEvent('focus');
+      dispatchWindowEvent('blur');
+      dispatchWindowEvent('focus');
+      expect(evCallback).toHaveBeenCalledTimes(2);
+
+      expect(evCallback).toHaveBeenNthCalledWith(1, true);
+      expect(evCallback).toHaveBeenNthCalledWith(2, true);
+    });
+
+    it('should fire callback for pagehide after visibility change cycle', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+
+      setVisibilityState('visible');
+      dispatchDocumentEvent('visibilitychange');
+
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledTimes(2);
+
+      expect(evCallback).toHaveBeenNthCalledWith(1, true);
+      expect(evCallback).toHaveBeenNthCalledWith(2, false);
+    });
+
+    it('should fire callback for beforeunload after visibility change cycle for IE11', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+
+      setVisibilityState('visible');
+      dispatchDocumentEvent('visibilitychange');
+
+      dispatchWindowEvent('beforeunload');
+      expect(evCallback).toHaveBeenCalledTimes(2);
+
+      expect(evCallback).toHaveBeenNthCalledWith(1, true);
+      expect(evCallback).toHaveBeenNthCalledWith(2, false);
+    });
+
+    it('should fire beforeunload on next tick after visibilitychange for IE11', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenNthCalledWith(1, true);
+
+      jest.runAllTimers();
+
+      dispatchWindowEvent('beforeunload');
+
+      expect(evCallback).toHaveBeenCalledTimes(2);
+      expect(evCallback).toHaveBeenNthCalledWith(2, false);
+    });
   });
 
-  it('should fire the callback on visibilitychange event', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+  describe('avoidBfCacheOptimisation parameter', () => {
+    it('should subscribe to beforeunload event on modern browsers when avoidBfCacheOptimisation is true', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback, true);
 
-    setVisibilityState('hidden');
-    dispatchDocumentEvent('visibilitychange');
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenCalledWith(true);
+      dispatchWindowEvent('beforeunload');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should not subscribe to beforeunload event on modern browsers when avoidBfCacheOptimisation is false', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback, false);
+
+      dispatchWindowEvent('beforeunload');
+      expect(evCallback).not.toHaveBeenCalled();
+    });
+
+    it('should subscribe to beforeunload event on IE11 regardless of avoidBfCacheOptimisation value', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback, false);
+
+      dispatchWindowEvent('beforeunload');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(false);
+    });
   });
 
-  it('should not fire the callback on visibilitychange event if visibilityState is visible', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+  describe('isAccessible flag behavior', () => {
+    it('should pass false for beforeunload events', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
 
-    setVisibilityState('visible');
-    dispatchDocumentEvent('visibilitychange');
-    expect(evCallback).not.toHaveBeenCalled();
+      dispatchWindowEvent('beforeunload');
+      expect(evCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should pass true for visibilitychange to hidden', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenCalledWith(true);
+    });
+
+    it('should pass true for blur events', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchWindowEvent('blur');
+      expect(evCallback).toHaveBeenCalledWith(true);
+    });
+
+    it('should pass false for pagehide with visible state', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('visible');
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should pass true for pagehide with hidden state', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledWith(true);
+    });
+
+    it('should maintain correct state across different event sequences', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      // blur → isAccessible = true
+      dispatchWindowEvent('blur');
+      expect(evCallback).toHaveBeenLastCalledWith(true);
+
+      // Reset and test beforeunload → isAccessible = false
+      dispatchWindowEvent('focus');
+      jest.clearAllMocks();
+
+      dispatchWindowEvent('beforeunload');
+      expect(evCallback).toHaveBeenLastCalledWith(false);
+
+      // Reset and test visibilitychange → isAccessible = true
+      jest.runAllTimers();
+      jest.clearAllMocks();
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenLastCalledWith(true);
+    });
   });
 
-  it('should fire the callback on blur event', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+  describe('focus and blur integration', () => {
+    it('should reset pageLeft flag on focus', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
 
-    dispatchWindowEvent('blur');
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenCalledWith(true);
+      dispatchWindowEvent('blur');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+
+      dispatchWindowEvent('focus');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+
+      dispatchWindowEvent('blur');
+      expect(evCallback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle iOS Safari tab close scenario', () => {
+      (globalThis.navigator as any).userAgent =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1';
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchWindowEvent('blur');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenCalledWith(true);
+    });
   });
 
-  it('should not fire the callback on focus event', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+  describe('pageLeft flag reset with setTimeout', () => {
+    it('should allow callback to fire again after setTimeout completes', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
 
-    dispatchWindowEvent('focus');
-    expect(evCallback).not.toHaveBeenCalled();
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+
+      // pageLeft should still be true, preventing duplicate calls
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+
+      // After timer runs, pageLeft should reset
+      jest.runAllTimers();
+
+      // Now callback should fire again
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should enable callback for inactive tab close scenario', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+
+      // Advance timers to reset pageLeft flag
+      jest.runAllTimers();
+
+      // Simulate another listener being triggered (e.g., pagehide)
+      dispatchDocumentEvent('pagehide');
+      expect(evCallback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not fire callback multiple times before setTimeout completes', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
+
+      dispatchWindowEvent('blur');
+      dispatchDocumentEvent('pagehide');
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+
+      expect(evCallback).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('should not fire the callback twice on pagehide event', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+  describe('edge cases', () => {
+    it('should handle visibility changes during blur state', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
 
-    dispatchDocumentEvent('pagehide');
-    dispatchDocumentEvent('pagehide');
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenCalledWith(false);
-  });
+      dispatchWindowEvent('blur');
+      expect(evCallback).toHaveBeenCalledTimes(1);
+      expect(evCallback).toHaveBeenLastCalledWith(true);
 
-  it('should not fire the callback twice on beforeunload event for IE11', () => {
-    (globalThis.navigator as any).userAgent =
-      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      // Should not fire again due to pageLeft flag
+      expect(evCallback).toHaveBeenCalledTimes(1);
+    });
 
-    dispatchWindowEvent('beforeunload');
-    dispatchWindowEvent('beforeunload');
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenCalledWith(false);
-  });
+    it('should correctly reset on visibilitychange to visible', () => {
+      const evCallback = jest.fn();
+      onPageLeave(evCallback);
 
-  it('should fire the callback only once if even multiple events are fired', () => {
-    (globalThis.navigator as any).userAgent =
-      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenCalledTimes(1);
 
-    dispatchDocumentEvent('pagehide');
-    dispatchWindowEvent('beforeunload');
-    setVisibilityState('hidden');
-    dispatchDocumentEvent('visibilitychange');
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenCalledWith(false);
-  });
+      // Return to visible should reset pageLeft
+      setVisibilityState('visible');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenCalledTimes(1);
 
-  it('should fire the callback reliably when visibility changes multiple times', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
-
-    setVisibilityState('hidden');
-    dispatchDocumentEvent('visibilitychange');
-
-    setVisibilityState('visible');
-    dispatchDocumentEvent('visibilitychange');
-
-    setVisibilityState('hidden');
-    dispatchDocumentEvent('visibilitychange');
-    expect(evCallback).toHaveBeenCalledTimes(2);
-
-    expect(evCallback).toHaveBeenNthCalledWith(1, true);
-    expect(evCallback).toHaveBeenNthCalledWith(2, true);
-  });
-
-  it('should fire the callback reliably when blur and focus events are fired multiple times', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
-
-    dispatchWindowEvent('blur');
-    dispatchWindowEvent('focus');
-    dispatchWindowEvent('blur');
-    dispatchWindowEvent('focus');
-    expect(evCallback).toHaveBeenCalledTimes(2);
-
-    expect(evCallback).toHaveBeenNthCalledWith(1, true);
-    expect(evCallback).toHaveBeenNthCalledWith(2, true);
-  });
-
-  it('should fire the callback on pagehide event even after multiple visibility changes happen', () => {
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
-
-    setVisibilityState('hidden');
-    dispatchDocumentEvent('visibilitychange');
-
-    setVisibilityState('visible');
-    dispatchDocumentEvent('visibilitychange');
-
-    dispatchDocumentEvent('pagehide');
-    expect(evCallback).toHaveBeenCalledTimes(2);
-
-    expect(evCallback).toHaveBeenNthCalledWith(1, true);
-    expect(evCallback).toHaveBeenNthCalledWith(2, false);
-  });
-
-  it('should fire the callback on beforeunload event even after multiple visibility changes happen for IE11', () => {
-    (globalThis.navigator as any).userAgent =
-      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
-
-    setVisibilityState('hidden');
-    dispatchDocumentEvent('visibilitychange');
-
-    setVisibilityState('visible');
-    dispatchDocumentEvent('visibilitychange');
-
-    dispatchWindowEvent('beforeunload');
-    expect(evCallback).toHaveBeenCalledTimes(2);
-
-    expect(evCallback).toHaveBeenNthCalledWith(1, true);
-
-    expect(evCallback).toHaveBeenNthCalledWith(2, false);
-  });
-
-  it('should fire the callback on beforeunload event on the next tick even when the tab is inactive for IE11', () => {
-    (globalThis.navigator as any).userAgent =
-      'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
-    const evCallback = jest.fn();
-    onPageLeave(evCallback);
-
-    setVisibilityState('hidden');
-    dispatchDocumentEvent('visibilitychange');
-
-    expect(evCallback).toHaveBeenCalledTimes(1);
-    expect(evCallback).toHaveBeenNthCalledWith(1, true);
-
-    jest.runAllTimers();
-
-    dispatchWindowEvent('beforeunload');
-
-    expect(evCallback).toHaveBeenCalledTimes(2);
-    expect(evCallback).toHaveBeenNthCalledWith(2, false);
+      // Should be able to fire again
+      setVisibilityState('hidden');
+      dispatchDocumentEvent('visibilitychange');
+      expect(evCallback).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/analytics-js-common/__tests__/utilities/page.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/page.test.ts
@@ -216,8 +216,8 @@ describe('onPageLeave', () => {
     });
   });
 
-  describe('avoidBfCacheOptimisation parameter', () => {
-    it('should subscribe to beforeunload event on modern browsers when avoidBfCacheOptimisation is true', () => {
+  describe('avoidBfCacheOptimization parameter', () => {
+    it('should subscribe to beforeunload event on modern browsers when avoidBfCacheOptimization is true', () => {
       (globalThis.navigator as any).userAgent =
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
       const evCallback = jest.fn();
@@ -228,7 +228,7 @@ describe('onPageLeave', () => {
       expect(evCallback).toHaveBeenCalledWith(false);
     });
 
-    it('should not subscribe to beforeunload event on modern browsers when avoidBfCacheOptimisation is false', () => {
+    it('should not subscribe to beforeunload event on modern browsers when avoidBfCacheOptimization is false', () => {
       (globalThis.navigator as any).userAgent =
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
       const evCallback = jest.fn();
@@ -238,7 +238,7 @@ describe('onPageLeave', () => {
       expect(evCallback).not.toHaveBeenCalled();
     });
 
-    it('should subscribe to beforeunload event on IE11 regardless of avoidBfCacheOptimisation value', () => {
+    it('should subscribe to beforeunload event on IE11 regardless of avoidBfCacheOptimization value', () => {
       (globalThis.navigator as any).userAgent =
         'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko';
       const evCallback = jest.fn();

--- a/packages/analytics-js-common/src/utilities/page.ts
+++ b/packages/analytics-js-common/src/utilities/page.ts
@@ -1,6 +1,14 @@
 import { isIE11 } from './detect';
 
-const onPageLeave = (callback: (isAccessible: boolean) => void) => {
+/**
+ * Registers events to detect page leave scenarios
+ * @param callback Callback function
+ * @param avoidBfCacheOptimisation When `true`, forcefully subscribes to beforeunload event, compromising on the bfcache optimisation
+ */
+const onPageLeave = (
+  callback: (isAccessible: boolean) => void,
+  avoidBfCacheOptimisation = false,
+) => {
   // To ensure the callback is only called once even if more than one events
   // are fired at once.
   let pageLeft = false;
@@ -29,7 +37,8 @@ const onPageLeave = (callback: (isAccessible: boolean) => void) => {
   // Note that 'pagehide' is not supported in IE.
   // Registering this event conditionally for IE11 also because
   // it affects bfcache optimization on modern browsers otherwise.
-  if (isIE11()) {
+  // However, if optimisation is disabled, force subscribe the event
+  if (avoidBfCacheOptimisation === true || isIE11()) {
     (globalThis as typeof window).addEventListener('beforeunload', () => {
       isAccessible = false;
       handleOnLeave();

--- a/packages/analytics-js-common/src/utilities/page.ts
+++ b/packages/analytics-js-common/src/utilities/page.ts
@@ -3,11 +3,11 @@ import { isIE11 } from './detect';
 /**
  * Registers events to detect page leave scenarios
  * @param callback Callback function
- * @param avoidBfCacheOptimisation When `true`, forcefully subscribes to beforeunload event, compromising on the bfcache optimisation
+ * @param avoidBfCacheOptimization When `true`, forcefully subscribes to beforeunload event, compromising on the bfcache optimization
  */
 const onPageLeave = (
   callback: (isAccessible: boolean) => void,
-  avoidBfCacheOptimisation = false,
+  avoidBfCacheOptimization = false,
 ) => {
   // To ensure the callback is only called once even if more than one events
   // are fired at once.
@@ -37,8 +37,8 @@ const onPageLeave = (
   // Note that 'pagehide' is not supported in IE.
   // Registering this event conditionally for IE11 also because
   // it affects bfcache optimization on modern browsers otherwise.
-  // However, if optimisation is disabled, force subscribe the event
-  if (avoidBfCacheOptimisation === true || isIE11()) {
+  // However, if optimization is disabled, force subscribe the event
+  if (avoidBfCacheOptimization || isIE11()) {
     (globalThis as typeof window).addEventListener('beforeunload', () => {
       isAccessible = false;
       handleOnLeave();

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -71,7 +71,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (ESM)',
     path: 'dist/npm/modern/bundled/esm/index.mjs',
     import: '*',
-    limit: '41 KiB',
+    limit: '41.5 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (CJS)',

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -292,7 +292,7 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
               },
             );
           }
-        });
+        }, true);
       } else {
         // log warning if beacon is disabled
         this.logger.warn(PAGE_UNLOAD_ON_BEACON_DISABLED_WARNING(RSA));


### PR DESCRIPTION
## PR Description

I've fixed the issue with page unloaded events firing functionality by forcefully subscribing to "beforeunloaded" event when this feature is enabled.
However, we need to compromise on the bfcache optimisation but it cannot be avoided.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4203/fix-page-unloaded-events-functionality

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional parameter to control cache-optimization behavior for page exit handling.

* **Improvements**
  * Page unload tracking now respects the optimization flag and has broader cross-browser handling for visibility, pagehide, focus/blur and unload sequences.
  * Expanded and reorganized test coverage for many exit scenarios and edge cases.

* **Updates**
  * Slight increase to the public bundle size limit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->