### PR TITLE
fix: race condition with server cookies data in events

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -7,6 +7,10 @@ on:
         description: "Deploy to NPM"
         type: boolean
         default: false
+      deploy_always:
+        description: Enable to by-pass all deploy restrictions
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -66,37 +70,46 @@ jobs:
               state: 'open'
             });
             
+            const deployAlways = '${{ inputs.deploy_always }}' === 'true';
+
             if (pullRequests.length > 0) {
               const pr = pullRequests[0];
               const prNumber = pr.number.toString();
               const prUrl = pr.html_url;
               console.log(`Found PR #${prNumber} for branch ${branch}: https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`);
-              
+
+              if (deployAlways) {
+                console.log(`⚠️  deploy_always is enabled - bypassing all PR restrictions for PR #${prNumber}`);
+                core.setOutput('pr_number', prNumber);
+                core.setOutput('pr_url', prUrl);
+                return;
+              }
+
               // Check if PR is in draft state
               if (pr.draft) {
                 core.setFailed(`PR #${prNumber} is in draft state. Please mark it as ready for review before deploying.`);
                 return;
               }
-              
+
               // Get detailed PR information including mergeable state
               const { data: prDetails } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber
               });
-              
+
               // Check if PR is mergeable and all requirements are satisfied
               if (prDetails.mergeable === false) {
                 core.setFailed(`PR #${prNumber} is not in a mergeable state. Please resolve conflicts before deploying.`);
                 return;
               }
-              
+
               // The mergeable_state can be one of: clean, dirty, blocked, unstable, or unknown
               // Only 'clean' means all requirements are met (checks passed, approvals received, no conflicts)
               if (prDetails.mergeable_state !== 'clean') {
                 // Get more details about why it's not clean
                 let reason = '';
-                
+
                 if (prDetails.mergeable_state === 'blocked') {
                   reason = 'required checks or approvals are missing';
                 } else if (prDetails.mergeable_state === 'dirty') {
@@ -106,13 +119,13 @@ jobs:
                 } else {
                   reason = `the mergeable state is "${prDetails.mergeable_state}"`;
                 }
-                
+
                 core.setFailed(`PR #${prNumber} is not ready to merge: ${reason}. Please resolve all issues before deploying.`);
                 return;
               }
-              
+
               console.log(`PR #${prNumber} is in a clean mergeable state. All requirements satisfied. Proceeding with beta deployment.`);
-              
+
               core.setOutput('pr_number', prNumber);
               core.setOutput('pr_url', prUrl);
             } else {

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -164,7 +164,8 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
         run: |
           # Remove unnecessary fields from package.json before publishing
-          npx nx affected --target=pre-release --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }}
+          # npx nx affected --target=pre-release --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }}
+          ./scripts/make-package-json-publish-ready.sh
 
           TAG_OPTION=""
           if [[ "${{ inputs.environment }}" == "beta" ]]; then

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -173,7 +173,8 @@ jobs:
             TAG_OPTION="--tag=beta"
           fi
 
-          npx nx release publish --verbose --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} $TAG_OPTION
+          # npx nx release publish --verbose --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }} $TAG_OPTION
+          npx nx release publish --verbose --projects=@rudderstack/analytics-js $TAG_OPTION
 
           # Reset the changes made to package.json
           git reset --hard

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -164,7 +164,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
         run: |
           # Remove unnecessary fields from package.json before publishing
-          ./scripts/make-package-json-publish-ready.sh
+          npx nx affected --target=pre-release --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }}
 
           TAG_OPTION=""
           if [[ "${{ inputs.environment }}" == "beta" ]]; then

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -165,7 +165,8 @@ jobs:
         run: |
           # Remove unnecessary fields from package.json before publishing
           # npx nx affected --target=pre-release --base=${{ env.last_monorepo_version }} --head=${{ env.current_monorepo_version }}
-          ./scripts/make-package-json-publish-ready.sh
+          # ./scripts/make-package-json-publish-ready.sh
+          npx nx run-many -t pre-release --projects=@rudderstack/analytics-js
 
           TAG_OPTION=""
           if [[ "${{ inputs.environment }}" == "beta" ]]; then

--- a/packages/analytics-js-common/project.json
+++ b/packages/analytics-js-common/project.json
@@ -56,6 +56,12 @@
         "discussion-category": "@rudderstack/analytics-js-common@3.26.1",
         "notesFile": "./packages/analytics-js-common/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/analytics-js-common"
+      }
     }
   }
 }

--- a/packages/analytics-js-common/src/utilities/checks.ts
+++ b/packages/analytics-js-common/src/utilities/checks.ts
@@ -6,6 +6,7 @@
 const isFunction = (value: any): value is Function =>
   typeof value === 'function' && Boolean(value.constructor && value.call && value.apply);
 
+
 /**
  * A function to check given value is a string
  * @param value input value

--- a/packages/analytics-js-cookies/project.json
+++ b/packages/analytics-js-cookies/project.json
@@ -56,6 +56,12 @@
         "discussion-category": "@rudderstack/analytics-js-cookies@0.5.5",
         "notesFile": "./packages/analytics-js-cookies/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/analytics-js-cookies"
+      }
     }
   }
 }

--- a/packages/analytics-js-integrations/project.json
+++ b/packages/analytics-js-integrations/project.json
@@ -56,6 +56,12 @@
         "discussion-category": "@rudderstack/analytics-js-integrations@3.19.0",
         "notesFile": "./packages/analytics-js-integrations/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/analytics-js-integrations"
+      }
     }
   }
 }

--- a/packages/analytics-js-legacy-utilities/project.json
+++ b/packages/analytics-js-legacy-utilities/project.json
@@ -56,6 +56,12 @@
         "discussion-category": "@rudderstack/analytics-js-legacy-utilities@0.1.0",
         "notesFile": "./packages/analytics-js-legacy-utilities/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/analytics-js-legacy-utilities"
+      }
     }
   }
 }

--- a/packages/analytics-js-plugins/project.json
+++ b/packages/analytics-js-plugins/project.json
@@ -56,6 +56,12 @@
         "discussion-category": "@rudderstack/analytics-js-plugins@3.14.1",
         "notesFile": "./packages/analytics-js-plugins/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/analytics-js-plugins"
+      }
     }
   }
 }

--- a/packages/analytics-js-service-worker/project.json
+++ b/packages/analytics-js-service-worker/project.json
@@ -56,6 +56,12 @@
         "discussion-category": "rudderstack/analytics-js-service-worker@3.3.5",
         "notesFile": "./packages/analytics-js-service-worker/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/analytics-js-service-worker"
+      }
     }
   }
 }

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -107,7 +107,7 @@ export default [
     name: 'Core (Content Script) - Modern - NPM (ESM)',
     path: 'dist/npm/modern/content-script/esm/index.mjs',
     import: '*',
-    limit: '41 KiB',
+    limit: '41.5 KiB',
   },
   {
     name: 'Core (Content Script) - Modern - NPM (CJS)',

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -73,9 +73,9 @@ describe('User session manager', () => {
 
   const clearStorage = () => {
     Object.values(COOKIE_KEYS).forEach(key => {
-      clientDataStoreCookie.remove(key);
-      clientDataStoreLS.remove(key);
-      clientDataStoreSession.remove(key);
+      clientDataStoreCookie.remove(key as string);
+      clientDataStoreLS.remove(key as string);
+      clientDataStoreSession.remove(key as string);
     });
   };
 
@@ -1401,12 +1401,16 @@ describe('User session manager', () => {
 
   describe('setInitialReferringDomain', () => {
     it('should set the provided initial referring domain', () => {
+      const setMock = jest.spyOn(clientDataStoreCookie, 'set');
+
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       const newReferrer = 'new-dummy-referrer-2';
       userSessionManager.init();
       userSessionManager.setInitialReferringDomain(newReferrer);
       expect(state.session.initialReferringDomain.value).toBe(newReferrer);
-      expect(clientDataStoreCookie.set).toHaveBeenCalled();
+      expect(setMock).toHaveBeenCalled();
+
+      setMock.mockRestore();
     });
 
     it('should reset the value to default value if persistence is not enabled for initial referring domain', () => {
@@ -1478,7 +1482,7 @@ describe('User session manager', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       userSessionManager.init();
 
-      const futureTimestamp = Date.now() + 5000;
+      const futureTimestamp = Date.now() + Number.MAX_SAFE_INTEGER;
       state.session.sessionInfo.value = {
         autoTrack: true,
         timeout: 10 * 60 * 1000,
@@ -1591,13 +1595,7 @@ describe('User session manager', () => {
       // The effect from registerEffects calls syncValueToStorage with just the key
       // refreshSession explicitly calls it with (sessionKey, sessionInfo) when SDK is not ready
       expect(syncValueToStorageSpy).toHaveBeenCalledTimes(3);
-      expect(syncValueToStorageSpy).toHaveBeenCalledWith('sessionInfo', {
-        autoTrack: true,
-        timeout: 1800000,
-        expiresAt: expect.any(Number),
-        id: expect.any(Number),
-        sessionStart: true,
-      });
+      expect(syncValueToStorageSpy).toHaveBeenCalledWith('sessionInfo');
     });
   });
 
@@ -2084,37 +2082,48 @@ describe('User session manager', () => {
   });
 
   describe('syncValueToStorage', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(0);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should not call setServerSideCookies method in case isEnabledServerSideCookies state option is not set', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId');
+
+      state.session.anonymousId.value = 'dummy_anonymousId';
+      userSessionManager.syncValueToStorage('anonymousId');
 
       jest.advanceTimersByTime(1000);
 
       expect(setServerSideCookiesSpy).not.toHaveBeenCalled();
     });
 
-    it('should call setServerSideCookies method in case isEnabledServerSideCookies state option is set to true', done => {
+    it('should call setServerSideCookies method in case isEnabledServerSideCookies state option is set to true', () => {
       state.serverCookies.isEnabledServerSideCookies.value = true;
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
-      clientDataStoreCookie.set = jest.fn();
-      const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId');
 
-      setTimeout(() => {
-        expect(setServerSideCookiesSpy).toHaveBeenCalledWith(
-          {
-            anonymousId: {
-              name: 'rl_anonymous_id',
-            },
+      userSessionManager.setServerSideCookies = jest.fn();
+
+      state.session.anonymousId.value = 'dummy_anonymousId';
+      userSessionManager.syncValueToStorage('anonymousId');
+
+      jest.runAllTimers();
+
+      expect(userSessionManager.setServerSideCookies).toHaveBeenCalledWith(
+        {
+          anonymousId: {
+            name: 'rl_anonymous_id',
           },
-          expect.any(Function),
-          expect.any(Object),
-        );
-        expect(clientDataStoreCookie.set).toHaveBeenCalled();
-        done();
-      }, 1000);
+        },
+        expect.any(Function),
+        expect.any(Object),
+      );
     });
 
     describe('Cookie should be removed from server side', () => {
@@ -2125,7 +2134,8 @@ describe('User session manager', () => {
         state.storage.entries.value = entriesWithOnlyCookieStorage;
         userSessionManager.setServerSideCookies = jest.fn();
         clientDataStoreCookie.remove = jest.fn();
-        userSessionManager.syncValueToStorage('anonymousId', cookieValue);
+        state.session.anonymousId.value = cookieValue;
+        userSessionManager.syncValueToStorage('anonymousId');
 
         jest.advanceTimersByTime(1000);
 
@@ -2135,33 +2145,35 @@ describe('User session manager', () => {
       });
     });
 
-    it('should debounce multiple cookie set network requests', done => {
+    it('should debounce multiple cookie set network requests', () => {
       state.serverCookies.isEnabledServerSideCookies.value = true;
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
-      clientDataStoreCookie.set = jest.fn();
-      const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+      // clientDataStoreCookie.set = jest.fn();
 
-      // The first call sends immediately, then subsequent calls within debounce window are consolidated
-      // So we expect 2 calls: first (dummy_anonymousId1) and last (dummy_anonymousId3)
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId1');
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId2');
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId3');
+      userSessionManager.setServerSideCookies = jest.fn();
 
-      setTimeout(() => {
-        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(2);
-        // Both calls should have the same structure with SessionEntryData
-        expect(setServerSideCookiesSpy).toHaveBeenCalledWith(
-          {
-            anonymousId: {
-              name: 'rl_anonymous_id',
-            },
+      // All calls within debounce window are consolidated into a single request with the latest value
+      // Each syncValueToStorage resets the debounce timer, so only the last value is sent
+      state.session.anonymousId.value = 'dummy_anonymousId1';
+      userSessionManager.syncValueToStorage('anonymousId');
+      state.session.anonymousId.value = 'dummy_anonymousId2';
+      userSessionManager.syncValueToStorage('anonymousId');
+      state.session.anonymousId.value = 'dummy_anonymousId3';
+      userSessionManager.syncValueToStorage('anonymousId');
+
+      jest.runAllTimers();
+
+      expect(userSessionManager.setServerSideCookies).toHaveBeenCalledTimes(1);
+      expect(userSessionManager.setServerSideCookies).toHaveBeenCalledWith(
+        {
+          anonymousId: {
+            name: 'rl_anonymous_id',
           },
-          expect.any(Function),
-          expect.any(Object),
-        );
-        done();
-      }, 1000);
+        },
+        expect.any(Function),
+        expect.any(Object),
+      );
     });
   });
 
@@ -2208,6 +2220,7 @@ describe('User session manager', () => {
       );
       done();
     });
+
     describe('Network request to Data service is successful', () => {
       it('should validate cookies are set from the server side', done => {
         state.source.value = {
@@ -2265,6 +2278,17 @@ describe('User session manager', () => {
           samesite: 'Lax',
         };
         state.session.userId.value = { prop1: 'sample property' };
+
+        // Mock store that:
+        // 1. Returns null initially (cookie doesn't exist - originalCookieVal = null)
+        // 2. Returns null after server request (cookie still doesn't exist - actualCookieVal = null)
+        // This simulates complete failure: both originalCookieVal and actualCookieVal are null
+        const mockStoreWithNull = {
+          encrypt: jest.fn(val => `encrypted_${JSON.parse(val)}`),
+          set: jest.fn(),
+          get: jest.fn(() => null), // Always returns null - complete failure to set
+        };
+
         userSessionManager.setServerSideCookies(
           {
             userId: {
@@ -2272,17 +2296,118 @@ describe('User session manager', () => {
             },
           },
           (name, val) => {
-            mockCookieStore.set(name, val);
+            mockStoreWithNull.set(name, val);
           },
-          mockCookieStore,
+          mockStoreWithNull,
         );
         setTimeout(() => {
-          expect(mockCookieStore.get).toHaveBeenCalledWith('key');
+          expect(mockStoreWithNull.get).toHaveBeenCalledWith('key');
           expect(stringifyWithoutCircular).toHaveBeenCalled();
+          // Error should be logged: originalCookieVal is null AND actualCookieVal is null
           expect(defaultLogger.error).toHaveBeenCalledWith(
             'The server failed to set the key cookie. As a fallback, the cookies will be set client side.',
           );
-          expect(mockCookieStore.set).toHaveBeenCalledWith('key', { prop1: 'sample property' });
+          expect(mockStoreWithNull.set).toHaveBeenCalledWith('key', { prop1: 'sample property' });
+          done();
+        }, 1000);
+      });
+      it('should not log error when cookie existed before (originalCookieVal not null)', done => {
+        state.source.value = {
+          workspaceId: 'sample_workspaceId',
+          id: 'sample_source_id',
+          name: 'sample_source_name',
+        };
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        state.storage.cookie.value = {
+          maxage: 10 * 60 * 1000, // 10 min
+          path: '/',
+          domain: 'dummy.dataplane.host.com',
+          samesite: 'Lax',
+        };
+        state.session.userId.value = { prop1: 'new value' };
+
+        // Mock store that:
+        // 1. Returns existing value initially (originalCookieVal = {prop1: 'old value'})
+        // 2. Returns different value after request (actualCookieVal = {prop1: 'old value'})
+        // This simulates: cookie existed before, so no error should be logged
+        const mockStoreWithExistingValue = {
+          encrypt: jest.fn(val => `encrypted_${JSON.parse(val)}`),
+          set: jest.fn(),
+          get: jest.fn(() => ({ prop1: 'old value' })), // Returns existing value (not null)
+        };
+
+        userSessionManager.setServerSideCookies(
+          {
+            userId: {
+              name: 'key',
+            },
+          },
+          (name, val) => {
+            mockStoreWithExistingValue.set(name, val);
+          },
+          mockStoreWithExistingValue,
+        );
+        setTimeout(() => {
+          expect(mockStoreWithExistingValue.get).toHaveBeenCalledWith('key');
+          // Error should NOT be logged because originalCookieVal was not null
+          expect(defaultLogger.error).not.toHaveBeenCalledWith(
+            'The server failed to set the key cookie. As a fallback, the cookies will be set client side.',
+          );
+          // But fallback should still be called because expectedCookieVal !== actualCookieVal
+          expect(mockStoreWithExistingValue.set).toHaveBeenCalledWith('key', {
+            prop1: 'new value',
+          });
+          done();
+        }, 1000);
+      });
+      it('should not log error when cookie was successfully set (originalCookieVal null, actualCookieVal not null)', done => {
+        state.source.value = {
+          workspaceId: 'sample_workspaceId',
+          id: 'sample_source_id',
+          name: 'sample_source_name',
+        };
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        state.storage.cookie.value = {
+          maxage: 10 * 60 * 1000, // 10 min
+          path: '/',
+          domain: 'dummy.dataplane.host.com',
+          samesite: 'Lax',
+        };
+        state.session.userId.value = { prop1: 'sample property' };
+
+        let callCount = 0;
+        // Mock store that:
+        // 1. Returns null on first call (originalCookieVal = null)
+        // 2. Returns value on subsequent calls (actualCookieVal = {prop1: 'sample property'})
+        // This simulates successful cookie set
+        const mockStoreWithSuccessfulSet = {
+          encrypt: jest.fn(val => `encrypted_${JSON.parse(val)}`),
+          set: jest.fn(),
+          get: jest.fn(() => {
+            callCount++;
+            return callCount === 1 ? null : { prop1: 'sample property' };
+          }),
+        };
+
+        userSessionManager.setServerSideCookies(
+          {
+            userId: {
+              name: 'key',
+            },
+          },
+          (name, val) => {
+            mockStoreWithSuccessfulSet.set(name, val);
+          },
+          mockStoreWithSuccessfulSet,
+        );
+        setTimeout(() => {
+          expect(mockStoreWithSuccessfulSet.get).toHaveBeenCalledWith('key');
+          // Error should NOT be logged: originalCookieVal is null but actualCookieVal is NOT null (success!)
+          expect(defaultLogger.error).not.toHaveBeenCalledWith(
+            'The server failed to set the key cookie. As a fallback, the cookies will be set client side.',
+          );
+          // Fallback should NOT be called because cookie was successfully set
+          expect(mockStoreWithSuccessfulSet.set).not.toHaveBeenCalled();
           done();
         }, 1000);
       });

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -160,7 +160,6 @@ describe('User session manager', () => {
         rl_anonymous_id: 'dummy-anonymousId',
       };
       setDataInCookieStorage(customData);
-      // @ts-expect-error - need to test this case
       state.loadOptions.value.externalAnonymousIdCookieName = 12345;
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       const spy = jest.spyOn(userSessionManager, 'getExternalAnonymousIdByCookieName');
@@ -175,7 +174,6 @@ describe('User session manager', () => {
         rl_anonymous_id: 'dummy-anonymousId',
       };
       setDataInCookieStorage(customData);
-      // @ts-expect-error - need to test this case
       state.loadOptions.value.externalAnonymousIdCookieName = null;
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       const spy = jest.spyOn(userSessionManager, 'getExternalAnonymousIdByCookieName');
@@ -649,7 +647,6 @@ describe('User session manager', () => {
 
     it('should log a warning and use default timeout if provided timeout is not in number format', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
-      // @ts-expect-error need to test this case
       state.loadOptions.value.sessions.timeout = '100000';
       userSessionManager.init();
       expect(defaultLogger.warn).toHaveBeenCalledWith(
@@ -681,7 +678,6 @@ describe('User session manager', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       state.loadOptions.value.sessions!.cutOff = {
         enabled: true,
-        // @ts-expect-error - need to test this case
         duration: '100000',
       };
 
@@ -1291,7 +1287,6 @@ describe('User session manager', () => {
     it('should reset the value to default value if the value is not an object', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       userSessionManager.init();
-      // @ts-expect-error - need to test this case
       userSessionManager.setUserTraits('dummy-user-traits');
       expect(state.session.userTraits.value).toStrictEqual(DEFAULT_USER_SESSION_VALUES.userTraits);
     });
@@ -1367,7 +1362,6 @@ describe('User session manager', () => {
     it('should reset the value to default value if the value is not an object', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       userSessionManager.init();
-      // @ts-expect-error - need to test this case
       userSessionManager.setGroupTraits('dummy-group-traits');
       expect(state.session.groupTraits.value).toStrictEqual(
         DEFAULT_USER_SESSION_VALUES.groupTraits,
@@ -1594,21 +1588,10 @@ describe('User session manager', () => {
       const syncValueToStorageSpy = jest.spyOn(userSessionManager, 'syncValueToStorage');
       userSessionManager.refreshSession();
 
+      // The effect from registerEffects calls syncValueToStorage with just the key
+      // refreshSession explicitly calls it with key + value when SDK is not ready
       expect(syncValueToStorageSpy).toHaveBeenCalledTimes(3);
-      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(1, 'sessionInfo', {
-        autoTrack: true,
-        timeout: 1800000,
-        expiresAt: expect.any(Number),
-        id: expect.any(Number),
-      });
-      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(2, 'sessionInfo', {
-        autoTrack: true,
-        timeout: 1800000,
-        expiresAt: expect.any(Number),
-        id: expect.any(Number),
-        sessionStart: true,
-      });
-      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(3, 'sessionInfo', {
+      expect(syncValueToStorageSpy).toHaveBeenCalledWith('sessionInfo', {
         autoTrack: true,
         timeout: 1800000,
         expiresAt: expect.any(Number),
@@ -1799,17 +1782,19 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataBeforeReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset();
@@ -1931,17 +1916,19 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataBeforeReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset({
@@ -1952,17 +1939,19 @@ describe('User session manager', () => {
         },
       });
 
-      const dataAfterReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataAfterReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       expect(dataAfterReset.userId).not.toEqual(dataBeforeReset.userId);
       expect(dataAfterReset.userTraits).not.toEqual(dataBeforeReset.userTraits);
@@ -2003,17 +1992,19 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataBeforeReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset({
@@ -2027,17 +2018,19 @@ describe('User session manager', () => {
         },
       });
 
-      const dataAfterReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataAfterReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       expect(dataAfterReset.userId).toEqual(dataBeforeReset.userId);
       expect(dataAfterReset.userTraits).toEqual(dataBeforeReset.userTraits);
@@ -2111,7 +2104,11 @@ describe('User session manager', () => {
 
       setTimeout(() => {
         expect(setServerSideCookiesSpy).toHaveBeenCalledWith(
-          [{ name: 'rl_anonymous_id', value: 'dummy_anonymousId' }],
+          {
+            anonymousId: {
+              name: 'rl_anonymous_id',
+            },
+          },
           expect.any(Function),
           expect.any(Object),
         );
@@ -2145,16 +2142,21 @@ describe('User session manager', () => {
       clientDataStoreCookie.set = jest.fn();
       const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
 
-      // Even though we are calling syncValueToStorage multiple times in quick succession, only the
-      // last value should be sent to the server
+      // The first call sends immediately, then subsequent calls within debounce window are consolidated
+      // So we expect 2 calls: first (dummy_anonymousId1) and last (dummy_anonymousId3)
       userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId1');
       userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId2');
       userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId3');
 
       setTimeout(() => {
-        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(2);
+        // Both calls should have the same structure with SessionEntryData
         expect(setServerSideCookiesSpy).toHaveBeenCalledWith(
-          [{ name: 'rl_anonymous_id', value: 'dummy_anonymousId3' }],
+          {
+            anonymousId: {
+              name: 'rl_anonymous_id',
+            },
+          },
           expect.any(Function),
           expect.any(Object),
         );
@@ -2183,11 +2185,16 @@ describe('User session manager', () => {
     const mockCallback = jest.fn();
     it('should encrypt cookie value and make request to data service', done => {
       state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+      state.session.anonymousId.value = 'sample_cookie_value_1234';
       const getEncryptedCookieDataSpy = jest.spyOn(userSessionManager, 'getEncryptedCookieData');
       const makeRequestToSetCookieSpy = jest.spyOn(userSessionManager, 'makeRequestToSetCookie');
 
       userSessionManager.setServerSideCookies(
-        [{ name: 'key1', value: 'sample_cookie_value_1234' }],
+        {
+          anonymousId: {
+            name: 'key1',
+          },
+        },
         () => {},
         mockCookieStore,
       );
@@ -2215,17 +2222,17 @@ describe('User session manager', () => {
           domain: 'dummy.dataplane.host.com',
           samesite: 'Lax',
         };
+        state.session.userId.value = {
+          prop1: 'sample property 1',
+          prop2: 12345678,
+          prop3: { city: 'Kolkata', zip: '700001' },
+        };
         userSessionManager.setServerSideCookies(
-          [
-            {
+          {
+            userId: {
               name: 'key',
-              value: {
-                prop1: 'sample property 1',
-                prop2: 12345678,
-                prop3: { city: 'Kolkata', zip: '700001' },
-              },
             },
-          ],
+          },
           mockCallback,
           mockCookieStore,
         );
@@ -2257,8 +2264,13 @@ describe('User session manager', () => {
           domain: 'dummy.dataplane.host.com',
           samesite: 'Lax',
         };
+        state.session.userId.value = { prop1: 'sample property' };
         userSessionManager.setServerSideCookies(
-          [{ name: 'key', value: { prop1: 'sample property' } }],
+          {
+            userId: {
+              name: 'key',
+            },
+          },
           (name, val) => {
             mockCookieStore.set(name, val);
           },
@@ -2290,8 +2302,13 @@ describe('User session manager', () => {
         domain: 'dummy.dataplane.host.com',
         samesite: 'Lax',
       };
+      state.session.anonymousId.value = 'sample_cookie_value_1234';
       userSessionManager.setServerSideCookies(
-        [{ name: 'key', value: 'sample_cookie_value_1234' }],
+        {
+          anonymousId: {
+            name: 'key',
+          },
+        },
         mockCallback,
         mockCookieStore,
       );
@@ -2314,8 +2331,13 @@ describe('User session manager', () => {
         domain: 'dummy.dataplane.host.com',
         samesite: 'Lax',
       };
+      state.session.anonymousId.value = 'sample_cookie_value_1234';
       userSessionManager.setServerSideCookies(
-        [{ name: 'key', value: 'sample_cookie_value_1234' }],
+        {
+          anonymousId: {
+            name: 'key',
+          },
+        },
         mockCallback,
         mockCookieStore,
       );
@@ -2341,8 +2363,13 @@ describe('User session manager', () => {
         domain: 'dummy.dataplane.host.com',
         samesite: 'Lax',
       };
+      state.session.anonymousId.value = 'sample_cookie_value_1234';
       userSessionManager.setServerSideCookies(
-        [{ name: 'key', value: 'sample_cookie_value_1234' }],
+        {
+          anonymousId: {
+            name: 'key',
+          },
+        },
         mockCallback,
         mockCookieStore,
       );
@@ -2369,12 +2396,17 @@ describe('User session manager', () => {
       });
       userSessionManager.onError = jest.fn();
 
-      const cookiesData = [
-        { name: 'cookie1', value: 'value1' },
-        { name: 'cookie2', value: { complex: 'object' } },
-      ];
+      state.session.anonymousId.value = 'value1';
 
-      userSessionManager.setServerSideCookies(cookiesData, mockCallback, mockCookieStore);
+      userSessionManager.setServerSideCookies(
+        {
+          anonymousId: {
+            name: 'cookie1',
+          },
+        },
+        mockCallback,
+        mockCookieStore,
+      );
 
       // Verify onError was called with the correct parameters
       expect(userSessionManager.onError).toHaveBeenCalledTimes(1);
@@ -2384,10 +2416,9 @@ describe('User session manager', () => {
         'Failed to set/remove cookies via server. As a fallback, the cookies will be managed client side.',
       );
 
-      // Verify fallback behavior: all cookies are processed via callback
-      expect(mockCallback).toHaveBeenCalledTimes(2);
-      expect(mockCallback).toHaveBeenNthCalledWith(1, 'cookie1', 'value1');
-      expect(mockCallback).toHaveBeenNthCalledWith(2, 'cookie2', { complex: 'object' });
+      // Verify fallback behavior: cookie is processed via callback
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+      expect(mockCallback).toHaveBeenCalledWith('cookie1', 'value1');
     });
 
     describe('getEncryptedCookieData', () => {

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1589,7 +1589,7 @@ describe('User session manager', () => {
       userSessionManager.refreshSession();
 
       // The effect from registerEffects calls syncValueToStorage with just the key
-      // refreshSession explicitly calls it with key + value when SDK is not ready
+      // refreshSession explicitly calls it with (sessionKey, sessionInfo) when SDK is not ready
       expect(syncValueToStorageSpy).toHaveBeenCalledTimes(3);
       expect(syncValueToStorageSpy).toHaveBeenCalledWith('sessionInfo', {
         autoTrack: true,

--- a/packages/analytics-js/project.json
+++ b/packages/analytics-js/project.json
@@ -57,6 +57,12 @@
         "discussion-category": "@rudderstack/analytics-js@3.25.1",
         "notesFile": "./packages/analytics-js/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/analytics-js"
+      }
     }
   }
 }

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -76,6 +76,7 @@ import type {
   CookieData,
   EncryptedCookieData,
   IUserSessionManager,
+  SessionEntryData,
   UserSessionStorageKeysType,
 } from './types';
 import { isPositiveInteger } from '../utilities/number';
@@ -88,6 +89,14 @@ class UserSessionManager implements IUserSessionManager {
   httpClient: IHttpClient;
   logger: ILogger;
   serverSideCookieDebounceFuncs: Record<UserSessionKey, number>;
+  /**
+   * Tracks whether the setting the cookies action has been queued or not
+   */
+  serverSideCookiesRequestInProgress: Record<UserSessionKey, boolean>;
+  /**
+   * Tracks the number of queued cookie set requests
+   */
+  serverSideCookieSetRequests: Record<UserSessionKey, number>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -103,6 +112,8 @@ class UserSessionManager implements IUserSessionManager {
     this.httpClient = httpClient;
     this.onError = this.onError.bind(this);
     this.serverSideCookieDebounceFuncs = {} as Record<UserSessionKey, number>;
+    this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
+    this.serverSideCookieSetRequests = {} as Record<UserSessionKey, number>;
   }
 
   /**
@@ -420,13 +431,35 @@ class UserSessionManager implements IUserSessionManager {
    * @param key       cookie name
    * @param value     encrypted cookie value
    */
-  setServerSideCookies(cookiesData: CookieData[], cb?: CallbackFunction, store?: IStore): void {
+  setServerSideCookies(
+    sessionEntries: SessionEntryData,
+    cb?: CallbackFunction,
+    store?: IStore,
+  ): void {
+    // Retrieve the cookie value from the state
+    const sessionKeys = Object.keys(sessionEntries) as UserSessionKey[];
+    const cookiesData: CookieData[] = sessionKeys.map((sessionKey: UserSessionKey) => {
+      return {
+        name: sessionEntries[sessionKey]!.name,
+        value: state.session[sessionKey]!.value as ApiObject | string,
+      };
+    });
+
+    const clearInProgressFlags = () => {
+      sessionKeys.forEach((sessionKey: UserSessionKey) => {
+        this.serverSideCookiesRequestInProgress[sessionKey] = false;
+      });
+    };
+
     try {
       // encrypt cookies values
       const encryptedCookieData = this.getEncryptedCookieData(cookiesData, store);
       if (encryptedCookieData.length > 0) {
         // make request to data service to set the cookie from server side
         this.makeRequestToSetCookie(encryptedCookieData, (res, details) => {
+          // Mark the cookie req status as done
+          clearInProgressFlags();
+
           if (details?.xhr?.status === 200) {
             cookiesData.forEach(cData => {
               const cookieValue = store?.get(cData.name);
@@ -448,8 +481,13 @@ class UserSessionManager implements IUserSessionManager {
             });
           }
         });
+      } else {
+        // Mark the cookie req status as done
+        clearInProgressFlags();
       }
     } catch (e) {
+      // Mark the cookie req status as done
+      clearInProgressFlags();
       this.onError(
         e,
         FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
@@ -466,11 +504,11 @@ class UserSessionManager implements IUserSessionManager {
   /**
    * A function to sync values in storage
    * @param sessionKey
-   * @param value
+   * @param value optional state value to sync. By default, we directly read from the state
    */
   syncValueToStorage(
     sessionKey: UserSessionKey,
-    value: Nullable<ApiObject> | Nullable<string> | undefined,
+    stateValue?: Nullable<ApiObject> | Nullable<string>,
   ) {
     const entries = state.storage.entries.value;
     const storageType = entries[sessionKey]?.type as StorageType;
@@ -479,6 +517,8 @@ class UserSessionManager implements IUserSessionManager {
         storageClientDataStoreNameMap[storageType] as string,
       );
       const key = entries[sessionKey]?.key as string;
+      // Determine the final user session entry value
+      const value = stateValue ?? state.session[sessionKey].value;
       if (value && (isString(value) || isNonEmptyObject(value))) {
         // if useServerSideCookies load option is set to true
         // set the cookie from server side
@@ -486,24 +526,50 @@ class UserSessionManager implements IUserSessionManager {
           state.serverCookies.isEnabledServerSideCookies.value &&
           storageType === COOKIE_STORAGE
         ) {
-          if (this.serverSideCookieDebounceFuncs[sessionKey]) {
-            (globalThis as typeof window).clearTimeout(
-              this.serverSideCookieDebounceFuncs[sessionKey],
+          // Mark the requests as in progress.
+          this.serverSideCookiesRequestInProgress[sessionKey] = true;
+          const setCookieFunc = () => {
+            const sessionEntries: SessionEntryData = {
+              [sessionKey]: {
+                name: key,
+              },
+            };
+            this.setServerSideCookies(
+              sessionEntries,
+              (cookieName, cookieValue) => {
+                curStore?.set(cookieName, cookieValue);
+              },
+              curStore,
             );
-          }
+          };
 
-          this.serverSideCookieDebounceFuncs[sessionKey] = (globalThis as typeof window).setTimeout(
-            () => {
-              this.setServerSideCookies(
-                [{ name: key, value }],
-                (cookieName, cookieValue) => {
-                  curStore?.set(cookieName, cookieValue);
-                },
-                curStore,
-              );
-            },
-            SERVER_SIDE_COOKIES_DEBOUNCE_TIME,
-          );
+          // When debounce is not active, set it up.
+          // Debounce behavior: Only the first and last values are sent during the debounce window.
+          // The first request is sent immediately to prevent events from missing session info.
+          // Subsequent changes within the debounce window are consolidated into a single request
+          // that sends the latest value after the debounce delay. Intermediate values are not persisted.
+          if (!this.serverSideCookieDebounceFuncs[sessionKey]) {
+            this.serverSideCookieSetRequests[sessionKey] = 0;
+
+            // For the first time, make the cookie request anyway.
+            setCookieFunc();
+
+            this.serverSideCookieDebounceFuncs[sessionKey] = (
+              globalThis as typeof window
+            ).setTimeout(() => {
+              delete this.serverSideCookieDebounceFuncs[sessionKey];
+
+              // In the debounce function, make the cookie request only when cookie requests are waiting
+              // in the queue. The first request would have been sent already.
+              if (this.serverSideCookieSetRequests[sessionKey] > 0) {
+                setCookieFunc();
+                this.serverSideCookieSetRequests[sessionKey] = 0;
+              }
+            }, SERVER_SIDE_COOKIES_DEBOUNCE_TIME);
+          } else {
+            // Increment the queued cookie set actions
+            this.serverSideCookieSetRequests[sessionKey] += 1;
+          }
         } else {
           curStore?.set(key, value);
         }
@@ -520,7 +586,7 @@ class UserSessionManager implements IUserSessionManager {
     // This will work as long as the user session entry key names are same as the state keys
     USER_SESSION_KEYS.forEach(sessionKey => {
       effect(() => {
-        this.syncValueToStorage(sessionKey, state.session[sessionKey].value);
+        this.syncValueToStorage(sessionKey);
       });
     });
   }
@@ -693,7 +759,14 @@ class UserSessionManager implements IUserSessionManager {
    * before using it for building event payloads.
    */
   refreshSession(): void {
-    let sessionInfo = this.getSessionInfo() ?? DEFAULT_USER_SESSION_VALUES.sessionInfo;
+    let initialSessionInfo = this.getSessionInfo();
+    // If cookie set request is in progress, use the state value. That should be sufficient.
+    if (initialSessionInfo === null && this.serverSideCookiesRequestInProgress['sessionInfo']) {
+      initialSessionInfo = state.session.sessionInfo.value;
+    }
+
+    let sessionInfo = initialSessionInfo ?? DEFAULT_USER_SESSION_VALUES.sessionInfo;
+
     if (sessionInfo.autoTrack || sessionInfo.manualTrack) {
       if (sessionInfo.autoTrack) {
         this.startOrRenewAutoTracking(sessionInfo);

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -557,7 +557,7 @@ class UserSessionManager implements IUserSessionManager {
             this.serverSideCookieDebounceFuncs[sessionKey] = (
               globalThis as typeof window
             ).setTimeout(() => {
-              delete this.serverSideCookieDebounceFuncs[sessionKey];x
+              delete this.serverSideCookieDebounceFuncs[sessionKey];
 
               // In the debounce function, make the cookie request only when cookie requests are waiting
               // in the queue. The first request would have been sent already.

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -504,7 +504,7 @@ class UserSessionManager implements IUserSessionManager {
   /**
    * A function to sync values in storage
    * @param sessionKey
-   * @param value optional state value to sync. By default, we directly read from the state
+   * @param stateValue optional state value to sync. By default, we directly read from the state
    */
   syncValueToStorage(
     sessionKey: UserSessionKey,
@@ -557,7 +557,7 @@ class UserSessionManager implements IUserSessionManager {
             this.serverSideCookieDebounceFuncs[sessionKey] = (
               globalThis as typeof window
             ).setTimeout(() => {
-              delete this.serverSideCookieDebounceFuncs[sessionKey];
+              delete this.serverSideCookieDebounceFuncs[sessionKey];x
 
               // In the debounce function, make the cookie request only when cookie requests are waiting
               // in the queue. The first request would have been sent already.

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -8,6 +8,7 @@ import {
 import {
   isDefinedAndNotNull,
   isDefinedNotNullAndNotEmptyString,
+  isNull,
   isNullOrUndefined,
   isString,
 } from '@rudderstack/analytics-js-common/utilities/checks';
@@ -93,10 +94,6 @@ class UserSessionManager implements IUserSessionManager {
    * Tracks whether the setting the cookies action has been queued or not
    */
   serverSideCookiesRequestInProgress: Record<UserSessionKey, boolean>;
-  /**
-   * Tracks the number of queued cookie set requests
-   */
-  serverSideCookieSetRequests: Record<UserSessionKey, number>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -113,7 +110,6 @@ class UserSessionManager implements IUserSessionManager {
     this.onError = this.onError.bind(this);
     this.serverSideCookieDebounceFuncs = {} as Record<UserSessionKey, number>;
     this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
-    this.serverSideCookieSetRequests = {} as Record<UserSessionKey, number>;
   }
 
   /**
@@ -438,11 +434,20 @@ class UserSessionManager implements IUserSessionManager {
   ): void {
     // Retrieve the cookie value from the state
     const sessionKeys = Object.keys(sessionEntries) as UserSessionKey[];
-    const cookiesData: CookieData[] = sessionKeys.map((sessionKey: UserSessionKey) => {
-      return {
-        name: sessionEntries[sessionKey]!.name,
-        value: state.session[sessionKey]!.value as ApiObject | string,
-      };
+    const getCurrentCookiesState = (): CookieData[] => {
+      return sessionKeys.map((sessionKey: UserSessionKey) => {
+        return {
+          name: sessionEntries[sessionKey]!.name,
+          value: state.session[sessionKey]!.value as ApiObject | string,
+        };
+      });
+    };
+
+    const currentCookieValues: Record<string, Nullable<any>> = {};
+    sessionKeys.forEach((sessionKey: UserSessionKey) => {
+      currentCookieValues[sessionEntries[sessionKey]!.name] = store?.get(
+        sessionEntries[sessionKey]!.name,
+      );
     });
 
     const clearInProgressFlags = () => {
@@ -453,7 +458,13 @@ class UserSessionManager implements IUserSessionManager {
 
     try {
       // encrypt cookies values
-      const encryptedCookieData = this.getEncryptedCookieData(cookiesData, store);
+      const expectedCookiesState: Record<string, Nullable<any>> = {};
+      sessionKeys.forEach((sessionKey: UserSessionKey) => {
+        expectedCookiesState[sessionEntries[sessionKey]!.name] = state.session[sessionKey]!
+          .value as ApiObject | string;
+      });
+
+      const encryptedCookieData = this.getEncryptedCookieData(getCurrentCookiesState(), store);
       if (encryptedCookieData.length > 0) {
         // make request to data service to set the cookie from server side
         this.makeRequestToSetCookie(encryptedCookieData, (res, details) => {
@@ -461,12 +472,18 @@ class UserSessionManager implements IUserSessionManager {
           clearInProgressFlags();
 
           if (details?.xhr?.status === 200) {
-            cookiesData.forEach(cData => {
-              const cookieValue = store?.get(cData.name);
-              const before = stringifyWithoutCircular(cData.value, false, []);
-              const after = stringifyWithoutCircular(cookieValue, false, []);
-              if (after !== before) {
-                this.logger.error(FAILED_SETTING_COOKIE_FROM_SERVER_ERROR(cData.name));
+            getCurrentCookiesState().forEach(cData => {
+              const originalCookieVal = currentCookieValues[cData.name];
+
+              const actualCookieVal = store?.get(cData.name);
+              if (
+                stringifyWithoutCircular(expectedCookiesState[cData.name], false, []) !==
+                stringifyWithoutCircular(store?.get(cData.name), false, [])
+              ) {
+                // Log an error only when cookie didn't exist at all and we're also unable to set it
+                if (isNull(originalCookieVal) && isNull(actualCookieVal)) {
+                  this.logger.error(FAILED_SETTING_COOKIE_FROM_SERVER_ERROR(cData.name));
+                }
                 if (cb) {
                   cb(cData.name, cData.value);
                 }
@@ -474,7 +491,7 @@ class UserSessionManager implements IUserSessionManager {
             });
           } else {
             this.logger.error(DATA_SERVER_REQUEST_FAIL_ERROR(details?.xhr?.status));
-            cookiesData.forEach(each => {
+            getCurrentCookiesState().forEach(each => {
               if (cb) {
                 cb(each.name, each.value);
               }
@@ -493,7 +510,7 @@ class UserSessionManager implements IUserSessionManager {
         FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
         FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
       );
-      cookiesData.forEach(each => {
+      getCurrentCookiesState().forEach(each => {
         if (cb) {
           cb(each.name, each.value);
         }
@@ -504,12 +521,8 @@ class UserSessionManager implements IUserSessionManager {
   /**
    * A function to sync values in storage
    * @param sessionKey
-   * @param stateValue optional state value to sync. By default, we directly read from the state
    */
-  syncValueToStorage(
-    sessionKey: UserSessionKey,
-    stateValue?: Nullable<ApiObject> | Nullable<string>,
-  ) {
+  syncValueToStorage(sessionKey: UserSessionKey) {
     const entries = state.storage.entries.value;
     const storageType = entries[sessionKey]?.type as StorageType;
     if (isStorageTypeValidForStoringData(storageType)) {
@@ -518,7 +531,7 @@ class UserSessionManager implements IUserSessionManager {
       );
       const key = entries[sessionKey]?.key as string;
       // Determine the final user session entry value
-      const value = stateValue ?? state.session[sessionKey].value;
+      const value = state.session[sessionKey].value;
       if (value && (isString(value) || isNonEmptyObject(value))) {
         // if useServerSideCookies load option is set to true
         // set the cookie from server side
@@ -528,48 +541,30 @@ class UserSessionManager implements IUserSessionManager {
         ) {
           // Mark the requests as in progress.
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
-          const setCookieFunc = () => {
-            const sessionEntries: SessionEntryData = {
-              [sessionKey]: {
-                name: key,
-              },
-            };
-            this.setServerSideCookies(
-              sessionEntries,
-              (cookieName, cookieValue) => {
-                curStore?.set(cookieName, cookieValue);
-              },
-              curStore,
+
+          if (this.serverSideCookieDebounceFuncs[sessionKey]) {
+            (globalThis as typeof window).clearTimeout(
+              this.serverSideCookieDebounceFuncs[sessionKey],
             );
-          };
-
-          // When debounce is not active, set it up.
-          // Debounce behavior: Only the first and last values are sent during the debounce window.
-          // The first request is sent immediately to prevent events from missing session info.
-          // Subsequent changes within the debounce window are consolidated into a single request
-          // that sends the latest value after the debounce delay. Intermediate values are not persisted.
-          if (!this.serverSideCookieDebounceFuncs[sessionKey]) {
-            this.serverSideCookieSetRequests[sessionKey] = 0;
-
-            // For the first time, make the cookie request anyway.
-            setCookieFunc();
-
-            this.serverSideCookieDebounceFuncs[sessionKey] = (
-              globalThis as typeof window
-            ).setTimeout(() => {
-              delete this.serverSideCookieDebounceFuncs[sessionKey];
-
-              // In the debounce function, make the cookie request only when cookie requests are waiting
-              // in the queue. The first request would have been sent already.
-              if (this.serverSideCookieSetRequests[sessionKey] > 0) {
-                setCookieFunc();
-                this.serverSideCookieSetRequests[sessionKey] = 0;
-              }
-            }, SERVER_SIDE_COOKIES_DEBOUNCE_TIME);
-          } else {
-            // Increment the queued cookie set actions
-            this.serverSideCookieSetRequests[sessionKey] += 1;
           }
+
+          this.serverSideCookieDebounceFuncs[sessionKey] = (globalThis as typeof window).setTimeout(
+            () => {
+              const sessionEntries: SessionEntryData = {
+                [sessionKey]: {
+                  name: key,
+                },
+              };
+              this.setServerSideCookies(
+                sessionEntries,
+                (cookieName, cookieValue) => {
+                  curStore?.set(cookieName, cookieValue);
+                },
+                curStore,
+              );
+            },
+            SERVER_SIDE_COOKIES_DEBOUNCE_TIME,
+          );
         } else {
           curStore?.set(key, value);
         }
@@ -760,8 +755,8 @@ class UserSessionManager implements IUserSessionManager {
    */
   refreshSession(): void {
     let initialSessionInfo = this.getSessionInfo();
-    // If cookie set request is in progress, use the state value. That should be sufficient.
-    if (initialSessionInfo === null && this.serverSideCookiesRequestInProgress['sessionInfo']) {
+    // Prefer session data from state if the cookie requests are in progress
+    if (this.serverSideCookiesRequestInProgress['sessionInfo']) {
       initialSessionInfo = state.session.sessionInfo.value;
     }
 
@@ -799,7 +794,7 @@ class UserSessionManager implements IUserSessionManager {
     if (state.lifecycle.status.value !== 'readyExecuted') {
       // Force update the storage as the 'effect' blocks are not getting triggered
       // when processing preload buffered requests
-      this.syncValueToStorage('sessionInfo', sessionInfo);
+      this.syncValueToStorage('sessionInfo');
     }
   }
 

--- a/packages/analytics-js/src/components/userSessionManager/types.ts
+++ b/packages/analytics-js/src/components/userSessionManager/types.ts
@@ -4,6 +4,7 @@ import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 import type { ApiObject } from '@rudderstack/analytics-js-common/types/ApiObject';
 import type { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
 import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
+import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
 
 export interface IUserSessionManager {
   storeManager?: IStoreManager;
@@ -32,6 +33,13 @@ export type UserSessionStorageKeysType = keyof typeof COOKIE_KEYS;
 export type CookieData = {
   name: string;
   value: ApiObject | string;
+};
+
+export type SessionEntryData = {
+  [key in UserSessionKey]?: {
+    name: string;
+    value?: string;
+  };
 };
 
 export type EncryptedCookieData = {

--- a/packages/analytics-v1.1/project.json
+++ b/packages/analytics-v1.1/project.json
@@ -64,6 +64,12 @@
         "discussion-category": "rudder-sdk-js@2.52.7",
         "notesFile": "./packages/analytics-v1.1/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/analytics-v1.1"
+      }
     }
   }
 }

--- a/packages/loading-scripts/project.json
+++ b/packages/loading-scripts/project.json
@@ -55,6 +55,12 @@
         "discussion-category": "@rudderstack/analytics-js-loading-scripts@3.2.0",
         "notesFile": "./packages/loading-scripts/CHANGELOG_LATEST.md"
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/loading-scripts"
+      }
     }
   }
 }

--- a/packages/sanity-suite/project.json
+++ b/packages/sanity-suite/project.json
@@ -47,6 +47,12 @@
         "tagPrefix": "{projectName}@",
         "trackDeps": true
       }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./scripts/make-package-json-publish-ready.sh packages/sanity-suite"
+      }
     }
   }
 }

--- a/scripts/make-package-json-publish-ready.sh
+++ b/scripts/make-package-json-publish-ready.sh
@@ -2,11 +2,22 @@
 
 # Define the base directory of your monorepo
 BASE_DIR=$(pwd)
-# Define the directory containing your packages
-PACKAGES_DIR="$BASE_DIR/packages"
+
+# If arguments are provided, use them; otherwise process all packages
+if [ $# -eq 0 ]; then
+  PACKAGES_DIR="$BASE_DIR/packages"
+  PACKAGES=$(find "$PACKAGES_DIR" -mindepth 1 -maxdepth 1 -type d)
+else
+  PACKAGES="$@"
+fi
 
 # Iterate over each package directory
-for package in "$PACKAGES_DIR"/*; do
+for package in $PACKAGES; do
+  # Convert to absolute path if relative
+  if [ "${package#/}" = "$package" ]; then
+    package="$BASE_DIR/$package"
+  fi
+
   if [ -d "$package" ]; then
     PACKAGE_JSON="$package/package.json"
     if [ -f "$PACKAGE_JSON" ]; then
@@ -18,11 +29,19 @@ for package in "$PACKAGES_DIR"/*; do
   fi
 done
 
-# Add postinstall script to the legacy SDK package.json
-legacy_sdk_package="$PACKAGES_DIR/analytics-v1.1"
-package_json="$legacy_sdk_package/package.json"
+# Add postinstall script to the legacy SDK package.json if it's being processed
+for package in $PACKAGES; do
+  # Convert to absolute path if relative
+  if [ "${package#/}" = "$package" ]; then
+    package="$BASE_DIR/$package"
+  fi
 
-echo "Adding postinstall script to $package_json..."
-jq '.scripts = (.scripts // {}) | .scripts.postinstall = "echo '\''This package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest @rudderstack/analytics-js (https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/'\''"' "$package_json" > "$legacy_sdk_package/package_cleaned.json" && mv "$legacy_sdk_package/package_cleaned.json" "$package_json"
+  # Check if this is the legacy SDK package
+  if [ "$(basename "$package")" = "analytics-v1.1" ]; then
+    package_json="$package/package.json"
+    echo "Adding postinstall script to $package_json..."
+    jq '.scripts = (.scripts // {}) | .scripts.postinstall = "echo '\''This package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest @rudderstack/analytics-js (https://www.npmjs.com/package/@rudderstack/analytics-js) package for enhanced features, security updates, and ongoing support. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/'\''"' "$package_json" > "$package/package_cleaned.json" && mv "$package/package_cleaned.json" "$package_json"
+  fi
+done
 
 echo "Cleaning completed for all packages."


### PR DESCRIPTION
## PR Description

When server-side cookies feature is enabled in the SDK, any initial events processed can potentially miss the session information data.

I've fixed the issue where we detect if the server-side cookie operation is in progress and fallback to the state data which will be always available.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4207/fix-race-condition-with-session-data-when-server-side-cookies-are-used

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved server-side cookie sync with request tracking, in‑flight flags, debounce-based batching, consolidated payloads and clearer session handling to reduce redundant writes and improve consistency.

* **Tests**
  * Updated suites to use object-shaped cookie payloads, reflect batching/debounce behavior, revised storage shapes, and expanded error/fallback coverage.

* **Chores**
  * Packaging script supports per-package selection; release workflow scoped to the analytics project; beta workflow gains an optional deploy-bypass input.

* **Style**
  * Minor formatting cleanup and a small bundle size limit increase for a core export.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->