### PR TITLE
chore(release): merge hotfix-release/3.105.0-SDK-4433 into main [SDK-4433]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4400,6 +4400,16 @@
         "node": ">=18.x"
       }
     },
+    "node_modules/@linear/sdk/node_modules/graphql": {
+      "version": "15.10.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz",
+      "integrity": "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -12194,32 +12204,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -14531,14 +14515,14 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "15.10.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz",
-      "integrity": "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/gzip-size": {
@@ -19864,16 +19848,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/msw/node_modules/graphql": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
-      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/msw/node_modules/tldts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rudderstack/analytics-js-monorepo",
-  "version": "3.104.0",
+  "version": "3.105.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rudderstack/analytics-js-monorepo",
-      "version": "3.104.0",
+      "version": "3.105.0",
       "hasInstallScript": true,
       "license": "Elastic-2.0",
       "workspaces": [
@@ -27150,7 +27150,7 @@
     },
     "packages/analytics-js": {
       "name": "@rudderstack/analytics-js",
-      "version": "3.28.0",
+      "version": "3.28.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@preact/signals-core": "1.12.1",
@@ -27188,7 +27188,7 @@
     },
     "packages/analytics-js-integrations": {
       "name": "@rudderstack/analytics-js-integrations",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@lukeed/uuid": "2.0.1",
@@ -27236,7 +27236,7 @@
     },
     "packages/analytics-js-plugins": {
       "name": "@rudderstack/analytics-js-plugins",
-      "version": "3.15.0",
+      "version": "3.15.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@rudderstack/analytics-js-common": "*",
@@ -27290,7 +27290,7 @@
     },
     "packages/analytics-v1.1": {
       "name": "rudder-sdk-js",
-      "version": "2.52.7",
+      "version": "2.52.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "@lukeed/uuid": "2.0.1",
@@ -27314,7 +27314,7 @@
     },
     "packages/sanity-suite": {
       "name": "@rudderstack/analytics-js-sanity-suite",
-      "version": "3.5.11",
+      "version": "3.5.12",
       "license": "Elastic-2.0",
       "dependencies": {
         "@rudderstack/analytics-js": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-monorepo",
-  "version": "3.104.0",
+  "version": "3.105.0",
   "private": true,
   "description": "Monorepo for RudderStack Analytics JS SDK",
   "workspaces": [

--- a/packages/analytics-js-integrations/CHANGELOG.md
+++ b/packages/analytics-js-integrations/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.20.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-integrations@3.19.0...@rudderstack/analytics-js-integrations@3.20.0) (2026-01-23)
+
+
+### Features
+
+* update braze version ([#2719](https://github.com/rudderlabs/rudder-sdk-js/issues/2719)) ([2db5ad0](https://github.com/rudderlabs/rudder-sdk-js/commit/2db5ad056955f92222a9f4950f028d8550c10ac4))
+
 ## [3.19.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-integrations@3.18.2...@rudderstack/analytics-js-integrations@3.19.0) (2025-11-20)
 
 

--- a/packages/analytics-js-integrations/CHANGELOG_LATEST.md
+++ b/packages/analytics-js-integrations/CHANGELOG_LATEST.md
@@ -1,7 +1,7 @@
-## [3.19.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-integrations@3.18.2...@rudderstack/analytics-js-integrations@3.19.0) (2025-11-20)
+## [3.20.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-integrations@3.19.0...@rudderstack/analytics-js-integrations@3.20.0) (2026-01-23)
 
 
 ### Features
 
-* add support of Platform Specific App Keys for braze ([#2585](https://github.com/rudderlabs/rudder-sdk-js/issues/2585)) ([02a2653](https://github.com/rudderlabs/rudder-sdk-js/commit/02a2653d84d77781efef0515c3551758fe5ca59d))
+* update braze version ([#2719](https://github.com/rudderlabs/rudder-sdk-js/issues/2719)) ([2db5ad0](https://github.com/rudderlabs/rudder-sdk-js/commit/2db5ad056955f92222a9f4950f028d8550c10ac4))
 

--- a/packages/analytics-js-integrations/package.json
+++ b/packages/analytics-js-integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-integrations",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "private": true,
   "type": "module",
   "description": "RudderStack JavaScript SDK device mode integrations",

--- a/packages/analytics-js-integrations/project.json
+++ b/packages/analytics-js-integrations/project.json
@@ -51,9 +51,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js-integrations@3.19.0",
-        "title": "@rudderstack/analytics-js-integrations@3.19.0",
-        "discussion-category": "@rudderstack/analytics-js-integrations@3.19.0",
+        "tag": "@rudderstack/analytics-js-integrations@3.20.0",
+        "title": "@rudderstack/analytics-js-integrations@3.20.0",
+        "discussion-category": "@rudderstack/analytics-js-integrations@3.20.0",
         "notesFile": "./packages/analytics-js-integrations/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/analytics-js-integrations/src/integrations/Braze/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/nativeSdkLoader.js
@@ -25,7 +25,7 @@ const loadNativeSdk = () => {
       return new window.braze.User();
     };
     (y = p.createElement(P)).type = 'text/javascript';
-    y.src = 'https://js.appboycdn.com/web-sdk/5.3/braze.min.js';
+    y.src = 'https://js.appboycdn.com/web-sdk/5.9/braze.min.js';
     y.async = 1;
     y.setAttribute('data-loader', LOAD_ORIGIN);
     (b = p.getElementsByTagName(P)[0]).parentNode.insertBefore(y, b);

--- a/packages/analytics-js-plugins/CHANGELOG.md
+++ b/packages/analytics-js-plugins/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.15.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.15.0...@rudderstack/analytics-js-plugins@3.15.1) (2026-01-23)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js-integrations` updated to version `3.20.0`
 ## [3.15.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.14.1...@rudderstack/analytics-js-plugins@3.15.0) (2026-01-22)
 
 ### Dependency Updates

--- a/packages/analytics-js-plugins/CHANGELOG_LATEST.md
+++ b/packages/analytics-js-plugins/CHANGELOG_LATEST.md
@@ -1,11 +1,5 @@
-## [3.15.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.14.1...@rudderstack/analytics-js-plugins@3.15.0) (2026-01-22)
+## [3.15.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-plugins@3.15.0...@rudderstack/analytics-js-plugins@3.15.1) (2026-01-23)
 
 ### Dependency Updates
 
-* `@rudderstack/analytics-js-common` updated to version `3.27.0`
-* `@rudderstack/analytics-js-cookies` updated to version `0.5.6`
-
-### Features
-
-* reduce noise in error reporting ([#2696](https://github.com/rudderlabs/rudder-sdk-js/issues/2696)) ([78d98e7](https://github.com/rudderlabs/rudder-sdk-js/commit/78d98e7ccbc58327ff94ccaa9c9c669f14fa6a11))
-
+* `@rudderstack/analytics-js-integrations` updated to version `3.20.0`

--- a/packages/analytics-js-plugins/package.json
+++ b/packages/analytics-js-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-plugins",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "private": true,
   "description": "RudderStack JavaScript SDK plugins",
   "main": "dist/npm/modern/cjs/index.cjs",

--- a/packages/analytics-js-plugins/project.json
+++ b/packages/analytics-js-plugins/project.json
@@ -51,9 +51,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js-plugins@3.15.0",
-        "title": "@rudderstack/analytics-js-plugins@3.15.0",
-        "discussion-category": "@rudderstack/analytics-js-plugins@3.15.0",
+        "tag": "@rudderstack/analytics-js-plugins@3.15.1",
+        "title": "@rudderstack/analytics-js-plugins@3.15.1",
+        "discussion-category": "@rudderstack/analytics-js-plugins@3.15.1",
         "notesFile": "./packages/analytics-js-plugins/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/analytics-js/CHANGELOG.md
+++ b/packages/analytics-js/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.28.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.28.0...@rudderstack/analytics-js@3.28.1) (2026-01-23)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js-plugins` updated to version `3.15.1`
 ## [3.28.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.27.0...@rudderstack/analytics-js@3.28.0) (2026-01-22)
 
 ### Dependency Updates

--- a/packages/analytics-js/CHANGELOG_LATEST.md
+++ b/packages/analytics-js/CHANGELOG_LATEST.md
@@ -1,12 +1,5 @@
-## [3.28.0](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.27.0...@rudderstack/analytics-js@3.28.0) (2026-01-22)
+## [3.28.1](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js@3.28.0...@rudderstack/analytics-js@3.28.1) (2026-01-23)
 
 ### Dependency Updates
 
-* `@rudderstack/analytics-js-cookies` updated to version `0.5.6`
-* `@rudderstack/analytics-js-common` updated to version `3.27.0`
-* `@rudderstack/analytics-js-plugins` updated to version `3.15.0`
-
-### Features
-
-* reduce noise in error reporting ([#2696](https://github.com/rudderlabs/rudder-sdk-js/issues/2696)) ([78d98e7](https://github.com/rudderlabs/rudder-sdk-js/commit/78d98e7ccbc58327ff94ccaa9c9c669f14fa6a11))
-
+* `@rudderstack/analytics-js-plugins` updated to version `3.15.1`

--- a/packages/analytics-js/package.json
+++ b/packages/analytics-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js",
-  "version": "3.28.0",
+  "version": "3.28.1",
   "description": "RudderStack JavaScript SDK",
   "main": "dist/npm/modern/cjs/index.cjs",
   "module": "dist/npm/modern/esm/index.mjs",

--- a/packages/analytics-js/project.json
+++ b/packages/analytics-js/project.json
@@ -52,9 +52,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "@rudderstack/analytics-js@3.28.0",
-        "title": "@rudderstack/analytics-js@3.28.0",
-        "discussion-category": "@rudderstack/analytics-js@3.28.0",
+        "tag": "@rudderstack/analytics-js@3.28.1",
+        "title": "@rudderstack/analytics-js@3.28.1",
+        "discussion-category": "@rudderstack/analytics-js@3.28.1",
         "notesFile": "./packages/analytics-js/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/analytics-v1.1/CHANGELOG.md
+++ b/packages/analytics-v1.1/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [2.52.8](https://github.com/rudderlabs/rudder-sdk-js/compare/rudder-sdk-js@2.52.7...rudder-sdk-js@2.52.8) (2026-01-23)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js-integrations` updated to version `3.20.0`
 ## [2.52.7](https://github.com/rudderlabs/rudder-sdk-js/compare/rudder-sdk-js@2.52.6...rudder-sdk-js@2.52.7) (2025-11-20)
 
 ### Dependency Updates

--- a/packages/analytics-v1.1/CHANGELOG_LATEST.md
+++ b/packages/analytics-v1.1/CHANGELOG_LATEST.md
@@ -1,5 +1,5 @@
-## [2.52.7](https://github.com/rudderlabs/rudder-sdk-js/compare/rudder-sdk-js@2.52.6...rudder-sdk-js@2.52.7) (2025-11-20)
+## [2.52.8](https://github.com/rudderlabs/rudder-sdk-js/compare/rudder-sdk-js@2.52.7...rudder-sdk-js@2.52.8) (2026-01-23)
 
 ### Dependency Updates
 
-* `@rudderstack/analytics-js-integrations` updated to version `3.19.0`
+* `@rudderstack/analytics-js-integrations` updated to version `3.20.0`

--- a/packages/analytics-v1.1/package.json
+++ b/packages/analytics-v1.1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-sdk-js",
-  "version": "2.52.7",
+  "version": "2.52.8",
   "description": "RudderStack JavaScript SDK",
   "main": "dist/npm/index.js",
   "module": "dist/npm/index.es.js",

--- a/packages/analytics-v1.1/project.json
+++ b/packages/analytics-v1.1/project.json
@@ -59,9 +59,9 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "rudder-sdk-js@2.52.7",
-        "title": "rudder-sdk-js@2.52.7",
-        "discussion-category": "rudder-sdk-js@2.52.7",
+        "tag": "rudder-sdk-js@2.52.8",
+        "title": "rudder-sdk-js@2.52.8",
+        "discussion-category": "rudder-sdk-js@2.52.8",
         "notesFile": "./packages/analytics-v1.1/CHANGELOG_LATEST.md"
       }
     }

--- a/packages/sanity-suite/CHANGELOG.md
+++ b/packages/sanity-suite/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.5.12](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-sanity-suite@3.5.11...@rudderstack/analytics-js-sanity-suite@3.5.12) (2026-01-23)
+
+### Dependency Updates
+
+* `@rudderstack/analytics-js` updated to version `3.28.1`
 ## [3.5.11](https://github.com/rudderlabs/rudder-sdk-js/compare/@rudderstack/analytics-js-sanity-suite@3.5.10...@rudderstack/analytics-js-sanity-suite@3.5.11) (2026-01-22)
 
 ### Dependency Updates

--- a/packages/sanity-suite/package.json
+++ b/packages/sanity-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/analytics-js-sanity-suite",
-  "version": "3.5.11",
+  "version": "3.5.12",
   "private": true,
   "description": "Sanity suite for testing JS SDK package",
   "main": "./dist/v3/cdn/testBook.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_repo_rudder-sdk-js
 sonar.organization=rudderlabs
 sonar.projectName=rudder-sdk-js
-sonar.projectVersion=3.104.0
+sonar.projectVersion=3.105.0
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-js


### PR DESCRIPTION
:crown: **Automated Release PR**

This pull request was created automatically by the GitHub Actions workflow. It merges the release branch (`hotfix-release/3.105.0-SDK-4433`) into the `main` branch.

This ensures that the latest release branch changes are incorporated into the `main` branch for production.

### Details
- **Monorepo Release Version**: v3.105.0
- **Release Branch**: `hotfix-release/3.105.0-SDK-4433`
- **Related Ticket**: [SDK-4433](https://linear.app/rudderstack/issue/SDK-4433)

### Version updates

| Package | New version |
|---------|-------------|
| @rudderstack/analytics-js-monorepo | 3.105.0 |
| @rudderstack/analytics-js-common | N/A |
| @rudderstack/analytics-js-cookies | N/A |
| @rudderstack/analytics-js-integrations | 3.20.0 |
| @rudderstack/analytics-js-legacy-utilities | N/A |
| @rudderstack/analytics-js-plugins | 3.15.1 |
| @rudderstack/analytics-js-service-worker | N/A |
| @rudderstack/analytics-js | 3.28.1 |
| rudder-sdk-js | 2.52.8 |
| @rudderstack/analytics-js-loading-scripts | N/A |
| @rudderstack/analytics-js-sanity-suite | 3.5.12 |

---
Please review and merge when ready. :rocket:
