### PR TITLE
fix(analytics-js): prevent redundant destination loading [SDK-4540]

### DIFF
--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -88,10 +88,12 @@ describe('Core - Analytics', () => {
       expect(onPluginsReadySpy).toHaveBeenCalledTimes(1);
       expect(state.lifecycle.status.value).toBe('readyExecuted');
 
+      state.nativeDestinations.clientDestinationsReady.value = false;
       state.lifecycle.status.value = 'initialized';
       expect(onInitializedSpy).toHaveBeenCalledTimes(2);
       expect(state.lifecycle.status.value).toBe('readyExecuted');
 
+      state.nativeDestinations.clientDestinationsReady.value = false;
       state.lifecycle.status.value = 'loaded';
       expect(loadDestinationsSpy).toHaveBeenCalledTimes(3);
       expect(state.lifecycle.status.value).toBe('readyExecuted');
@@ -358,8 +360,9 @@ describe('Core - Analytics', () => {
       expect(invokeSingleSpy).not.toHaveBeenCalled();
     });
 
-    it('should load destinations when clientDestinationsReady is false and lifecycle status is not destinationsLoading', () => {
+    it('should set both destinationsReady and clientDestinationsReady when there are zero active destinations', () => {
       state.nativeDestinations.clientDestinationsReady.value = false;
+      state.nativeDestinations.activeDestinations.value = [];
       state.lifecycle.status.value = 'loaded';
 
       const invokeSingleSpy = jest.spyOn(
@@ -369,6 +372,7 @@ describe('Core - Analytics', () => {
 
       analytics.loadDestinations();
 
+      // Should call setActiveDestinations
       expect(invokeSingleSpy).toHaveBeenCalledWith(
         'nativeDestinations.setActiveDestinations',
         state,
@@ -376,6 +380,69 @@ describe('Core - Analytics', () => {
         analytics.errorHandler,
         analytics.logger,
       );
+
+      // Should set both flags when activeDestinations is empty
+      expect(state.lifecycle.status.value).toBe('destinationsReady');
+      expect(state.nativeDestinations.clientDestinationsReady.value).toBe(true);
+    });
+
+    it('should return early when called multiple times with zero active destinations', () => {
+      state.nativeDestinations.clientDestinationsReady.value = false;
+      state.nativeDestinations.activeDestinations.value = [];
+      state.lifecycle.status.value = 'loaded';
+
+      const invokeSingleSpy = jest.spyOn(
+        analytics.pluginsManager as IPluginsManager,
+        'invokeSingle',
+      );
+
+      // First call - should process
+      analytics.loadDestinations();
+      expect(invokeSingleSpy).toHaveBeenCalledTimes(1);
+      expect(state.nativeDestinations.clientDestinationsReady.value).toBe(true);
+
+      invokeSingleSpy.mockClear();
+
+      // Second call - should return early because clientDestinationsReady is now true
+      analytics.loadDestinations();
+      expect(invokeSingleSpy).not.toHaveBeenCalled();
+    });
+
+    it('should load destinations when there are active destinations to load', () => {
+      state.nativeDestinations.clientDestinationsReady.value = false;
+      state.nativeDestinations.activeDestinations.value = [
+        { id: 'destination-1' },
+        { id: 'destination-2' },
+      ];
+      state.lifecycle.status.value = 'loaded';
+
+      const invokeSingleSpy = jest.spyOn(
+        analytics.pluginsManager as IPluginsManager,
+        'invokeSingle',
+      );
+
+      analytics.loadDestinations();
+
+      // Should call setActiveDestinations
+      expect(invokeSingleSpy).toHaveBeenCalledWith(
+        'nativeDestinations.setActiveDestinations',
+        state,
+        analytics.pluginsManager,
+        analytics.errorHandler,
+        analytics.logger,
+      );
+
+      // Should proceed to load destinations
+      expect(invokeSingleSpy).toHaveBeenCalledWith(
+        'nativeDestinations.load',
+        state,
+        analytics.externalSrcLoader,
+        analytics.errorHandler,
+        analytics.logger,
+      );
+
+      // Should set lifecycle status to destinationsLoading
+      expect(state.lifecycle.status.value).toBe('destinationsLoading');
     });
   });
 

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -327,6 +327,58 @@ describe('Core - Analytics', () => {
     });
   });
 
+  describe('loadDestinations', () => {
+    beforeEach(() => {
+      analytics.prepareInternalServices();
+    });
+
+    it('should not load destinations when lifecycle status is destinationsLoading', () => {
+      state.lifecycle.status.value = 'destinationsLoading';
+
+      const invokeSingleSpy = jest.spyOn(
+        analytics.pluginsManager as IPluginsManager,
+        'invokeSingle',
+      );
+
+      analytics.loadDestinations();
+
+      expect(invokeSingleSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not load destinations when clientDestinationsReady is true', () => {
+      state.nativeDestinations.clientDestinationsReady.value = true;
+
+      const invokeSingleSpy = jest.spyOn(
+        analytics.pluginsManager as IPluginsManager,
+        'invokeSingle',
+      );
+
+      analytics.loadDestinations();
+
+      expect(invokeSingleSpy).not.toHaveBeenCalled();
+    });
+
+    it('should load destinations when clientDestinationsReady is false and lifecycle status is not destinationsLoading', () => {
+      state.nativeDestinations.clientDestinationsReady.value = false;
+      state.lifecycle.status.value = 'loaded';
+
+      const invokeSingleSpy = jest.spyOn(
+        analytics.pluginsManager as IPluginsManager,
+        'invokeSingle',
+      );
+
+      analytics.loadDestinations();
+
+      expect(invokeSingleSpy).toHaveBeenCalledWith(
+        'nativeDestinations.setActiveDestinations',
+        state,
+        analytics.pluginsManager,
+        analytics.errorHandler,
+        analytics.logger,
+      );
+    });
+  });
+
   describe('ready', () => {
     it('should invoke callbacks passed', () => {
       const callback = jest.fn();

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -394,7 +394,7 @@ class Analytics implements IAnalytics {
     // If the integrations load is already triggered or completed, skip the rest of the logic
     if (
       state.lifecycle.status.value === 'destinationsLoading' ||
-      state.lifecycle.status.value === 'destinationsReady'
+      state.nativeDestinations.clientDestinationsReady.value === true
     ) {
       return;
     }

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -410,7 +410,10 @@ class Analytics implements IAnalytics {
 
     const totalDestinationsToLoad = state.nativeDestinations.activeDestinations.value.length;
     if (totalDestinationsToLoad === 0) {
-      state.lifecycle.status.value = 'destinationsReady';
+      batch(() => {
+        state.nativeDestinations.clientDestinationsReady.value = true;
+        state.lifecycle.status.value = 'destinationsReady';
+      });
       return;
     }
 
@@ -427,10 +430,9 @@ class Analytics implements IAnalytics {
     // Progress to next lifecycle phase if all native destinations are initialized or failed
     effect(() => {
       const areAllDestinationsReady =
-        totalDestinationsToLoad === 0 ||
         state.nativeDestinations.initializedDestinations.value.length +
           state.nativeDestinations.failedDestinations.value.length ===
-          totalDestinationsToLoad;
+        totalDestinationsToLoad;
 
       if (areAllDestinationsReady) {
         batch(() => {


### PR DESCRIPTION
## PR Description

This PR fixes an issue where device-mode destinations were being loaded redundantly when the consent API was invoked multiple times. The fix changes the early return condition in `loadDestinations()` to check the more specific `clientDestinationsReady` flag instead of the general lifecycle status `destinationsReady`.

**Changes:**
- Modified `loadDestinations()` to check `state.nativeDestinations.clientDestinationsReady.value` instead of `state.lifecycle.status.value === 'destinationsReady'`
- Added comprehensive unit tests to verify the early return behavior

**Why this change:**
The `clientDestinationsReady` flag is set when all destinations are loaded and ready. Using this flag instead of the lifecycle status provides a more accurate check and prevents unnecessary re-loading of destinations, particularly when the consent API is called multiple times.

## Linear task (optional)

SDK-4540

## Cross Browser Tests

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for destination loading: skips during in-progress loads, skips when already ready, handles zero-config destinations, and is safe on repeated calls.

* **Bug Fixes**
  * More reliable destination readiness handling and batched updates when no destinations are configured, preventing unnecessary work and ensuring consistent readiness signaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->