### PR TITLE
fix: race conditions with cookies data sync

### DIFF
--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -42,7 +42,7 @@ export default [
     name: 'Core - Modern - NPM (UMD)',
     path: 'dist/npm/modern/umd/index.js',
     import: '*',
-    limit: '28 KiB',
+    limit: '28.5 KiB',
   },
   {
     name: 'Core - Modern - CDN',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -107,7 +107,7 @@ export default [
     name: 'Core (Content Script) - Modern - NPM (ESM)',
     path: 'dist/npm/modern/content-script/esm/index.mjs',
     import: '*',
-    limit: '41 KiB',
+    limit: '41.5 KiB',
   },
   {
     name: 'Core (Content Script) - Modern - NPM (CJS)',

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -886,6 +886,163 @@ describe('User session manager', () => {
     });
   });
 
+  describe('getUserSessionValue', () => {
+    it('should return value from storage when no server-side cookie request is in progress', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store's get method to return a different value than state
+      const getSpy = jest
+        .spyOn(clientDataStoreCookie, 'get')
+        .mockReturnValue('dummy-userId-from-storage');
+      state.session.userId.value = 'dummy-userId-from-state';
+
+      // Ensure no request is in progress
+      userSessionManager.serverSideCookiesRequestInProgress.userId = false;
+
+      const actualUserId = userSessionManager.getUserSessionValue<string>('userId');
+      expect(actualUserId).toBe('dummy-userId-from-storage');
+      getSpy.mockRestore();
+    });
+
+    it('should return value from state when server-side cookie request is in progress', () => {
+      const customData = {
+        rl_user_id: 'dummy-userId-from-storage',
+      };
+      setDataInCookieStorage(customData);
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Set different value in state
+      state.session.userId.value = 'dummy-userId-from-state';
+
+      // Mark request as in progress
+      userSessionManager.serverSideCookiesRequestInProgress.userId = true;
+
+      const actualUserId = userSessionManager.getUserSessionValue<string>('userId');
+      expect(actualUserId).toBe('dummy-userId-from-state');
+    });
+
+    it('should return null when value not in storage and request not in progress', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      userSessionManager.serverSideCookiesRequestInProgress.userId = false;
+
+      const actualUserId = userSessionManager.getUserSessionValue<string>('userId');
+      expect(actualUserId).toBe(null);
+    });
+
+    it('should handle complex object types from state during in-progress request', () => {
+      const storageTraits = { key1: 'storage-value' };
+      const stateTraits = { key1: 'state-value', key2: 'new-value' };
+
+      setDataInCookieStorage({ rl_trait: storageTraits });
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.userTraits.value = stateTraits;
+      userSessionManager.serverSideCookiesRequestInProgress.userTraits = true;
+
+      const actualTraits = userSessionManager.getUserSessionValue<ApiObject>('userTraits');
+      expect(actualTraits).toStrictEqual(stateTraits);
+    });
+
+    it('should handle complex object types from storage when request not in progress', () => {
+      const storageTraits = { key1: 'storage-value' };
+      const stateTraits = { key1: 'state-value', key2: 'new-value' };
+
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store's get method to return storage value
+      const getSpy = jest.spyOn(clientDataStoreCookie, 'get').mockReturnValue(storageTraits);
+      state.session.userTraits.value = stateTraits;
+      userSessionManager.serverSideCookiesRequestInProgress.userTraits = false;
+
+      const actualTraits = userSessionManager.getUserSessionValue<ApiObject>('userTraits');
+      expect(actualTraits).toStrictEqual(storageTraits);
+      getSpy.mockRestore();
+    });
+
+    it('should handle sessionInfo objects correctly during in-progress request', () => {
+      const storageSessionInfo = {
+        autoTrack: true,
+        timeout: 10 * 60 * 1000,
+        expiresAt: Date.now() + 5000,
+        id: 1111111111,
+        sessionStart: false,
+      };
+      const stateSessionInfo = {
+        autoTrack: true,
+        timeout: 10 * 60 * 1000,
+        expiresAt: Date.now() + 5000,
+        id: 2222222222,
+        sessionStart: true,
+      };
+
+      setDataInCookieStorage({ rl_session: storageSessionInfo });
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.sessionInfo.value = stateSessionInfo;
+      userSessionManager.serverSideCookiesRequestInProgress.sessionInfo = true;
+
+      const actualSessionInfo = userSessionManager.getUserSessionValue<SessionInfo>('sessionInfo');
+      expect(actualSessionInfo?.id).toBe(2222222222);
+      expect(actualSessionInfo?.sessionStart).toBe(true);
+    });
+
+    it('should default to storage value when serverSideCookiesRequestInProgress flag is undefined', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store's get method
+      const getSpy = jest
+        .spyOn(clientDataStoreCookie, 'get')
+        .mockReturnValue('dummy-userId-from-storage');
+      state.session.userId.value = 'dummy-userId-from-state';
+
+      // Don't set the flag at all
+      delete userSessionManager.serverSideCookiesRequestInProgress.userId;
+
+      const actualUserId = userSessionManager.getUserSessionValue<string>('userId');
+      // Should default to storage since flag is falsy (undefined)
+      expect(actualUserId).toBe('dummy-userId-from-storage');
+      getSpy.mockRestore();
+    });
+
+    it('should work correctly for all session keys', () => {
+      const customData = {
+        rl_user_id: 'test-user-id',
+        rl_trait: { name: 'test' },
+        rl_group_id: 'test-group-id',
+        rl_group_trait: { company: 'test-company' },
+        ajs_anonymous_id: 'test-anon-id',
+        rl_page_init_referrer: 'https://test.com',
+        rl_page_init_referring_domain: 'test.com',
+        rl_session: { id: 123456789, autoTrack: true },
+        rl_auth_token: 'test-token',
+      };
+      setDataInCookieStorage(customData);
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Test each key without in-progress flag (reads from storage during init)
+      expect(userSessionManager.getUserSessionValue('userId')).toBe('test-user-id');
+      expect(userSessionManager.getUserSessionValue('userTraits')).toStrictEqual({ name: 'test' });
+      expect(userSessionManager.getUserSessionValue('groupId')).toBe('test-group-id');
+      expect(userSessionManager.getUserSessionValue('groupTraits')).toStrictEqual({
+        company: 'test-company',
+      });
+      // anonymousId gets set to test_uuid by the mock, which is expected
+      expect(userSessionManager.getUserSessionValue('anonymousId')).toBeDefined();
+      expect(userSessionManager.getUserSessionValue('initialReferrer')).toBe('https://test.com');
+      expect(userSessionManager.getUserSessionValue('initialReferringDomain')).toBe('test.com');
+      expect(userSessionManager.getUserSessionValue('authToken')).toBe('test-token');
+    });
+  });
+
   describe('getUserId', () => {
     it('should return the persisted user ID', () => {
       const customData = {
@@ -916,6 +1073,35 @@ describe('User session manager', () => {
       userSessionManager.init();
       const actualUserId = userSessionManager.getUserId();
       expect(actualUserId).toBe(null);
+    });
+
+    it('should prefer state value when server-side cookie request is in progress', () => {
+      const customData = {
+        rl_user_id: 'storage-user-id',
+      };
+      setDataInCookieStorage(customData);
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.userId.value = 'state-user-id';
+      userSessionManager.serverSideCookiesRequestInProgress.userId = true;
+
+      const actualUserId = userSessionManager.getUserId();
+      expect(actualUserId).toBe('state-user-id');
+    });
+
+    it('should prefer storage value when no server-side cookie request is in progress', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store to return different value than state
+      const getSpy = jest.spyOn(clientDataStoreCookie, 'get').mockReturnValue('storage-user-id');
+      state.session.userId.value = 'state-user-id';
+      userSessionManager.serverSideCookiesRequestInProgress.userId = false;
+
+      const actualUserId = userSessionManager.getUserId();
+      expect(actualUserId).toBe('storage-user-id');
+      getSpy.mockRestore();
     });
   });
 
@@ -950,6 +1136,38 @@ describe('User session manager', () => {
       const actualUserTraits = userSessionManager.getUserTraits();
       expect(actualUserTraits).toStrictEqual(null);
     });
+
+    it('should prefer state value when server-side cookie request is in progress', () => {
+      const storageTraits = { key1: 'storage-value' };
+      const stateTraits = { key1: 'state-value', key2: 'new-key' };
+
+      setDataInCookieStorage({ rl_trait: storageTraits });
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.userTraits.value = stateTraits;
+      userSessionManager.serverSideCookiesRequestInProgress.userTraits = true;
+
+      const actualUserTraits = userSessionManager.getUserTraits();
+      expect(actualUserTraits).toStrictEqual(stateTraits);
+    });
+
+    it('should prefer storage value when no server-side cookie request is in progress', () => {
+      const storageTraits = { key1: 'storage-value' };
+      const stateTraits = { key1: 'state-value', key2: 'new-key' };
+
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store to return storage value
+      const getSpy = jest.spyOn(clientDataStoreCookie, 'get').mockReturnValue(storageTraits);
+      state.session.userTraits.value = stateTraits;
+      userSessionManager.serverSideCookiesRequestInProgress.userTraits = false;
+
+      const actualUserTraits = userSessionManager.getUserTraits();
+      expect(actualUserTraits).toStrictEqual(storageTraits);
+      getSpy.mockRestore();
+    });
   });
 
   describe('getGroupId', () => {
@@ -983,6 +1201,32 @@ describe('User session manager', () => {
       const actualGroupId = userSessionManager.getGroupId();
       expect(actualGroupId).toStrictEqual(null);
     });
+
+    it('should prefer state value when server-side cookie request is in progress', () => {
+      setDataInCookieStorage({ rl_group_id: 'storage-group-id' });
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.groupId.value = 'state-group-id';
+      userSessionManager.serverSideCookiesRequestInProgress.groupId = true;
+
+      const actualGroupId = userSessionManager.getGroupId();
+      expect(actualGroupId).toBe('state-group-id');
+    });
+
+    it('should prefer storage value when no server-side cookie request is in progress', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store to return storage value
+      const getSpy = jest.spyOn(clientDataStoreCookie, 'get').mockReturnValue('storage-group-id');
+      state.session.groupId.value = 'state-group-id';
+      userSessionManager.serverSideCookiesRequestInProgress.groupId = false;
+
+      const actualGroupId = userSessionManager.getGroupId();
+      expect(actualGroupId).toBe('storage-group-id');
+      getSpy.mockRestore();
+    });
   });
 
   describe('getGroupTraits', () => {
@@ -1015,6 +1259,38 @@ describe('User session manager', () => {
       userSessionManager.init();
       const actualGroupTraits = userSessionManager.getGroupTraits();
       expect(actualGroupTraits).toStrictEqual(null);
+    });
+
+    it('should prefer state value when server-side cookie request is in progress', () => {
+      const storageTraits = { company: 'storage-company' };
+      const stateTraits = { company: 'state-company', industry: 'tech' };
+
+      setDataInCookieStorage({ rl_group_trait: storageTraits });
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.groupTraits.value = stateTraits;
+      userSessionManager.serverSideCookiesRequestInProgress.groupTraits = true;
+
+      const actualGroupTraits = userSessionManager.getGroupTraits();
+      expect(actualGroupTraits).toStrictEqual(stateTraits);
+    });
+
+    it('should prefer storage value when no server-side cookie request is in progress', () => {
+      const storageTraits = { company: 'storage-company' };
+      const stateTraits = { company: 'state-company', industry: 'tech' };
+
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store to return storage value
+      const getSpy = jest.spyOn(clientDataStoreCookie, 'get').mockReturnValue(storageTraits);
+      state.session.groupTraits.value = stateTraits;
+      userSessionManager.serverSideCookiesRequestInProgress.groupTraits = false;
+
+      const actualGroupTraits = userSessionManager.getGroupTraits();
+      expect(actualGroupTraits).toStrictEqual(storageTraits);
+      getSpy.mockRestore();
     });
   });
 
@@ -1054,6 +1330,34 @@ describe('User session manager', () => {
       const actualInitialReferrer = userSessionManager.getInitialReferrer();
       expect(actualInitialReferrer).toStrictEqual(null);
     });
+
+    it('should prefer state value when server-side cookie request is in progress', () => {
+      setDataInCookieStorage({ rl_page_init_referrer: 'https://storage.com' });
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.initialReferrer.value = 'https://state.com';
+      userSessionManager.serverSideCookiesRequestInProgress.initialReferrer = true;
+
+      const actualInitialReferrer = userSessionManager.getInitialReferrer();
+      expect(actualInitialReferrer).toBe('https://state.com');
+    });
+
+    it('should prefer storage value when no server-side cookie request is in progress', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store to return storage value
+      const getSpy = jest
+        .spyOn(clientDataStoreCookie, 'get')
+        .mockReturnValue('https://storage.com');
+      state.session.initialReferrer.value = 'https://state.com';
+      userSessionManager.serverSideCookiesRequestInProgress.initialReferrer = false;
+
+      const actualInitialReferrer = userSessionManager.getInitialReferrer();
+      expect(actualInitialReferrer).toBe('https://storage.com');
+      getSpy.mockRestore();
+    });
   });
 
   describe('getInitialReferringDomain', () => {
@@ -1088,6 +1392,32 @@ describe('User session manager', () => {
       const actualInitialReferringDomain = userSessionManager.getInitialReferringDomain();
       expect(actualInitialReferringDomain).toStrictEqual(null);
     });
+
+    it('should prefer state value when server-side cookie request is in progress', () => {
+      setDataInCookieStorage({ rl_page_init_referring_domain: 'storage.com' });
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.initialReferringDomain.value = 'state.com';
+      userSessionManager.serverSideCookiesRequestInProgress.initialReferringDomain = true;
+
+      const actualInitialReferringDomain = userSessionManager.getInitialReferringDomain();
+      expect(actualInitialReferringDomain).toBe('state.com');
+    });
+
+    it('should prefer storage value when no server-side cookie request is in progress', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store to return storage value
+      const getSpy = jest.spyOn(clientDataStoreCookie, 'get').mockReturnValue('storage.com');
+      state.session.initialReferringDomain.value = 'state.com';
+      userSessionManager.serverSideCookiesRequestInProgress.initialReferringDomain = false;
+
+      const actualInitialReferringDomain = userSessionManager.getInitialReferringDomain();
+      expect(actualInitialReferringDomain).toBe('storage.com');
+      getSpy.mockRestore();
+    });
   });
 
   describe('getAuthToken', () => {
@@ -1120,6 +1450,32 @@ describe('User session manager', () => {
       userSessionManager.init();
       const actualAuthToken = userSessionManager.getAuthToken();
       expect(actualAuthToken).toStrictEqual(null);
+    });
+
+    it('should prefer state value when server-side cookie request is in progress', () => {
+      setDataInCookieStorage({ rl_auth_token: 'storage-token-123' });
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      state.session.authToken.value = 'state-token-456';
+      userSessionManager.serverSideCookiesRequestInProgress.authToken = true;
+
+      const actualAuthToken = userSessionManager.getAuthToken();
+      expect(actualAuthToken).toBe('state-token-456');
+    });
+
+    it('should prefer storage value when no server-side cookie request is in progress', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Mock the store to return storage value
+      const getSpy = jest.spyOn(clientDataStoreCookie, 'get').mockReturnValue('storage-token-123');
+      state.session.authToken.value = 'state-token-456';
+      userSessionManager.serverSideCookiesRequestInProgress.authToken = false;
+
+      const actualAuthToken = userSessionManager.getAuthToken();
+      expect(actualAuthToken).toBe('storage-token-123');
+      getSpy.mockRestore();
     });
   });
 
@@ -1598,6 +1954,106 @@ describe('User session manager', () => {
       expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(1, 'sessionInfo');
       expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(2, 'sessionInfo');
       expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(3, 'sessionInfo');
+    });
+
+    describe('Race condition with server-side cookie requests', () => {
+      it('should prefer state over storage when cookie request is in progress', () => {
+        state.storage.entries.value = entriesWithOnlyCookieStorage;
+        state.serverCookies.isEnabledServerSideCookies.value = true;
+        userSessionManager.init();
+
+        // Set up initial session in storage
+        const storageSessionInfo = {
+          autoTrack: true,
+          timeout: 10 * 60 * 1000,
+          expiresAt: Date.now() + 5000,
+          id: 1111111111,
+          sessionStart: false,
+        };
+        setDataInCookieStorage({
+          rl_session: storageSessionInfo,
+        });
+
+        // Set different session info in state (simulating a pending update)
+        const stateSessionInfo = {
+          autoTrack: true,
+          timeout: 10 * 60 * 1000,
+          expiresAt: Date.now() + 5000,
+          id: 2222222222,
+          sessionStart: true,
+        };
+        state.session.sessionInfo.value = stateSessionInfo;
+
+        // Mark cookie request as in progress
+        userSessionManager.serverSideCookiesRequestInProgress.sessionInfo = true;
+
+        // Call refreshSession
+        userSessionManager.refreshSession();
+
+        // Should use state value (2222222222) not storage value (1111111111)
+        expect(state.session.sessionInfo.value.id).toBe(2222222222);
+      });
+
+      it('should read from storage when no cookie request is in progress', () => {
+        state.storage.entries.value = entriesWithOnlyCookieStorage;
+        state.serverCookies.isEnabledServerSideCookies.value = true;
+        userSessionManager.init();
+
+        // Set up session in storage
+        const storageSessionInfo = {
+          autoTrack: true,
+          timeout: 10 * 60 * 1000,
+          expiresAt: Date.now() + 5000,
+          id: 1111111111,
+          sessionStart: false,
+        };
+        setDataInCookieStorage({
+          rl_session: storageSessionInfo,
+        });
+
+        // Set different session info in state
+        state.session.sessionInfo.value = {
+          autoTrack: true,
+          timeout: 10 * 60 * 1000,
+          expiresAt: Date.now() + 5000,
+          id: 2222222222,
+          sessionStart: true,
+        };
+
+        // Ensure no cookie request is in progress
+        userSessionManager.serverSideCookiesRequestInProgress.sessionInfo = false;
+
+        // Call refreshSession
+        userSessionManager.refreshSession();
+
+        // Should use storage value (1111111111) not state value (2222222222)
+        expect(state.session.sessionInfo.value.id).toBe(1111111111);
+      });
+
+      it('should handle undefined serverSideCookiesRequestInProgress flag', () => {
+        state.storage.entries.value = entriesWithOnlyCookieStorage;
+        state.serverCookies.isEnabledServerSideCookies.value = true;
+        userSessionManager.init();
+
+        const storageSessionInfo = {
+          autoTrack: true,
+          timeout: 10 * 60 * 1000,
+          expiresAt: Date.now() + 5000,
+          id: 1111111111,
+          sessionStart: false,
+        };
+        setDataInCookieStorage({
+          rl_session: storageSessionInfo,
+        });
+
+        // Don't set the flag at all (undefined)
+        delete userSessionManager.serverSideCookiesRequestInProgress.sessionInfo;
+
+        userSessionManager.refreshSession();
+
+        // Should default to reading from storage
+        expect(state.session.sessionInfo.value.id).toBe(1111111111);
+      });
     });
   });
 
@@ -2392,6 +2848,150 @@ describe('User session manager', () => {
       expect(mockCallback).toHaveBeenCalledTimes(2);
       expect(mockCallback).toHaveBeenNthCalledWith(1, 'cookie1', 'value1');
       expect(mockCallback).toHaveBeenNthCalledWith(2, 'cookie2', { complex: 'object' });
+    });
+
+    describe('serverSideCookiesRequestInProgress flag management', () => {
+      it('should set flag when syncValueToStorage triggers server-side cookie request', done => {
+        state.serverCookies.isEnabledServerSideCookies.value = true;
+        state.storage.entries.value = entriesWithOnlyCookieStorage;
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        state.session.anonymousId.value = 'test_anon_id';
+
+        expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBeFalsy();
+
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        // Flag should be set immediately
+        expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(true);
+
+        setTimeout(() => {
+          // Flag should be cleared after request completes
+          expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(false);
+          done();
+        }, 1000);
+      });
+
+      it('should clear flag after successful server-side cookie set', done => {
+        state.source.value = {
+          workspaceId: 'sample_workspaceId',
+          id: 'sample_source_id',
+          name: 'sample_source_name',
+        };
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        state.storage.cookie.value = {
+          maxage: 10 * 60 * 1000,
+          path: '/',
+          domain: 'dummy.dataplane.host.com',
+          samesite: 'Lax',
+        };
+        state.session.anonymousId.value = 'test_value';
+
+        const mockStore = {
+          encrypt: jest.fn(val => `encrypted_${JSON.parse(val)}`),
+          set: jest.fn(),
+          get: jest.fn(() => 'test_value'),
+        };
+
+        // Set flag as in progress
+        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = true;
+
+        userSessionManager.setServerSideCookies(
+          { anonymousId: { name: 'key' } },
+          () => {},
+          mockStore,
+        );
+
+        setTimeout(() => {
+          // Flag should be cleared after successful request
+          expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(false);
+          done();
+        }, 1000);
+      });
+
+      it('should clear flag after failed server-side cookie set', done => {
+        state.source.value = {
+          workspaceId: 'sample_workspaceId',
+          id: 'sample_source_id',
+          name: 'sample_source_name',
+        };
+        state.serverCookies.dataServiceUrl.value =
+          'https://dummy.dataplane.host.com/serverDown/rsaRequest';
+        state.storage.cookie.value = {
+          maxage: 10 * 60 * 1000,
+          path: '/',
+          domain: 'dummy.dataplane.host.com',
+          samesite: 'Lax',
+        };
+        state.session.anonymousId.value = 'test_value';
+
+        const mockStore = {
+          encrypt: jest.fn(val => `encrypted_${JSON.parse(val)}`),
+          set: jest.fn(),
+          get: jest.fn(() => null),
+        };
+
+        // Set flag as in progress
+        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = true;
+
+        userSessionManager.setServerSideCookies(
+          { anonymousId: { name: 'key' } },
+          () => {},
+          mockStore,
+        );
+
+        setTimeout(() => {
+          // Flag should be cleared even after failed request
+          expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(false);
+          done();
+        }, 1000);
+      });
+
+      it('should clear flag when no encrypted data to send', () => {
+        state.session.anonymousId.value = 'test_value';
+
+        const mockStore = {
+          encrypt: jest.fn(() => null), // No encrypted data
+          set: jest.fn(),
+          get: jest.fn(() => 'test_value'),
+        };
+
+        // Set flag as in progress
+        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = true;
+
+        userSessionManager.setServerSideCookies(
+          { anonymousId: { name: 'key' } },
+          () => {},
+          mockStore,
+        );
+
+        // Flag should be cleared immediately when no data to send
+        expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(false);
+      });
+
+      it('should clear flag when error occurs in setServerSideCookies', () => {
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        state.session.anonymousId.value = 'test_value';
+
+        const mockStore = {
+          encrypt: jest.fn(() => {
+            throw new Error('Encryption error');
+          }),
+          set: jest.fn(),
+          get: jest.fn(() => 'test_value'),
+        };
+
+        // Set flag as in progress
+        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = true;
+
+        userSessionManager.setServerSideCookies(
+          { anonymousId: { name: 'key' } },
+          () => {},
+          mockStore,
+        );
+
+        // Flag should be cleared even when error occurs
+        expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(false);
+      });
     });
 
     describe('Race condition handling', () => {

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1595,26 +1595,9 @@ describe('User session manager', () => {
       userSessionManager.refreshSession();
 
       expect(syncValueToStorageSpy).toHaveBeenCalledTimes(3);
-      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(1, 'sessionInfo', {
-        autoTrack: true,
-        timeout: 1800000,
-        expiresAt: expect.any(Number),
-        id: expect.any(Number),
-      });
-      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(2, 'sessionInfo', {
-        autoTrack: true,
-        timeout: 1800000,
-        expiresAt: expect.any(Number),
-        id: expect.any(Number),
-        sessionStart: true,
-      });
-      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(3, 'sessionInfo', {
-        autoTrack: true,
-        timeout: 1800000,
-        expiresAt: expect.any(Number),
-        id: expect.any(Number),
-        sessionStart: true,
-      });
+      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(1, 'sessionInfo');
+      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(2, 'sessionInfo');
+      expect(syncValueToStorageSpy).toHaveBeenNthCalledWith(3, 'sessionInfo');
     });
   });
 
@@ -1799,17 +1782,19 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataBeforeReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset();
@@ -1931,17 +1916,19 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataBeforeReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset({
@@ -1952,17 +1939,19 @@ describe('User session manager', () => {
         },
       });
 
-      const dataAfterReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataAfterReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       expect(dataAfterReset.userId).not.toEqual(dataBeforeReset.userId);
       expect(dataAfterReset.userTraits).not.toEqual(dataBeforeReset.userTraits);
@@ -2003,17 +1992,19 @@ describe('User session manager', () => {
       userSessionManager.setInitialReferringDomain('test_initial_referring_domain');
       userSessionManager.setAuthToken('test_auth_token');
 
-      const dataBeforeReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataBeforeReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       jest.advanceTimersByTime(1000);
       userSessionManager.reset({
@@ -2027,17 +2018,19 @@ describe('User session manager', () => {
         },
       });
 
-      const dataAfterReset = JSON.parse(JSON.stringify({
-        userId: state.session.userId.value,
-        userTraits: state.session.userTraits.value,
-        groupId: state.session.groupId.value,
-        groupTraits: state.session.groupTraits.value,
-        initialReferrer: state.session.initialReferrer.value,
-        initialReferringDomain: state.session.initialReferringDomain.value,
-        anonymousId: state.session.anonymousId.value,
-        sessionInfo: state.session.sessionInfo.value,
-        authToken: state.session.authToken.value,
-      }));
+      const dataAfterReset = JSON.parse(
+        JSON.stringify({
+          userId: state.session.userId.value,
+          userTraits: state.session.userTraits.value,
+          groupId: state.session.groupId.value,
+          groupTraits: state.session.groupTraits.value,
+          initialReferrer: state.session.initialReferrer.value,
+          initialReferringDomain: state.session.initialReferringDomain.value,
+          anonymousId: state.session.anonymousId.value,
+          sessionInfo: state.session.sessionInfo.value,
+          authToken: state.session.authToken.value,
+        }),
+      );
 
       expect(dataAfterReset.userId).toEqual(dataBeforeReset.userId);
       expect(dataAfterReset.userTraits).toEqual(dataBeforeReset.userTraits);
@@ -2093,8 +2086,9 @@ describe('User session manager', () => {
   describe('syncValueToStorage', () => {
     it('should not call setServerSideCookies method in case isEnabledServerSideCookies state option is not set', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
+      state.session.anonymousId.value = 'dummy_anonymousId';
       const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId');
+      userSessionManager.syncValueToStorage('anonymousId');
 
       jest.advanceTimersByTime(1000);
 
@@ -2105,13 +2099,14 @@ describe('User session manager', () => {
       state.serverCookies.isEnabledServerSideCookies.value = true;
       state.storage.entries.value = entriesWithOnlyCookieStorage;
       state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+      state.session.anonymousId.value = 'dummy_anonymousId';
       clientDataStoreCookie.set = jest.fn();
       const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId');
+      userSessionManager.syncValueToStorage('anonymousId');
 
       setTimeout(() => {
         expect(setServerSideCookiesSpy).toHaveBeenCalledWith(
-          [{ name: 'rl_anonymous_id', value: 'dummy_anonymousId' }],
+          { anonymousId: { name: 'rl_anonymous_id' } },
           expect.any(Function),
           expect.any(Object),
         );
@@ -2126,9 +2121,10 @@ describe('User session manager', () => {
         jest.useFakeTimers();
         state.serverCookies.isEnabledServerSideCookies.value = true;
         state.storage.entries.value = entriesWithOnlyCookieStorage;
+        state.session.anonymousId.value = cookieValue;
         userSessionManager.setServerSideCookies = jest.fn();
         clientDataStoreCookie.remove = jest.fn();
-        userSessionManager.syncValueToStorage('anonymousId', cookieValue);
+        userSessionManager.syncValueToStorage('anonymousId');
 
         jest.advanceTimersByTime(1000);
 
@@ -2147,14 +2143,17 @@ describe('User session manager', () => {
 
       // Even though we are calling syncValueToStorage multiple times in quick succession, only the
       // last value should be sent to the server
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId1');
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId2');
-      userSessionManager.syncValueToStorage('anonymousId', 'dummy_anonymousId3');
+      state.session.anonymousId.value = 'dummy_anonymousId1';
+      userSessionManager.syncValueToStorage('anonymousId');
+      state.session.anonymousId.value = 'dummy_anonymousId2';
+      userSessionManager.syncValueToStorage('anonymousId');
+      state.session.anonymousId.value = 'dummy_anonymousId3';
+      userSessionManager.syncValueToStorage('anonymousId');
 
       setTimeout(() => {
         expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
         expect(setServerSideCookiesSpy).toHaveBeenCalledWith(
-          [{ name: 'rl_anonymous_id', value: 'dummy_anonymousId3' }],
+          { anonymousId: { name: 'rl_anonymous_id' } },
           expect.any(Function),
           expect.any(Object),
         );
@@ -2183,11 +2182,12 @@ describe('User session manager', () => {
     const mockCallback = jest.fn();
     it('should encrypt cookie value and make request to data service', done => {
       state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+      state.session.anonymousId.value = 'sample_cookie_value_1234';
       const getEncryptedCookieDataSpy = jest.spyOn(userSessionManager, 'getEncryptedCookieData');
       const makeRequestToSetCookieSpy = jest.spyOn(userSessionManager, 'makeRequestToSetCookie');
 
       userSessionManager.setServerSideCookies(
-        [{ name: 'key1', value: 'sample_cookie_value_1234' }],
+        { anonymousId: { name: 'key1' } },
         () => {},
         mockCookieStore,
       );
@@ -2215,17 +2215,13 @@ describe('User session manager', () => {
           domain: 'dummy.dataplane.host.com',
           samesite: 'Lax',
         };
+        state.session.anonymousId.value = {
+          prop1: 'sample property 1',
+          prop2: 12345678,
+          prop3: { city: 'Kolkata', zip: '700001' },
+        };
         userSessionManager.setServerSideCookies(
-          [
-            {
-              name: 'key',
-              value: {
-                prop1: 'sample property 1',
-                prop2: 12345678,
-                prop3: { city: 'Kolkata', zip: '700001' },
-              },
-            },
-          ],
+          { anonymousId: { name: 'key' } },
           mockCallback,
           mockCookieStore,
         );
@@ -2257,8 +2253,11 @@ describe('User session manager', () => {
           domain: 'dummy.dataplane.host.com',
           samesite: 'Lax',
         };
+        state.session.anonymousId.value = { prop1: 'sample property' };
+        // Mock store to return null to simulate cookie not being set
+        mockCookieStore.get = jest.fn(() => null);
         userSessionManager.setServerSideCookies(
-          [{ name: 'key', value: { prop1: 'sample property' } }],
+          { anonymousId: { name: 'key' } },
           (name, val) => {
             mockCookieStore.set(name, val);
           },
@@ -2290,8 +2289,9 @@ describe('User session manager', () => {
         domain: 'dummy.dataplane.host.com',
         samesite: 'Lax',
       };
+      state.session.anonymousId.value = 'sample_cookie_value_1234';
       userSessionManager.setServerSideCookies(
-        [{ name: 'key', value: 'sample_cookie_value_1234' }],
+        { anonymousId: { name: 'key' } },
         mockCallback,
         mockCookieStore,
       );
@@ -2314,8 +2314,9 @@ describe('User session manager', () => {
         domain: 'dummy.dataplane.host.com',
         samesite: 'Lax',
       };
+      state.session.anonymousId.value = 'sample_cookie_value_1234';
       userSessionManager.setServerSideCookies(
-        [{ name: 'key', value: 'sample_cookie_value_1234' }],
+        { anonymousId: { name: 'key' } },
         mockCallback,
         mockCookieStore,
       );
@@ -2331,6 +2332,7 @@ describe('User session manager', () => {
         name: 'sample_source_name',
       };
       state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+      state.session.anonymousId.value = 'sample_cookie_value_1234';
       userSessionManager.getEncryptedCookieData = jest.fn(() => {
         throw new Error('test error');
       });
@@ -2342,7 +2344,7 @@ describe('User session manager', () => {
         samesite: 'Lax',
       };
       userSessionManager.setServerSideCookies(
-        [{ name: 'key', value: 'sample_cookie_value_1234' }],
+        { anonymousId: { name: 'key' } },
         mockCallback,
         mockCookieStore,
       );
@@ -2362,6 +2364,8 @@ describe('User session manager', () => {
         name: 'sample_source_name',
       };
       state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+      state.session.anonymousId.value = 'value1';
+      state.session.userId.value = { complex: 'object' };
 
       // Mock an error scenario in getEncryptedCookieData
       userSessionManager.getEncryptedCookieData = jest.fn(() => {
@@ -2369,12 +2373,12 @@ describe('User session manager', () => {
       });
       userSessionManager.onError = jest.fn();
 
-      const cookiesData = [
-        { name: 'cookie1', value: 'value1' },
-        { name: 'cookie2', value: { complex: 'object' } },
-      ];
+      const sessionToCookiesMap = {
+        anonymousId: { name: 'cookie1' },
+        userId: { name: 'cookie2' },
+      };
 
-      userSessionManager.setServerSideCookies(cookiesData, mockCallback, mockCookieStore);
+      userSessionManager.setServerSideCookies(sessionToCookiesMap, mockCallback, mockCookieStore);
 
       // Verify onError was called with the correct parameters
       expect(userSessionManager.onError).toHaveBeenCalledTimes(1);
@@ -2388,6 +2392,128 @@ describe('User session manager', () => {
       expect(mockCallback).toHaveBeenCalledTimes(2);
       expect(mockCallback).toHaveBeenNthCalledWith(1, 'cookie1', 'value1');
       expect(mockCallback).toHaveBeenNthCalledWith(2, 'cookie2', { complex: 'object' });
+    });
+
+    describe('Race condition handling', () => {
+      it('should not log error when another session updates cookie value concurrently', done => {
+        state.source.value = {
+          workspaceId: 'sample_workspaceId',
+          id: 'sample_source_id',
+          name: 'sample_source_name',
+        };
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        state.storage.cookie.value = {
+          maxage: 10 * 60 * 1000,
+          path: '/',
+          domain: 'dummy.dataplane.host.com',
+          samesite: 'Lax',
+        };
+        state.session.anonymousId.value = 'original_value';
+
+        // Mock store to simulate another session updating the cookie to a different value
+        const mockStore = {
+          encrypt: jest.fn(val => `encrypted_${JSON.parse(val)}`),
+          set: jest.fn(),
+          get: jest.fn(() => 'updated_by_another_session'),
+        };
+
+        userSessionManager.setServerSideCookies(
+          { anonymousId: { name: 'key' } },
+          mockCallback,
+          mockStore,
+        );
+
+        setTimeout(() => {
+          expect(mockStore.get).toHaveBeenCalledWith('key');
+          // Should not log error because cookie existed before (wasn't null)
+          expect(defaultLogger.error).not.toHaveBeenCalledWith(
+            'The server failed to set the key cookie. As a fallback, the cookies will be set client side.',
+          );
+          // Callback should be called to sync with the new value
+          expect(mockCallback).toHaveBeenCalledWith('key', 'original_value');
+          done();
+        }, 1000);
+      });
+
+      it('should log error when cookie was null before and after server-side set attempt', done => {
+        state.source.value = {
+          workspaceId: 'sample_workspaceId',
+          id: 'sample_source_id',
+          name: 'sample_source_name',
+        };
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        state.storage.cookie.value = {
+          maxage: 10 * 60 * 1000,
+          path: '/',
+          domain: 'dummy.dataplane.host.com',
+          samesite: 'Lax',
+        };
+        state.session.anonymousId.value = 'test_value';
+
+        // Mock store to return null both before and after the request
+        const mockStore = {
+          encrypt: jest.fn(val => `encrypted_${JSON.parse(val)}`),
+          set: jest.fn(),
+          get: jest.fn(() => null),
+        };
+
+        userSessionManager.setServerSideCookies(
+          { anonymousId: { name: 'key' } },
+          mockCallback,
+          mockStore,
+        );
+
+        setTimeout(() => {
+          expect(mockStore.get).toHaveBeenCalledWith('key');
+          // Should log error because cookie was null before and is still null
+          expect(defaultLogger.error).toHaveBeenCalledWith(
+            'The server failed to set the key cookie. As a fallback, the cookies will be set client side.',
+          );
+          expect(mockCallback).toHaveBeenCalledWith('key', 'test_value');
+          done();
+        }, 1000);
+      });
+
+      it('should not log error when cookie had value before but is null after (concurrent deletion)', done => {
+        state.source.value = {
+          workspaceId: 'sample_workspaceId',
+          id: 'sample_source_id',
+          name: 'sample_source_name',
+        };
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        state.storage.cookie.value = {
+          maxage: 10 * 60 * 1000,
+          path: '/',
+          domain: 'dummy.dataplane.host.com',
+          samesite: 'Lax',
+        };
+        state.session.anonymousId.value = 'test_value';
+
+        // Mock store to simulate cookie being deleted by another session
+        const mockStore = {
+          encrypt: jest.fn(val => `encrypted_${JSON.parse(val)}`),
+          set: jest.fn(),
+          get: jest
+            .fn()
+            .mockReturnValueOnce('existing_value') // Original value before request
+            .mockReturnValueOnce(null), // After request, deleted by another session
+        };
+
+        userSessionManager.setServerSideCookies(
+          { anonymousId: { name: 'key' } },
+          mockCallback,
+          mockStore,
+        );
+
+        setTimeout(() => {
+          // Should not log error because cookie existed before (wasn't null originally)
+          expect(defaultLogger.error).not.toHaveBeenCalledWith(
+            'The server failed to set the key cookie. As a fallback, the cookies will be set client side.',
+          );
+          expect(mockCallback).toHaveBeenCalledWith('key', 'test_value');
+          done();
+        }, 1000);
+      });
     });
 
     describe('getEncryptedCookieData', () => {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -436,7 +436,7 @@ class UserSessionManager implements IUserSessionManager {
       return sessionKeys.map((sessionKey: UserSessionKey) => {
         return {
           name: sessionToCookiesMap[sessionKey]!.name,
-          value: state.session[sessionKey]!.value,
+          value: state.session[sessionKey].value,
         } as CookieData;
       });
     };
@@ -453,7 +453,7 @@ class UserSessionManager implements IUserSessionManager {
       const expectedCookieValues: Record<string, CookieValue | undefined | null> = {};
       sessionKeys.forEach((sessionKey: UserSessionKey) => {
         expectedCookieValues[sessionToCookiesMap[sessionKey]!.name] =
-          state.session[sessionKey]!.value;
+          state.session[sessionKey].value;
       });
 
       // encrypt cookies values

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -514,7 +514,6 @@ class UserSessionManager implements IUserSessionManager {
   /**
    * A function to sync values in storage
    * @param sessionKey
-   * @param value
    */
   syncValueToStorage(sessionKey: UserSessionKey) {
     const entries = state.storage.entries.value;

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -8,6 +8,7 @@ import {
 import {
   isDefinedAndNotNull,
   isDefinedNotNullAndNotEmptyString,
+  isNull,
   isNullOrUndefined,
   isString,
 } from '@rudderstack/analytics-js-common/utilities/checks';
@@ -74,8 +75,10 @@ import { DEFAULT_USER_SESSION_VALUES, SERVER_SIDE_COOKIES_DEBOUNCE_TIME } from '
 import type {
   CallbackFunction,
   CookieData,
+  CookieValue,
   EncryptedCookieData,
   IUserSessionManager,
+  SessionToCookiesMap,
   UserSessionStorageKeysType,
 } from './types';
 import { isPositiveInteger } from '../utilities/number';
@@ -417,23 +420,68 @@ class UserSessionManager implements IUserSessionManager {
 
   /**
    * A function to make an external request to set the cookie from server side
-   * @param key       cookie name
-   * @param value     encrypted cookie value
+   * @param sessionToCookiesMap map of session key to cookie name
+   * @param cb callback function to be called when the cookie is set
+   * @param store store to be used to get the cookie value
    */
-  setServerSideCookies(cookiesData: CookieData[], cb?: CallbackFunction, store?: IStore): void {
+  setServerSideCookies(
+    sessionToCookiesMap: SessionToCookiesMap,
+    cb?: CallbackFunction,
+    store?: IStore,
+  ): void {
+    // Retrieve the cookie value from the state
+    const sessionKeys = Object.keys(sessionToCookiesMap) as UserSessionKey[];
+
+    const getCurrentCookieValuesFromState = (): CookieData[] => {
+      return sessionKeys.map((sessionKey: UserSessionKey) => {
+        return {
+          name: sessionToCookiesMap[sessionKey]!.name,
+          value: state.session[sessionKey]!.value,
+        } as CookieData;
+      });
+    };
+
+    // Preserve the current cookie values
+    const originalCookieValues: Record<string, Nullable<CookieValue | undefined>> = {};
+    sessionKeys.forEach((sessionKey: UserSessionKey) => {
+      originalCookieValues[sessionToCookiesMap[sessionKey]!.name] = store?.get(
+        sessionToCookiesMap[sessionKey]!.name,
+      );
+    });
+
     try {
+      const expectedCookieValues: Record<string, CookieValue | undefined | null> = {};
+      sessionKeys.forEach((sessionKey: UserSessionKey) => {
+        expectedCookieValues[sessionToCookiesMap[sessionKey]!.name] =
+          state.session[sessionKey]!.value;
+      });
+
       // encrypt cookies values
-      const encryptedCookieData = this.getEncryptedCookieData(cookiesData, store);
+      const encryptedCookieData = this.getEncryptedCookieData(
+        getCurrentCookieValuesFromState(),
+        store,
+      );
+
       if (encryptedCookieData.length > 0) {
         // make request to data service to set the cookie from server side
         this.makeRequestToSetCookie(encryptedCookieData, (res, details) => {
           if (details?.xhr?.status === 200) {
-            cookiesData.forEach(cData => {
-              const cookieValue = store?.get(cData.name);
-              const before = stringifyWithoutCircular(cData.value, false, []);
-              const after = stringifyWithoutCircular(cookieValue, false, []);
-              if (after !== before) {
-                this.logger.error(FAILED_SETTING_COOKIE_FROM_SERVER_ERROR(cData.name));
+            getCurrentCookieValuesFromState().forEach(cData => {
+              const originalCookieVal = originalCookieValues[cData.name];
+              const currentCookieVal = store?.get(cData.name);
+
+              // Check if the expected cookie values are set.
+              if (
+                stringifyWithoutCircular(expectedCookieValues[cData.name], false, []) !==
+                stringifyWithoutCircular(currentCookieVal, false, [])
+              ) {
+                // It's fine if the values don't match as other active SDK sessions might have updated the cookie values
+                // or other cookie requests might have updated the cookie value.
+
+                // Log an error only when cookie didn't exist previously and currently also doesn't exist.
+                if (isNull(originalCookieVal) && isNull(currentCookieVal)) {
+                  this.logger.error(FAILED_SETTING_COOKIE_FROM_SERVER_ERROR(cData.name));
+                }
                 if (cb) {
                   cb(cData.name, cData.value);
                 }
@@ -441,7 +489,7 @@ class UserSessionManager implements IUserSessionManager {
             });
           } else {
             this.logger.error(DATA_SERVER_REQUEST_FAIL_ERROR(details?.xhr?.status));
-            cookiesData.forEach(each => {
+            getCurrentCookieValuesFromState().forEach(each => {
               if (cb) {
                 cb(each.name, each.value);
               }
@@ -455,7 +503,7 @@ class UserSessionManager implements IUserSessionManager {
         FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
         FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
       );
-      cookiesData.forEach(each => {
+      getCurrentCookieValuesFromState().forEach(each => {
         if (cb) {
           cb(each.name, each.value);
         }
@@ -468,18 +516,16 @@ class UserSessionManager implements IUserSessionManager {
    * @param sessionKey
    * @param value
    */
-  syncValueToStorage(
-    sessionKey: UserSessionKey,
-    value: Nullable<ApiObject> | Nullable<string> | undefined,
-  ) {
+  syncValueToStorage(sessionKey: UserSessionKey) {
     const entries = state.storage.entries.value;
     const storageType = entries[sessionKey]?.type as StorageType;
     if (isStorageTypeValidForStoringData(storageType)) {
-      const curStore = this.storeManager?.getStore(
+      const curStore = this.storeManager.getStore(
         storageClientDataStoreNameMap[storageType] as string,
       );
-      const key = entries[sessionKey]?.key as string;
-      if (value && (isString(value) || isNonEmptyObject(value))) {
+      const cookieName = entries[sessionKey]?.key as string;
+      const cookieValue = state.session[sessionKey].value;
+      if (cookieValue && (isString(cookieValue) || isNonEmptyObject(cookieValue))) {
         // if useServerSideCookies load option is set to true
         // set the cookie from server side
         if (
@@ -494,8 +540,15 @@ class UserSessionManager implements IUserSessionManager {
 
           this.serverSideCookieDebounceFuncs[sessionKey] = (globalThis as typeof window).setTimeout(
             () => {
+              // Create a map of session key to cookie name
+              const sessionToCookiesMap: SessionToCookiesMap = {
+                [sessionKey]: {
+                  name: cookieName,
+                },
+              };
+
               this.setServerSideCookies(
-                [{ name: key, value }],
+                sessionToCookiesMap,
                 (cookieName, cookieValue) => {
                   curStore?.set(cookieName, cookieValue);
                 },
@@ -505,10 +558,10 @@ class UserSessionManager implements IUserSessionManager {
             SERVER_SIDE_COOKIES_DEBOUNCE_TIME,
           );
         } else {
-          curStore?.set(key, value);
+          curStore?.set(cookieName, cookieValue);
         }
       } else {
-        curStore?.remove(key);
+        curStore?.remove(cookieName);
       }
     }
   }
@@ -520,7 +573,7 @@ class UserSessionManager implements IUserSessionManager {
     // This will work as long as the user session entry key names are same as the state keys
     USER_SESSION_KEYS.forEach(sessionKey => {
       effect(() => {
-        this.syncValueToStorage(sessionKey, state.session[sessionKey].value);
+        this.syncValueToStorage(sessionKey);
       });
     });
   }
@@ -726,7 +779,7 @@ class UserSessionManager implements IUserSessionManager {
     if (state.lifecycle.status.value !== 'readyExecuted') {
       // Force update the storage as the 'effect' blocks are not getting triggered
       // when processing preload buffered requests
-      this.syncValueToStorage('sessionInfo', sessionInfo);
+      this.syncValueToStorage('sessionInfo');
     }
   }
 

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -91,6 +91,10 @@ class UserSessionManager implements IUserSessionManager {
   httpClient: IHttpClient;
   logger: ILogger;
   serverSideCookieDebounceFuncs: Record<UserSessionKey, number>;
+  /**
+   * Tracks whether a server-side cookie setting request is in progress or not.
+   */
+  serverSideCookiesRequestInProgress: Record<UserSessionKey, boolean>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -106,6 +110,7 @@ class UserSessionManager implements IUserSessionManager {
     this.httpClient = httpClient;
     this.onError = this.onError.bind(this);
     this.serverSideCookieDebounceFuncs = {} as Record<UserSessionKey, number>;
+    this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
   }
 
   /**
@@ -449,6 +454,20 @@ class UserSessionManager implements IUserSessionManager {
       );
     });
 
+    const clearInProgressFlags = () => {
+      sessionKeys.forEach((sessionKey: UserSessionKey) => {
+        this.serverSideCookiesRequestInProgress[sessionKey] = false;
+      });
+    };
+
+    const setCookiesClientSide = () => {
+      getCurrentCookieValuesFromState().forEach(each => {
+        if (cb) {
+          cb(each.name, each.value);
+        }
+      });
+    };
+
     try {
       const expectedCookieValues: Record<string, CookieValue | undefined | null> = {};
       sessionKeys.forEach((sessionKey: UserSessionKey) => {
@@ -465,6 +484,9 @@ class UserSessionManager implements IUserSessionManager {
       if (encryptedCookieData.length > 0) {
         // make request to data service to set the cookie from server side
         this.makeRequestToSetCookie(encryptedCookieData, (res, details) => {
+          // Mark the cookie req status as done
+          clearInProgressFlags();
+
           if (details?.xhr?.status === 200) {
             getCurrentCookieValuesFromState().forEach(cData => {
               const originalCookieVal = originalCookieValues[cData.name];
@@ -489,13 +511,14 @@ class UserSessionManager implements IUserSessionManager {
             });
           } else {
             this.logger.error(DATA_SERVER_REQUEST_FAIL_ERROR(details?.xhr?.status));
-            getCurrentCookieValuesFromState().forEach(each => {
-              if (cb) {
-                cb(each.name, each.value);
-              }
-            });
+            setCookiesClientSide();
           }
         });
+      } else {
+        setCookiesClientSide();
+
+        // Mark the cookie req status as done
+        clearInProgressFlags();
       }
     } catch (e) {
       this.onError(
@@ -503,11 +526,10 @@ class UserSessionManager implements IUserSessionManager {
         FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
         FAILED_SETTING_COOKIE_FROM_SERVER_GLOBAL_ERROR,
       );
-      getCurrentCookieValuesFromState().forEach(each => {
-        if (cb) {
-          cb(each.name, each.value);
-        }
-      });
+      setCookiesClientSide();
+
+      // Mark the cookie req status as done
+      clearInProgressFlags();
     }
   }
 
@@ -531,6 +553,9 @@ class UserSessionManager implements IUserSessionManager {
           state.serverCookies.isEnabledServerSideCookies.value &&
           storageType === COOKIE_STORAGE
         ) {
+          // Mark the requests as in progress.
+          this.serverSideCookiesRequestInProgress[sessionKey] = true;
+
           if (this.serverSideCookieDebounceFuncs[sessionKey]) {
             (globalThis as typeof window).clearTimeout(
               this.serverSideCookieDebounceFuncs[sessionKey],
@@ -665,11 +690,27 @@ class UserSessionManager implements IUserSessionManager {
   }
 
   /**
+   * Fetches the value for a session key. Preferably from storage, if the server-side
+   * cookies request is not in progress. Otherwise, from the state.
+   * @param sessionKey - The session key to fetch the value for
+   * @returns - The value for the session key
+   */
+  getUserSessionValue<T>(sessionKey: UserSessionKey): Nullable<T> {
+    // If the server-side cookies request is in progress, fetch the value from the state.
+    if (this.serverSideCookiesRequestInProgress[sessionKey]) {
+      return state.session[sessionKey].value as Nullable<T>;
+    }
+
+    // Otherwise, fetch the value from storage.
+    return this.getEntryValue(sessionKey);
+  }
+
+  /**
    * Fetches User Id
    * @returns
    */
   getUserId(): Nullable<string> {
-    return this.getEntryValue('userId');
+    return this.getUserSessionValue<string>('userId');
   }
 
   /**
@@ -677,7 +718,7 @@ class UserSessionManager implements IUserSessionManager {
    * @returns
    */
   getUserTraits(): Nullable<ApiObject> {
-    return this.getEntryValue('userTraits');
+    return this.getUserSessionValue<ApiObject>('userTraits');
   }
 
   /**
@@ -685,7 +726,7 @@ class UserSessionManager implements IUserSessionManager {
    * @returns
    */
   getGroupId(): Nullable<string> {
-    return this.getEntryValue('groupId');
+    return this.getUserSessionValue<string>('groupId');
   }
 
   /**
@@ -693,7 +734,7 @@ class UserSessionManager implements IUserSessionManager {
    * @returns
    */
   getGroupTraits(): Nullable<ApiObject> {
-    return this.getEntryValue('groupTraits');
+    return this.getUserSessionValue<ApiObject>('groupTraits');
   }
 
   /**
@@ -701,7 +742,7 @@ class UserSessionManager implements IUserSessionManager {
    * @returns
    */
   getInitialReferrer(): Nullable<string> {
-    return this.getEntryValue('initialReferrer');
+    return this.getUserSessionValue<string>('initialReferrer');
   }
 
   /**
@@ -709,7 +750,7 @@ class UserSessionManager implements IUserSessionManager {
    * @returns
    */
   getInitialReferringDomain(): Nullable<string> {
-    return this.getEntryValue('initialReferringDomain');
+    return this.getUserSessionValue<string>('initialReferringDomain');
   }
 
   /**
@@ -717,7 +758,7 @@ class UserSessionManager implements IUserSessionManager {
    * @returns
    */
   getSessionInfo(): Nullable<SessionInfo> {
-    return this.getEntryValue('sessionInfo');
+    return this.getUserSessionValue<SessionInfo>('sessionInfo');
   }
 
   /**
@@ -725,7 +766,7 @@ class UserSessionManager implements IUserSessionManager {
    * @returns
    */
   getAuthToken(): Nullable<string> {
-    return this.getEntryValue('authToken');
+    return this.getUserSessionValue<string>('authToken');
   }
 
   /**
@@ -746,6 +787,7 @@ class UserSessionManager implements IUserSessionManager {
    */
   refreshSession(): void {
     let sessionInfo = this.getSessionInfo() ?? DEFAULT_USER_SESSION_VALUES.sessionInfo;
+
     if (sessionInfo.autoTrack || sessionInfo.manualTrack) {
       if (sessionInfo.autoTrack) {
         this.startOrRenewAutoTracking(sessionInfo);

--- a/packages/analytics-js/src/components/userSessionManager/types.ts
+++ b/packages/analytics-js/src/components/userSessionManager/types.ts
@@ -4,6 +4,8 @@ import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 import type { ApiObject } from '@rudderstack/analytics-js-common/types/ApiObject';
 import type { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
 import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
+import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
+import type { SessionInfo } from '@rudderstack/analytics-js-common/types/Session';
 
 export interface IUserSessionManager {
   storeManager?: IStoreManager;
@@ -29,9 +31,17 @@ export interface IUserSessionManager {
 
 export type UserSessionStorageKeysType = keyof typeof COOKIE_KEYS;
 
+export type CookieValue = ApiObject | string | SessionInfo;
+
 export type CookieData = {
   name: string;
-  value: ApiObject | string;
+  value: CookieValue;
+};
+
+export type SessionToCookiesMap = {
+  [key in UserSessionKey]?: {
+    name: string;
+  };
 };
 
 export type EncryptedCookieData = {


### PR DESCRIPTION
## PR Description

Fixes race conditions in server-side cookie synchronization and eliminates false-positive console errors when multiple SDK sessions update cookies concurrently.

## Problem

**Race Condition**: `syncValueToStorage` captured values when the debounce timer started, not when the network request executed. Rapid successive calls could send stale data to the server.

**Noisy Errors**: Console logged errors whenever cookie values didn't match expectations, even when other active SDK sessions legitimately updated them.

## Solution

### 1. Read State at Request Time
- `syncValueToStorage` signature changed: `syncValueToStorage(key, value)` → `syncValueToStorage(key)`
- Now reads from state **when the network request executes**, ensuring latest value is always sent

### 2. Smart Error Detection
- Track the "before" cookie value when starting a server-side set operation
- Only log errors when cookie was `null` before **AND** remains `null` after (true failure)
- Silent when:
  - Another session updated the cookie to a different value (legitimate)
  - Concurrent deletion occurred (another session cleared it)

### 3. Fallback with Current State
- When mismatch detected, callback receives **current state value** (not stale request value)
- Ensures eventual consistency across concurrent sessions

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4207/fix-race-condition-with-session-data-when-server-side-cookies-are-used

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for session reads, race conditions, and server-side cookie synchronization across many session keys.

* **Refactor**
  * Updated session cookie and storage-sync APIs to a map-based flow and single-argument sync calls (impacts integration/signature usage).
  * Added helpers to prefer in-memory state during in-flight server cookie requests.

* **Chores**
  * Increased public size-limit thresholds for analytics bundle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->