### PR TITLE
chore: fix job url in slack notifications

### DIFF
--- a/.github/actions/get-job-url/action.yml
+++ b/.github/actions/get-job-url/action.yml
@@ -22,5 +22,6 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
       run: |
         jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs)
+        echo $jobs
         job_url=$(echo "$jobs" | jq -r '.jobs[] | select(.name=="${{ github.job }}") | .html_url')
         echo "job_url=$job_url" >> $GITHUB_OUTPUT

--- a/.github/actions/get-job-url/action.yml
+++ b/.github/actions/get-job-url/action.yml
@@ -22,6 +22,5 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
       run: |
         jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs)
-        echo $jobs
-        job_url=$(echo "$jobs" | jq -r '.jobs[] | select(.name=="${{ github.job }}") | .html_url')
+        job_url=$(echo "$jobs" | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .html_url')
         echo "job_url=$job_url" >> $GITHUB_OUTPUT

--- a/.github/actions/get-job-url/action.yml
+++ b/.github/actions/get-job-url/action.yml
@@ -23,4 +23,8 @@ runs:
       run: |
         jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs)
         job_url=$(echo "$jobs" | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .html_url')
+        job_url=${job_url:-""}
+        if [ "$job_url" = "null" ]; then
+          job_url=${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+        fi
         echo "job_url=$job_url" >> $GITHUB_OUTPUT

--- a/.github/actions/get-job-url/action.yml
+++ b/.github/actions/get-job-url/action.yml
@@ -23,8 +23,7 @@ runs:
       run: |
         jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs)
         job_url=$(echo "$jobs" | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .html_url')
-        job_url=${job_url:-""}
-        if [ "$job_url" = "null" ]; then
+        if [ -z "$job_url" ] || [ "$job_url" = "null" ]; then
           job_url=${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
         fi
         echo "job_url=$job_url" >> $GITHUB_OUTPUT

--- a/.github/actions/get-job-url/action.yml
+++ b/.github/actions/get-job-url/action.yml
@@ -1,0 +1,26 @@
+name: 'Get Job URL'
+description: 'Fetches the direct URL to the current GitHub Actions job'
+
+inputs:
+  github_token:
+    description: 'GitHub token for API access'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  job_url:
+    description: 'Direct URL to the current job in GitHub Actions UI'
+    value: ${{ steps.get-job-url.outputs.job_url }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get Job URL
+      id: get-job-url
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs)
+        job_url=$(echo "$jobs" | jq -r '.jobs[] | select(.name=="${{ github.job }}") | .html_url')
+        echo "job_url=$job_url" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -214,6 +214,11 @@ jobs:
         run: |
           npm deprecate rudder-sdk-js "This package is deprecated and no longer maintained. While your events are still being tracked and delivered, we strongly recommend you to migrate to the latest package, @rudderstack/analytics-js (https://www.npmjs.com/package/@rudderstack/analytics-js), for the latest features, security updates, and improved performance. For more details, visit the migration guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/migration-guide/."
 
+      - name: Get Job URL
+        id: get-job-url
+        continue-on-error: true
+        uses: ./.github/actions/get-job-url
+
       - name: Send message to Slack channel
         if: env.CURRENT_NPM_VERSION != env.NEW_NPM_VERSION && env.NEW_NPM_VERSION != 'not found'
         id: slack
@@ -223,7 +228,7 @@ jobs:
           PROJECT_NAME: ${{ format('JS SDK NPM Package{0}', (inputs.environment == 'staging' && ' - Staging') || (inputs.environment == 'development' && ' - Development') || (inputs.environment == 'beta' && ' - Beta') || '') }}
           NPM_PACKAGE_URL: ${{ format('https://www.npmjs.com/package/@rudderstack/analytics-js/v/{0}', env.CURRENT_VERSION_VALUE) }}
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js@'
-          GITHUB_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}/jobs/{3}', github.server_url, github.repository, github.run_id, github.job) }}
+          GITHUB_RUN_URL: ${{ steps.get-job-url.outputs.job_url }}
           ACTOR_URL: ${{ format('{0}/{1}', github.server_url, github.actor) }}
           ACTOR: ${{ github.actor }}
         with:
@@ -294,7 +299,7 @@ jobs:
           PROJECT_NAME: ${{ format('JS SDK Service Worker NPM Package{0}', (inputs.environment == 'staging' && ' - Staging') || (inputs.environment == 'development' && ' - Development') || (inputs.environment == 'beta' && ' - Beta') || '') }}
           NPM_PACKAGE_URL: ${{ format('https://www.npmjs.com/package/@rudderstack/analytics-js-service-worker/v/{0}', env.CURRENT_VERSION_SW_VALUE) }}
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js-service-worker@'
-          GITHUB_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}/jobs/{3}', github.server_url, github.repository, github.run_id, github.job) }}
+          GITHUB_RUN_URL: ${{ steps.get-job-url.outputs.job_url }}
           ACTOR_URL: ${{ format('{0}/{1}', github.server_url, github.actor) }}
           ACTOR: ${{ github.actor }}
         with:
@@ -354,7 +359,7 @@ jobs:
           PROJECT_NAME: ${{ format('JS SDK Cookies Utilities{0}', (inputs.environment == 'staging' && ' - Staging') || (inputs.environment == 'development' && ' - Development') || (inputs.environment == 'beta' && ' - Beta') || '') }}
           NPM_PACKAGE_URL: ${{ format('https://www.npmjs.com/package/@rudderstack/analytics-js-cookies/v/{0}', env.CURRENT_VERSION_COOKIE_UTILS_VALUE) }}
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js-cookies@'
-          GITHUB_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}/jobs/{3}', github.server_url, github.repository, github.run_id, github.job) }}
+          GITHUB_RUN_URL: ${{ steps.get-job-url.outputs.job_url }}
           ACTOR_URL: ${{ format('{0}/{1}', github.server_url, github.actor) }}
           ACTOR: ${{ github.actor }}
         with:

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -161,6 +161,11 @@ jobs:
         run: |
           AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --paths "/sanity-suite${{ env.SUITE_CDN_PATH }}*"
 
+      - name: Get Job URL
+        id: get-job-url
+        continue-on-error: true
+        uses: ./.github/actions/get-job-url
+
       - name: Send message to Slack channel
         id: slack
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
@@ -169,7 +174,7 @@ jobs:
           PROJECT_NAME: ${{ format('Sanity Suite - {0}', (inputs.environment == 'production' && 'Production') || (inputs.environment == 'staging' && 'Staging') || (inputs.environment == 'development' && 'Development') || 'Beta') }}
           CDN_URL: '${{ inputs.base_cdn_url }}/sanity-suite${{ env.SUITE_CDN_PATH }}/v3/cdn/index.html'
           LINK_TEXT: ${{ ((inputs.environment == 'development' && format('v{0} - Development', env.CURRENT_VERSION_VALUE)) || (inputs.environment == 'staging' && format('v{0} - Staging', env.CURRENT_VERSION_VALUE)) || (inputs.environment == 'beta' && format('v{0} - Beta', env.CURRENT_VERSION_VALUE)) || format('v{0}', env.CURRENT_VERSION_VALUE)) }}
-          GITHUB_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}/jobs/{3}', github.server_url, github.repository, github.run_id, github.job) }}
+          GITHUB_RUN_URL: ${{ steps.get-job-url.outputs.job_url }}
           ACTOR_URL: ${{ format('{0}/{1}', github.server_url, github.actor) }}
           ACTOR: ${{ github.actor }}
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -290,6 +290,11 @@ jobs:
           
           aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
+      - name: Get Job URL
+        id: get-job-url
+        continue-on-error: true
+        uses: ./.github/actions/get-job-url
+
       - name: Send message to Slack channel
         id: slack
         continue-on-error: true
@@ -299,7 +304,7 @@ jobs:
           CDN_URL: ${{ format('{0}/{1}/modern/rsa.min.js', inputs.base_cdn_url, inputs.s3_dir_path) }}
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js@'
           LINK_TEXT: ${{ (inputs.environment == 'development' && 'Development') || (inputs.environment == 'staging' && format('v{0} - Staging', env.CURRENT_VERSION_VALUE)) || format('v{0}', env.CURRENT_VERSION_VALUE) }}
-          GITHUB_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}/jobs/{3}', github.server_url, github.repository, github.run_id, github.job) }}
+          GITHUB_RUN_URL: ${{ steps.get-job-url.outputs.job_url }}
           ACTOR: ${{ github.actor }}
           ACTOR_URL: ${{ format('{0}/{1}', github.server_url, github.actor) }}
         with:

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -206,6 +206,11 @@ jobs:
             --title "$pr_title" \
             --body-file pr_body.md
 
+      - name: Get Job URL
+        id: get-job-url
+        continue-on-error: true
+        uses: ./.github/actions/get-job-url
+
       - name: Send message to Slack channel
         id: slack
         if: always()
@@ -215,7 +220,7 @@ jobs:
           PROJECT_NAME: 'JS SDK Monorepo'
           TAG_COMPARE_URL: 'https://github.com/rudderlabs/rudder-sdk-js/compare/'
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/'
-          GITHUB_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}/jobs/{3}', github.server_url, github.repository, github.run_id, github.job) }}
+          GITHUB_RUN_URL: ${{ steps.get-job-url.outputs.job_url }}
           ACTOR_URL: ${{ format('{0}/{1}', github.server_url, github.actor) }}
           ACTOR: ${{ github.actor }}
         with:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -140,6 +140,11 @@ jobs:
 
           aws cloudfront wait invalidation-completed --distribution-id ${{ secrets.AWS_PROD_CF_DISTRIBUTION_ID }} --id "$invalidation_id"
 
+      - name: Get Job URL
+        id: get-job-url
+        continue-on-error: true
+        uses: ./.github/actions/get-job-url
+
       - name: Mark the rollback version as the latest GitHub release
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         continue-on-error: true
@@ -201,7 +206,7 @@ jobs:
           CDN_URL: ${{ format('https://cdn.rudderlabs.com/{0}/modern/rsa.min.js', env.LATEST_VERSION_DIR_NAME) }}
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-js/releases/tag/@rudderstack/analytics-js@'
           LINK_TEXT: ${{ format('v{0}', env.ROLLBACK_VERSION_VALUE) }}
-          GITHUB_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}/jobs/{3}', github.server_url, github.repository, github.run_id, github.job) }}
+          GITHUB_RUN_URL: ${{ steps.get-job-url.outputs.job_url }}
           ACTOR_URL: ${{ format('{0}/{1}', github.server_url, github.actor) }}
           ACTOR: ${{ github.actor }}
         with:

--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -26,8 +26,15 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Get Job URL
+        id: get-job-url
+        continue-on-error: true
+        uses: ./.github/actions/get-job-url
+
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        env:
+          JOB_URL: ${{ steps.get-job-url.outputs.job_url }}
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -32,15 +32,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: Get Job URL
-        id: get-job-url
-        continue-on-error: true
-        uses: ./.github/actions/get-job-url
-
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        env:
-          JOB_URL: ${{ steps.get-job-url.outputs.job_url }}
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -26,21 +26,22 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+
       - name: Get Job URL
         id: get-job-url
         continue-on-error: true
         uses: ./.github/actions/get-job-url
 
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        env:
-          JOB_URL: ${{ steps.get-job-url.outputs.job_url }}
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        env:
+          JOB_URL: ${{ steps.get-job-url.outputs.job_url }}
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/unit-tests-and-lint.yml
+++ b/.github/workflows/unit-tests-and-lint.yml
@@ -32,7 +32,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-
       - name: Get Job URL
         id: get-job-url
         continue-on-error: true


### PR DESCRIPTION
## PR Description

Slack notifications now correctly point to the job URL.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4405/fix-job-url-in-slack-notifications

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal deployment workflow infrastructure by centralizing job URL retrieval across multiple GitHub Actions workflows for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->