### PR TITLE
feat: enable error grouping for npm installations too

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
+#!/bin/sh
 npm run commit-msg

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 npm run pre-commit

--- a/package-lock.json
+++ b/package-lock.json
@@ -23485,7 +23485,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sass-lookup": {

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -30,7 +30,7 @@ export default [
     name: 'Core - Modern - NPM (ESM)',
     path: 'dist/npm/modern/esm/index.mjs',
     import: '*',
-    limit: '28 KiB',
+    limit: '28.5 KiB',
   },
   {
     name: 'Core - Modern - NPM (CJS)',

--- a/packages/analytics-js/__tests__/services/ErrorHandler/ErrorHandler.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/ErrorHandler.test.ts
@@ -336,35 +336,6 @@ describe('ErrorHandler', () => {
         'Test:: Sample custom message - dummy error',
       );
     });
-
-    it('should not generate grouping hash for non-CDN installations', async () => {
-      // @ts-expect-error for testing
-      state.context.app.value.installType = 'npm';
-      state.reporting.isErrorReportingEnabled.value = true;
-
-      const getBugsnagErrorEventSpy = jest.spyOn(
-        require('../../../src/services/ErrorHandler/utils'),
-        'getBugsnagErrorEvent',
-      );
-
-      const error = new Error('dummy error');
-      error.stack =
-        'Error: Test:: dummy error\n    at Object.<anonymous> (https://cdn.rudderlabs.com/v3/modern/rsa.min.js:1:1)';
-
-      await errorHandlerInstance.onError({
-        error,
-        context: 'Test',
-        customMessage: 'Sample custom message',
-      });
-
-      expect(getBugsnagErrorEventSpy).toHaveBeenCalledTimes(1);
-      expect(getBugsnagErrorEventSpy).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      );
-    });
   });
 
   describe('CSP violation errors handling', () => {

--- a/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
@@ -1418,43 +1418,8 @@ describe('Error Reporting utilities', () => {
   });
 
   describe('getErrorGroupingHash', () => {
-    const getState = (installType = 'cdn') =>
-      ({
-        context: {
-          app: { value: { installType } },
-        },
-      }) as any;
-
-    it('should return undefined if installType is not cdn', () => {
-      const result = getErrorGroupingHash(
-        'some-hash',
-        'default-hash',
-        getState('npm'),
-        defaultLogger,
-      );
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined if installType is not cdn (testing with different install types)', () => {
-      const installTypes = ['npm', 'module', 'bower'];
-      installTypes.forEach(installType => {
-        const result = getErrorGroupingHash(
-          'some-hash',
-          'default-hash',
-          getState(installType),
-          defaultLogger,
-        );
-        expect(result).toBeUndefined();
-      });
-    });
-
     it('should return groupingHash if it is a non-empty string', () => {
-      const result = getErrorGroupingHash(
-        'some-hash',
-        'default-hash',
-        getState('cdn'),
-        defaultLogger,
-      );
+      const result = getErrorGroupingHash('some-hash', 'default-hash', defaultLogger);
       expect(result).toBe('some-hash');
     });
 
@@ -1463,35 +1428,25 @@ describe('Error Reporting utilities', () => {
       const testStrings = ['custom-error-hash', 'not an error object', 'any string value'];
 
       testStrings.forEach(testString => {
-        const result = getErrorGroupingHash(
-          testString,
-          'default-hash',
-          getState('cdn'),
-          defaultLogger,
-        );
+        const result = getErrorGroupingHash(testString, 'default-hash', defaultLogger);
         expect(result).toBe(testString);
       });
     });
 
     it('should return defaultGroupingHash if groupingHash is undefined', () => {
-      const result = getErrorGroupingHash(
-        undefined,
-        'default-hash',
-        getState('cdn'),
-        defaultLogger,
-      );
+      const result = getErrorGroupingHash(undefined, 'default-hash', defaultLogger);
       expect(result).toBe('default-hash');
     });
 
     it('should return error.message if groupingHash is an Error object', () => {
       const error = new Error('error-message');
-      const result = getErrorGroupingHash(error, 'default-hash', getState('cdn'), defaultLogger);
+      const result = getErrorGroupingHash(error, 'default-hash', defaultLogger);
       expect(result).toBe('error-message');
     });
 
     it('should return defaultGroupingHash if groupingHash is an object that is not an Error', () => {
       const notError = { foo: 'bar' };
-      const result = getErrorGroupingHash(notError, 'default-hash', getState('cdn'), defaultLogger);
+      const result = getErrorGroupingHash(notError, 'default-hash', defaultLogger);
       expect(result).toBe('default-hash');
     });
 
@@ -1499,18 +1454,13 @@ describe('Error Reporting utilities', () => {
       // Test case where normalizeError function returns undefined (when the error is not valid)
       // Non-string inputs that are not valid Error objects should cause normalizeError to return undefined
       const invalidError = { not: 'an error object' };
-      const result = getErrorGroupingHash(
-        invalidError,
-        'default-hash',
-        getState('cdn'),
-        defaultLogger,
-      );
+      const result = getErrorGroupingHash(invalidError, 'default-hash', defaultLogger);
       expect(result).toBe('default-hash');
     });
 
     it('should return defaultGroupingHash when normalizeError returns undefined for null values', () => {
       // Test case for null input
-      const result = getErrorGroupingHash(null, 'default-hash', getState('cdn'), defaultLogger);
+      const result = getErrorGroupingHash(null, 'default-hash', defaultLogger);
       expect(result).toBe('default-hash');
     });
 
@@ -1519,12 +1469,7 @@ describe('Error Reporting utilities', () => {
       const nonErrorTypes = [123, true, [], {}, Symbol('test')];
 
       nonErrorTypes.forEach(invalidType => {
-        const result = getErrorGroupingHash(
-          invalidType,
-          'default-hash',
-          getState('cdn'),
-          defaultLogger,
-        );
+        const result = getErrorGroupingHash(invalidType, 'default-hash', defaultLogger);
         expect(result).toBe('default-hash');
       });
     });
@@ -1534,35 +1479,14 @@ describe('Error Reporting utilities', () => {
       const errorWithoutStack = new Error('error without stack');
       errorWithoutStack.stack = undefined;
 
-      const result = getErrorGroupingHash(
-        errorWithoutStack,
-        'default-hash',
-        getState('cdn'),
-        defaultLogger,
-      );
+      const result = getErrorGroupingHash(errorWithoutStack, 'default-hash', defaultLogger);
       // This should return default hash since normalizeError will return undefined for errors without stack
       expect(result).toBe('default-hash');
     });
 
-    it('should handle edge case with empty string vs undefined for non-CDN installs', () => {
-      // Test to ensure that even for non-CDN installs, function returns undefined consistently
-      const result1 = getErrorGroupingHash(
-        undefined,
-        'default-hash',
-        getState('npm'),
-        defaultLogger,
-      );
-      const result2 = getErrorGroupingHash('', 'default-hash', getState('npm'), defaultLogger);
-      const result3 = getErrorGroupingHash(
-        'some-hash',
-        'default-hash',
-        getState('npm'),
-        defaultLogger,
-      );
-
-      expect(result1).toBeUndefined();
-      expect(result2).toBeUndefined();
-      expect(result3).toBeUndefined();
+    it('should return empty string when groupingHash is an empty string', () => {
+      const result = getErrorGroupingHash('', 'default-hash', defaultLogger);
+      expect(result).toBe('');
     });
   });
 

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -144,16 +144,15 @@ class ErrorHandler implements IErrorHandler {
             severityReason: { type: errorType },
           };
 
-          // Set grouping hash only for CDN installations (as an experiment)
           // This will allow us to group errors by the message instead of the surrounding code.
-          // In case of NPM installations, the default grouping by surrounding code does not make sense as each user application is different.
+          // In case of NPM installations, the default grouping by surrounding code
+          // does not make sense as each user application is different. This will create a lot of noise in the alerts.
           // References:
           // https://docs.bugsnag.com/platforms/javascript/customizing-error-reports/#groupinghash
           // https://docs.bugsnag.com/product/error-grouping/#user_defined
           const normalizedGroupingHash = getErrorGroupingHash(
             groupingHash,
             bsException.message,
-            state,
             this.logger,
           );
 

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorHandler.ts
@@ -144,9 +144,9 @@ class ErrorHandler implements IErrorHandler {
             severityReason: { type: errorType },
           };
 
-          // This will allow us to group errors by the message instead of the surrounding code.
+          // This will allow custom grouping of errors.
           // In case of NPM installations, the default grouping by surrounding code
-          // does not make sense as each user application is different. This will create a lot of noise in the alerts.
+          // does not make sense as each user application is different and will create a lot of noise in the alerts.
           // References:
           // https://docs.bugsnag.com/platforms/javascript/customizing-error-reports/#groupinghash
           // https://docs.bugsnag.com/product/error-grouping/#user_defined

--- a/packages/analytics-js/src/services/ErrorHandler/utils.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/utils.ts
@@ -279,13 +279,11 @@ const getErrorDeliveryPayload = (
 
 /**
  * A function to get the grouping hash value to be used for the error event.
- * Grouping hash is suppressed for non-cdn installs.
  * If the grouping hash is an error instance, the normalized error message is used as the grouping hash.
  * If the grouping hash is an empty string or not specified, the default grouping hash is used.
  * If the grouping hash is a string, it is used as is.
  * @param curErrGroupingHash The grouping hash value part of the error event
  * @param defaultGroupingHash The default grouping hash value. It is the error message.
- * @param state The application state
  * @param logger The logger instance
  * @returns The final grouping hash value to be used for the error event
  */

--- a/packages/analytics-js/src/services/ErrorHandler/utils.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/utils.ts
@@ -292,13 +292,9 @@ const getErrorDeliveryPayload = (
 const getErrorGroupingHash = (
   curErrGroupingHash: undefined | string | SDKError,
   defaultGroupingHash: string,
-  state: ApplicationState,
   logger: ILogger,
 ) => {
   let normalizedGroupingHash: string | undefined;
-  if (state.context.app.value.installType !== 'cdn') {
-    return normalizedGroupingHash;
-  }
 
   if (!isDefined(curErrGroupingHash)) {
     normalizedGroupingHash = defaultGroupingHash;


### PR DESCRIPTION
## PR Description

Enabled error grouping for NPM installations too.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4347/enable-custom-error-grouping-for-the-npm-package

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package size configuration for analytics library.
  * Added development hook scripts for improved source control workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->