### PR TITLE
feat: allow overloaded identify method in query string api

### DIFF
--- a/packages/analytics-js/__tests__/components/preloadBuffer/index.test.ts
+++ b/packages/analytics-js/__tests__/components/preloadBuffer/index.test.ts
@@ -51,6 +51,30 @@ describe('Preload Buffer', () => {
     ]);
   });
 
+  it('should retrieve identify event with only traits (no userId)', () => {
+    const testUrlParams = `${originalWindowLocation}?ajs_trait_email=test@example.com&ajs_trait_name=John`;
+
+    window.history.pushState({}, '', testUrlParams);
+
+    const argumentsArray: PreloadedEventCall[] = [];
+    retrieveEventsFromQueryString(argumentsArray);
+
+    expect(argumentsArray).toStrictEqual([
+      ['identify', { email: 'test@example.com', name: 'John' }],
+    ]);
+  });
+
+  it('should not add identify event when no userId or traits are present', () => {
+    const testUrlParams = `${originalWindowLocation}?ajs_event=dummyName&ajs_prop_dummy=true`;
+
+    window.history.pushState({}, '', testUrlParams);
+
+    const argumentsArray: PreloadedEventCall[] = [];
+    retrieveEventsFromQueryString(argumentsArray);
+
+    expect(argumentsArray).toStrictEqual([['track', 'dummyName', { dummy: 'true' }]]);
+  });
+
   it('should retrieve the load event if any', () => {
     const argumentsArray: PreloadedEventCall[] = [
       ['track'],

--- a/packages/analytics-js/src/components/preloadBuffer/index.ts
+++ b/packages/analytics-js/src/components/preloadBuffer/index.ts
@@ -7,6 +7,7 @@ import {
   trackArgumentsToCallOptions,
 } from '@rudderstack/analytics-js-common/utilities/eventMethodOverloads';
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
+import { isNonEmptyObject } from '@rudderstack/analytics-js-common/utilities/object';
 import { clone } from 'ramda';
 import type { PreloadedEventCall } from './types';
 import {
@@ -62,13 +63,14 @@ const retrieveEventsFromQueryString = (argumentsArray: PreloadedEventCall[] = []
     ]);
   }
 
-  // Set userId and user traits
-  if (queryObject.get(QUERY_PARAM_USER_ID_KEY)) {
-    argumentsArray.unshift([
-      'identify',
-      queryObject.get(QUERY_PARAM_USER_ID_KEY),
-      getEventDataFromQueryString(queryObject, eventArgumentToQueryParamMap.trait),
-    ]);
+  // Send identify event
+  const userId = queryObject.get(QUERY_PARAM_USER_ID_KEY);
+  const userTraits = getEventDataFromQueryString(queryObject, eventArgumentToQueryParamMap.trait);
+  if (userId || isNonEmptyObject(userTraits)) {
+    // In identify API, user ID is optional
+    const identifyApiArgs = [...(userId ? [userId] : []), userTraits];
+
+    argumentsArray.unshift(['identify', ...identifyApiArgs]);
   }
 
   // Set anonymousID


### PR DESCRIPTION
## PR Description

I've enhanced the query string API in the SDK to allow setting traits (via identify) call for anonymous users.

The identify method supports two overloads,
```
rudderanalytics.identify(userId, traits);

// Updates traits for existing user (identified or anonymous)
rudderanalytics.identify(traits);
```

Before this change, the SDK did not fire any `identify` event when the page URL was something like below,
```
https://<page_url>?ajs_trait_example_key_1=example_value_1&ajs_trait_example_key_2=example_value_2
```

Now, it does.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4239/improve-query-string-api

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
