### PR TITLE
chore(ci): migrate workflows from PAT to GitHub App token [SEC-58]

### DIFF
--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -14,8 +14,6 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
-    secrets:
-      PAT: ${{ secrets.PAT }}
 
   create-branch:
     name: Create a new hotfix branch

--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -14,6 +14,8 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   create-branch:
     name: Create a new hotfix branch

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -32,6 +32,8 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   find-pr:
     name: Find PR for Current Branch
@@ -271,3 +273,6 @@ jobs:
       sanity_test_suite_url: https://cdn.rudderlabs.com/sanity-suite/beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}
       build_source_id: ${{ needs.get-deploy-inputs.outputs.beta_identifier_for_automation_tests }}
       trigger_source: ${{ needs.get-deploy-inputs.outputs.trigger_source }}
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -32,8 +32,6 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
-    secrets:
-      PAT: ${{ secrets.PAT }}
 
   find-pr:
     name: Find PR for Current Branch
@@ -273,5 +271,3 @@ jobs:
       sanity_test_suite_url: https://cdn.rudderlabs.com/sanity-suite/beta/${{ needs.get-deploy-inputs.outputs.beta_identifier }}
       build_source_id: ${{ needs.get-deploy-inputs.outputs.beta_identifier_for_automation_tests }}
       trigger_source: ${{ needs.get-deploy-inputs.outputs.trigger_source }}
-    secrets:
-      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -77,3 +77,4 @@ jobs:
       environment: development
       trigger_source: ${{ needs.get-deploy-inputs.outputs.trigger_source }}
     secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -77,4 +77,3 @@ jobs:
       environment: development
       trigger_source: ${{ needs.get-deploy-inputs.outputs.trigger_source }}
     secrets:
-      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -100,4 +100,5 @@ jobs:
       monorepo_release_version: ${{ needs.get-deploy-inputs.outputs.release_version }}
       release_ticket_id: ${{ needs.get-deploy-inputs.outputs.release_ticket_id }}
     secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -100,5 +100,4 @@ jobs:
       monorepo_release_version: ${{ needs.get-deploy-inputs.outputs.release_version }}
       release_ticket_id: ${{ needs.get-deploy-inputs.outputs.release_ticket_id }}
     secrets:
-      PAT: ${{ secrets.PAT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -107,4 +107,5 @@ jobs:
       monorepo_release_version: ${{ needs.get-deploy-inputs.outputs.release_version }}
       release_ticket_id: ${{ needs.get-deploy-inputs.outputs.release_ticket_id }}
     secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -107,5 +107,4 @@ jobs:
       monorepo_release_version: ${{ needs.get-deploy-inputs.outputs.release_version }}
       release_ticket_id: ${{ needs.get-deploy-inputs.outputs.release_ticket_id }}
     secrets:
-      PAT: ${{ secrets.PAT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -19,8 +19,7 @@ env:
 
 jobs:
   validate-actor:
-    permissions:
-      contents: read # to checkout repository code
+    permissions: {}
     # Only allow to draft a new release from develop and hotfix branches
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/')
     uses: ./.github/workflows/validate-actor.yml
@@ -140,7 +139,6 @@ jobs:
           commit-message: 'chore(monorepo): sync versions and generate release logs'
           files: |
             .
-          push-branch: true
 
       - name: Create pull request into main
         id: create-pr

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -137,12 +137,19 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # The signed-commit action requires the branch to exist on the remote.
-          # Create the remote ref pointing at the current HEAD before committing.
+          # Idempotent: update ref if it exists, create if it doesn't.
           sha=$(git rev-parse HEAD)
-          gh api "repos/${REPO}/git/refs" \
-            --method POST \
-            -f "ref=refs/heads/${BRANCH_NAME}" \
-            -f "sha=${sha}"
+          if gh api "repos/${REPO}/git/ref/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
+            gh api "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" \
+              --method PATCH \
+              -f "sha=${sha}" \
+              -F "force=true"
+          else
+            gh api "repos/${REPO}/git/refs" \
+              --method POST \
+              -f "ref=refs/heads/${BRANCH_NAME}" \
+              -f "sha=${sha}"
+          fi
 
       - name: Create verified commit and push release branch
         uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -19,6 +19,8 @@ env:
 
 jobs:
   validate-actor:
+    permissions:
+      contents: read # to checkout repository code
     # Only allow to draft a new release from develop and hotfix branches
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/')
     uses: ./.github/workflows/validate-actor.yml
@@ -50,6 +52,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -96,7 +99,6 @@ jobs:
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
           git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
@@ -120,8 +122,6 @@ jobs:
           npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE sonar-project.properties
           npm install
           npm run clean
-          git add .
-          git commit -m "chore(monorepo): sync versions and generate release logs" -n
 
       - name: Generate packages versions table
         id: packages-versions
@@ -129,9 +129,16 @@ jobs:
           chmod +x ./scripts/collect-packages-versions.sh
           ./scripts/collect-packages-versions.sh > packages_versions.md
 
-      - name: Push new version in release branch
-        run: |
-          git push --follow-tags
+      - name: Create verified commit and push release branch
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(monorepo): sync versions and generate release logs'
+          files: |
+            .
+          push-branch: true
 
       - name: Create pull request into main
         id: create-pr

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -130,6 +130,20 @@ jobs:
           chmod +x ./scripts/collect-packages-versions.sh
           ./scripts/collect-packages-versions.sh > packages_versions.md
 
+      - name: Create release branch on remote
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BRANCH_NAME: ${{ steps.create-release.outputs.branch_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The signed-commit action requires the branch to exist on the remote.
+          # Create the remote ref pointing at the current HEAD before committing.
+          sha=$(git rev-parse HEAD)
+          gh api "repos/${REPO}/git/refs" \
+            --method POST \
+            -f "ref=refs/heads/${BRANCH_NAME}" \
+            -f "sha=${sha}"
+
       - name: Create verified commit and push release branch
         uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
         env:

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -26,6 +26,8 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   draft-new-release:
     needs: validate-actor
@@ -271,6 +273,7 @@ jobs:
         if: startsWith(github.ref_name, 'hotfix/')
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const branchToDelete = '${{ github.ref_name }}';
             const owner = context.repo.owner;

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -24,18 +24,27 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
-    secrets:
-      PAT: ${{ secrets.PAT }}
 
   draft-new-release:
     needs: validate-actor
     name: Draft a new release
     runs-on: [self-hosted, Linux, X64]
+    permissions:
+      contents: read # to checkout repository code
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and push branches
+          permission-pull-requests: write # to create and update PRs
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -127,7 +136,7 @@ jobs:
       - name: Create pull request into main
         id: create-pr
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           pr_title="chore(release): merge ${{ steps.create-release.outputs.branch_name }} into main [${{ github.event.inputs.release_ticket_id }}]"
           

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -300,6 +300,7 @@ jobs:
     name: Publish packages to NPM
     permissions:
       contents: read # to checkout repository code
+      id-token: write # to allow reusable workflow to request OIDC token for NPM provenance
     uses: ./.github/workflows/deploy-npm.yml
     with:
       trigger_source: ${{ needs.get-release-inputs.outputs.trigger_source }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -114,7 +114,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
-          branch-name: ${{ github.ref_name }}
+          branch-name: ${{ github.event.pull_request.base.ref }}
           commit-message: 'chore(monorepo): release v${{ steps.extract-version.outputs.release_version }}'
           files: |
             .
@@ -147,7 +147,7 @@ jobs:
         continue-on-error: true
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # The default behavior of Nx is to consider changes to package-lock.json
           # as impacting all the packages.
@@ -165,7 +165,7 @@ jobs:
         id: mark_latest_release
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Get the analytics-js package version from package.json
           ANALYTICS_JS_VERSION=$(jq -r '.version' packages/analytics-js/package.json)

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -179,7 +179,7 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           pr_title="chore(release): merge main into develop after release v${{ steps.extract-version.outputs.release_version }} [${{ steps.extract-version.outputs.release_ticket_id }}]"
           

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -14,6 +14,8 @@ jobs:
   get-release-inputs:
     name: Get Release Inputs
     runs-on: [self-hosted, Linux, X64]
+    permissions:
+      contents: read # to read repository contents
     outputs:
       trigger_source: ${{ steps.set-outputs.outputs.trigger_source }}
       release_version: ${{ steps.extract-release-info.outputs.release_version }}
@@ -50,6 +52,8 @@ jobs:
     needs: [get-release-inputs]
     # For publishing GitHub release, we need to only use the GitHub hosted runners
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout repository code
     # only merged pull requests must trigger this job
     if: >
       (startsWith(github.event.pull_request.head.ref, 'release/') ||
@@ -61,6 +65,15 @@ jobs:
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+          permission-pull-requests: write # to create and update PRs
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -86,6 +99,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
@@ -94,11 +108,17 @@ jobs:
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
 
-      - name: Create monorepo release tag
+      - name: Create monorepo release tag via API
         id: create_monorepo_release
-        run: |
-          git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore(monorepo): release v${{ steps.extract-version.outputs.release_version }}"
-          git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ github.ref_name }}
+          commit-message: 'chore(monorepo): release v${{ steps.extract-version.outputs.release_version }}'
+          files: |
+            .
+          tag: 'v${{ steps.extract-version.outputs.release_version }}'
 
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -278,6 +298,8 @@ jobs:
   publish-npm-packages:
     needs: [get-release-inputs, release]
     name: Publish packages to NPM
+    permissions:
+      contents: read # to checkout repository code
     uses: ./.github/workflows/deploy-npm.yml
     with:
       trigger_source: ${{ needs.get-release-inputs.outputs.trigger_source }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -29,8 +29,6 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
-    secrets:
-      PAT: ${{ secrets.PAT }}
 
   get-rollback-inputs:
     name: Get Rollback Inputs
@@ -283,5 +281,3 @@ jobs:
     with:
       environment: production
       trigger_source: ${{ needs.get-rollback-inputs.outputs.trigger_source }}
-    secrets:
-      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -29,6 +29,8 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'js-sdk,integrations'
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   get-rollback-inputs:
     name: Get Rollback Inputs
@@ -281,3 +283,5 @@ jobs:
     with:
       environment: production
       trigger_source: ${{ needs.get-rollback-inputs.outputs.trigger_source }}
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}

--- a/.github/workflows/run-e2e-regression-test-suites.yml
+++ b/.github/workflows/run-e2e-regression-test-suites.yml
@@ -26,8 +26,8 @@ on:
         type: string
         required: false
     secrets:
-      PAT:
-        description: Personal Access Token
+      RELEASE_PRIVATE_KEY:
+        description: GitHub App private key for token generation
         required: true
       SLACK_BOT_TOKEN:
         description: Slack Bot Token for posting to release threads

--- a/.github/workflows/run-e2e-regression-test-suites.yml
+++ b/.github/workflows/run-e2e-regression-test-suites.yml
@@ -80,6 +80,8 @@ jobs:
     name: Run Sanity E2E Regression Tests
     runs-on: [self-hosted, Linux, X64]
     needs: extract-monorepo-version
+    permissions:
+      contents: read # to checkout repository code
     outputs:
       sanity-status: ${{ steps.run_sanity_tests.outputs.status }}
       sanity-conclusion: ${{ steps.run_sanity_tests.outputs.conclusion }}
@@ -89,6 +91,15 @@ jobs:
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-actions: write # to trigger workflows in target repository
+          repositories: rudder-client-side-test # to access cross-repo test repository
 
       - name: Checkout (for composite action)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -110,7 +121,7 @@ jobs:
         id: run_sanity_tests
         uses: ./.github/actions/workflow-utils
         with:
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           target_repo: ${{ env.TARGET_REPO }}
           workflow_file: sdk-team-js-sanity-suite.yaml
           workflow_ref: main
@@ -158,12 +169,23 @@ jobs:
     needs: [extract-monorepo-version, trigger-and-wait-sanity-test-suite]
     # Only run if sanity tests passed
     if: needs.trigger-and-wait-sanity-test-suite.outputs.sanity-conclusion == 'success'
+    permissions:
+      contents: read # to checkout repository code
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-actions: write # to trigger workflows in target repository
+          repositories: rudder-client-side-test # to access cross-repo test repository
 
       - name: Checkout (for composite action)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -185,7 +207,7 @@ jobs:
         id: run_e2e_tests
         uses: ./.github/actions/workflow-utils
         with:
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           target_repo: ${{ env.TARGET_REPO }}
           workflow_file: sdk-team-js-regression.yaml
           workflow_ref: main

--- a/.github/workflows/run-e2e-regression-test-suites.yml
+++ b/.github/workflows/run-e2e-regression-test-suites.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -2,32 +2,36 @@ name: Validate Actor
 
 on:
   workflow_call:
-    secrets:
-      PAT:
-        required: true
     inputs:
       team_names:
         description: 'Comma-separated list of team names'
         type: string
         default: 'js-sdk'
 
-permissions:
-  contents: read
-
 jobs:
   validate-actor:
     runs-on: [self-hosted, Linux, X64]
+    permissions:
+      contents: read # to checkout repository code
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-members: read # to check org team membership
+
       - name: Validate if actor is allowed to trigger the workflow
         env:
           ORG_NAME: rudderlabs
           TEAM_NAMES: ${{ inputs.team_names }}
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           actor=${{ github.actor || github.triggering_actor }}
           allowed=false

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -7,6 +7,9 @@ on:
         description: 'Comma-separated list of team names'
         type: string
         default: 'js-sdk'
+    secrets:
+      RELEASE_PRIVATE_KEY:
+        required: true
 
 jobs:
   validate-actor:

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -15,7 +15,7 @@ jobs:
   validate-actor:
     runs-on: [self-hosted, Linux, X64]
     permissions:
-      contents: read # to checkout repository code
+      contents: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -14,8 +14,7 @@ on:
 jobs:
   validate-actor:
     runs-on: [self-hosted, Linux, X64]
-    permissions:
-      contents: read
+    permissions: {}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2


### PR DESCRIPTION
## Summary
This PR migrates release workflows from PAT to GitHub App token with verified/signed commits.

### Migration Details

| File | Change | Why |
|------|--------|-----|
| **draft-new-release.yml** | Added job-level permissions | Follows January 2026 guidelines for minimal, explicit permissions |
| **publish-new-release.yml** | Added GitHub App token generation, replaced `git push` with `ryancyq/github-signed-commit` action | Git push with any token creates unverified commits; API-based commits are verified and trigger CI |
| **publish-new-release.yml** | Added job-level permissions to all jobs | Reduces attack surface by limiting GITHUB_TOKEN to minimal required permissions |
| **publish-new-release.yml** | Pass App Token to checkout | Ensures consistent credential usage throughout workflow |

### Key Changes

1. **Added GitHub App Token Generation** in `publish-new-release.yml` (before checkout)
   - Early token generation pattern per plan guidelines
   - Scoped permissions: `contents: write`, `pull-requests: write`

2. **Replaced git push with Signed Commit Action**
   - Changed from: `git tag -a ... && git push origin refs/tags/...`
   - Changed to: `ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0`
   - Result: Commits will show as "Verified" on GitHub and trigger CI workflows

3. **Added Job-Level Permissions**
   - `get-release-inputs`: `contents: read`
   - `release`: `contents: read`
   - `publish-npm-packages`: `contents: read`
   - `validate-actor` (draft): `contents: read`
   - All permissions include comments explaining why

4. **Fixed Token Reference Bug**
   - Line 182 in `publish-new-release.yml` referenced missing `steps.generate-token.outputs.token`
   - Added token generation step to fix this bug

### Security Improvements

- **Minimal Permissions**: Each job only has the permissions it needs via job-level `permissions:` blocks
- **Verified Commits**: Using GitHub API ensures commits are cryptographically signed
- **Consistent Token Usage**: App Token used for all write operations (checkout, commits, PRs)

### Linting Results

Both `actionlint` and `zizmor` pass with no new issues introduced. All reported issues are pre-existing:
- Pre-existing shellcheck warnings (unquoted variables)
- Pre-existing template-injection warnings (user inputs in scripts)

## Test plan
- [ ] Verify both workflows pass after merge
- [ ] Confirm release commits show as "Verified" on GitHub
- [ ] Verify release PRs trigger CI checks as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced PAT-based authentication with GitHub App token generation across CI workflows and propagated generated tokens to checkout, cross-repo triggers, test suites, and release steps.
  * Introduced signed-commit flows and token-backed PR/tag creation.
  * Updated job permissions to enable repository checkout and testing.
  * Replaced PAT mappings with RELEASE_PRIVATE_KEY and added Slack bot token usage where required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->