### PR TITLE
fix: optimizely audiences name

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/Optimizely/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Optimizely/browser.test.js
@@ -1,0 +1,316 @@
+import Optimizely from '../../../src/integrations/Optimizely/browser';
+
+const destinationInfo = {
+  areTransformationsConnected: false,
+  destinationId: 'sample-destination-id',
+};
+
+const defaultConfig = {
+  sendExperimentTrack: true,
+  sendExperimentIdentify: true,
+  sendExperimentTrackAsNonInteractive: false,
+  revenueOnlyOnOrderCompleted: true,
+  trackCategorizedPages: true,
+  trackNamedPages: true,
+};
+
+const mockAnalytics = {
+  logLevel: 'debug',
+  track: jest.fn(),
+  identify: jest.fn(),
+};
+
+beforeEach(() => {
+  loggerErrorMock = jest.fn();
+  const scriptElement = document.createElement('script');
+  scriptElement.type = 'text/javascript';
+  scriptElement.id = 'dummyScript';
+  const headElements = document.getElementsByTagName('head');
+  headElements[0].insertBefore(scriptElement, headElements[0].firstChild);
+  delete window.optimizely;
+  jest.clearAllMocks();
+});
+
+describe('Optimizely init tests', () => {
+  test('should initialize with correct name and config', () => {
+    const optimizely = new Optimizely(defaultConfig, mockAnalytics, destinationInfo);
+    optimizely.init();
+
+    expect(optimizely.name).toBe('OPTIMIZELY');
+    expect(optimizely.sendExperimentTrack).toBe(true);
+    expect(optimizely.trackCategorizedPages).toBe(true);
+    expect(optimizely.trackNamedPages).toBe(true);
+  });
+
+  test('isLoaded should return false when optimizely is not loaded', () => {
+    const optimizely = new Optimizely(defaultConfig, mockAnalytics, destinationInfo);
+    optimizely.init();
+
+    expect(optimizely.isLoaded()).toBe(false);
+  });
+
+  test('isLoaded should return true when optimizely push is available and not Array prototype', () => {
+    window.optimizely = { push: jest.fn() };
+    const optimizely = new Optimizely(defaultConfig, mockAnalytics, destinationInfo);
+
+    expect(optimizely.isLoaded()).toBe(true);
+  });
+
+  test('isReady should match isLoaded', () => {
+    window.optimizely = { push: jest.fn() };
+    const optimizely = new Optimizely(defaultConfig, mockAnalytics, destinationInfo);
+
+    expect(optimizely.isReady()).toBe(optimizely.isLoaded());
+  });
+});
+
+describe('Optimizely getAudienceIdsAndNames', () => {
+  let optimizely;
+
+  beforeEach(() => {
+    optimizely = new Optimizely(defaultConfig, mockAnalytics, destinationInfo);
+  });
+
+  test('should return empty arrays for null or undefined audiences', () => {
+    const emptyResult = { audienceIds: [], audienceNames: [] };
+
+    expect(optimizely.getAudienceIdsAndNames(null)).toEqual(emptyResult);
+    expect(optimizely.getAudienceIdsAndNames(undefined)).toEqual(emptyResult);
+  });
+
+  test('should return empty arrays for non-array audiences', () => {
+    const emptyResult = { audienceIds: [], audienceNames: [] };
+
+    expect(optimizely.getAudienceIdsAndNames({})).toEqual(emptyResult);
+    expect(optimizely.getAudienceIdsAndNames('not-array')).toEqual(emptyResult);
+  });
+
+  test('should handle audiences with valid id and name', () => {
+    const audiences = [
+      { id: '7527562222', name: 'Peaky Blinders' },
+      { id: '7527111138', name: 'Trust Tree' },
+    ];
+    const result = optimizely.getAudienceIdsAndNames(audiences);
+
+    expect(result.audienceIds).toEqual(['7527111138', '7527562222']);
+    expect(result.audienceNames).toEqual(['Peaky Blinders', 'Trust Tree']);
+  });
+
+  test('should safely handle null audience names without throwing (INT-5858)', () => {
+    const audiences = [
+      { id: '7527562222', name: 'Peaky Blinders' },
+      { id: '7527111138', name: null },
+    ];
+    const result = optimizely.getAudienceIdsAndNames(audiences);
+
+    expect(result.audienceIds).toEqual(['7527111138', '7527562222']);
+    expect(result.audienceNames).toEqual(['Peaky Blinders']);
+  });
+
+  test('should safely handle undefined audience names', () => {
+    const audiences = [{ id: '123', name: undefined }];
+    const result = optimizely.getAudienceIdsAndNames(audiences);
+
+    expect(result.audienceIds).toEqual(['123']);
+    expect(result.audienceNames).toEqual([]);
+  });
+
+  test('should skip audiences with empty or null id', () => {
+    const audiences = [
+      { id: '123', name: 'Audience A' },
+      { id: null, name: 'Should Skip' },
+      { id: '', name: 'Also Skip' },
+    ];
+    const result = optimizely.getAudienceIdsAndNames(audiences);
+
+    expect(result.audienceIds).toEqual(['123']);
+    expect(result.audienceNames).toEqual(['Also Skip', 'Audience A', 'Should Skip']);
+  });
+
+  test('should return empty audienceNames array when all names are null', () => {
+    const audiences = [
+      { id: '1', name: null },
+      { id: '2', name: null },
+    ];
+    const result = optimizely.getAudienceIdsAndNames(audiences);
+
+    expect(result.audienceIds).toEqual(['1', '2']);
+    expect(result.audienceNames).toEqual([]);
+  });
+});
+
+describe('Optimizely sendDataToRudder', () => {
+  let optimizely;
+
+  beforeEach(() => {
+    optimizely = new Optimizely(defaultConfig, mockAnalytics, destinationInfo);
+  });
+
+  test('should call analytics.track with Experiment Viewed when sendExperimentTrack is true', () => {
+    const campaignState = {
+      id: 'campaign-123',
+      campaignName: 'Test Campaign',
+      isInCampaignHoldback: false,
+      audiences: [
+        { id: '7527562222', name: 'Audience One' },
+        { id: '7527562223', name: null },
+        { id: null, name: 'Audience Three' }
+      ],
+      experiment: { id: 'exp-1', name: 'Test Experiment', referrer: null },
+      variation: { id: 'var-1', name: 'Variation A' },
+    };
+
+    optimizely.sendDataToRudder(campaignState);
+
+    expect(mockAnalytics.track).toHaveBeenCalledWith(
+      'Experiment Viewed',
+      expect.objectContaining({
+        campaignName: 'Test Campaign',
+        campaignId: 'campaign-123',
+        experimentId: 'exp-1',
+        experimentName: 'Test Experiment',
+        variationName: 'Variation A',
+        variationId: 'var-1',
+        audienceId: '7527562222,7527562223',
+        audienceName: 'Audience One,Audience Three',
+        isInCampaignHoldback: false,
+      }),
+      {
+        integrations: { All: true },
+      },
+    );
+  });
+
+  test('should call analytics.identify when sendExperimentIdentify is true', () => {
+    const campaignState = {
+      id: 'campaign-123',
+      campaignName: 'Test Campaign',
+      isInCampaignHoldback: false,
+      audiences: [],
+      experiment: { id: 'exp-1', name: 'Test Experiment' },
+      variation: { id: 'var-1', name: 'Variation A' },
+    };
+
+    optimizely.sendDataToRudder(campaignState);
+
+    expect(mockAnalytics.identify).toHaveBeenCalledWith({
+      'Experiment: Test Experiment': 'Variation A',
+    });
+  });
+
+  test('should not throw when audiences contain null names', () => {
+    const campaignState = {
+      id: 'campaign-123',
+      campaignName: 'Test Campaign',
+      isInCampaignHoldback: false,
+      audiences: [
+        { id: '7527562222', name: 'Valid Audience' },
+        { id: '7527111138', name: null },
+      ],
+      experiment: { id: 'exp-1', name: 'Test Experiment' },
+      variation: { id: 'var-1', name: 'Variation A' },
+    };
+
+    expect(() => optimizely.sendDataToRudder(campaignState)).not.toThrow();
+    expect(mockAnalytics.track).toHaveBeenCalled();
+  });
+});
+
+describe('Optimizely track', () => {
+  let optimizely;
+
+  beforeEach(() => {
+    optimizely = new Optimizely(defaultConfig, mockAnalytics, destinationInfo);
+    window.optimizely = { push: jest.fn() };
+  });
+
+  test('should push event to optimizely with colons replaced by underscores', () => {
+    optimizely.track({
+      message: {
+        event: 'Custom: Event',
+        properties: { item: 'Test' },
+      },
+    });
+
+    expect(window.optimizely.push).toHaveBeenCalledWith({
+      type: 'event',
+      eventName: 'Custom_ Event',
+      tags: { item: 'Test' },
+    });
+  });
+
+  test('should convert revenue to cents for Order Completed when revenueOnlyOnOrderCompleted is true', () => {
+    optimizely.track({
+      message: {
+        event: 'Order Completed',
+        properties: { revenue: 25.5 },
+      },
+    });
+
+    expect(window.optimizely.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: expect.objectContaining({ revenue: 2550 }),
+      }),
+    );
+  });
+
+  test('should remove revenue for non-Order Completed events when revenueOnlyOnOrderCompleted is true', () => {
+    optimizely.track({
+      message: {
+        event: 'Product Viewed',
+        properties: { revenue: 50 },
+      },
+    });
+
+    const tags = window.optimizely.push.mock.calls[0][0].tags;
+    expect(tags.revenue).toBeUndefined();
+  });
+});
+
+describe('Optimizely page', () => {
+  let optimizely;
+
+  beforeEach(() => {
+    optimizely = new Optimizely(defaultConfig, mockAnalytics, destinationInfo);
+    window.optimizely = { push: jest.fn() };
+  });
+
+  test('should track categorized page when trackCategorizedPages is true', () => {
+    optimizely.page({
+      message: {
+        properties: { category: 'Products' },
+      },
+    });
+
+    expect(window.optimizely.push).toHaveBeenCalledWith({
+      type: 'event',
+      eventName: 'Viewed Products page',
+      tags: { category: 'Products' },
+    });
+  });
+
+  test('should track named page when trackNamedPages is true', () => {
+    optimizely.page({
+      message: {
+        name: 'Home',
+        properties: {},
+      },
+    });
+
+    expect(window.optimizely.push).toHaveBeenCalledWith({
+      type: 'event',
+      eventName: 'Viewed Home page',
+      tags: {},
+    });
+  });
+
+  test('should not track when category and name are missing', () => {
+    optimizely.page({
+      message: {
+        properties: {},
+      },
+    });
+
+    expect(window.optimizely.push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/analytics-js-integrations/__tests__/integrations/Optimizely/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Optimizely/browser.test.js
@@ -96,19 +96,20 @@ describe('Optimizely getAudienceIdsAndNames', () => {
     expect(result.audienceNames).toEqual(['Peaky Blinders', 'Trust Tree']);
   });
 
-  test('should safely handle null audience names without throwing (INT-5858)', () => {
+  test('should safely handle null audience names without throwing', () => {
     const audiences = [
       { id: '7527562222', name: 'Peaky Blinders' },
       { id: '7527111138', name: null },
+      { id: '7527562223' },
     ];
     const result = optimizely.getAudienceIdsAndNames(audiences);
 
-    expect(result.audienceIds).toEqual(['7527111138', '7527562222']);
+    expect(result.audienceIds).toEqual(['7527111138', '7527562222', '7527562223']);
     expect(result.audienceNames).toEqual(['Peaky Blinders']);
   });
 
   test('should safely handle undefined audience names', () => {
-    const audiences = [{ id: '123', name: undefined }];
+    const audiences = [{ id: '123', name: undefined }, null, undefined];
     const result = optimizely.getAudienceIdsAndNames(audiences);
 
     expect(result.audienceIds).toEqual(['123']);

--- a/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
@@ -2,6 +2,8 @@
 import { NAME, DISPLAY_NAME } from './constants';
 import Logger from '../../utils/logger';
 import { mapRudderPropsToOptimizelyProps } from './utils';
+import { isArray } from '../../utils/utils';
+import { isDefinedAndNotNullAndNotEmpty } from '../../utils/commonUtils';
 
 const logger = new Logger(DISPLAY_NAME);
 
@@ -51,23 +53,33 @@ class Optimizely {
     return undefined;
   };
 
+  getAudienceIdsAndNames = audiences => {
+    const audienceIds = [];
+    const audienceNames = [];
+    if (!isArray(audiences)) {
+      return { audienceIds, audienceNames };
+    }
+
+    for (const audience of audiences) {
+      const { id, name } = audience;
+      if (isDefinedAndNotNullAndNotEmpty(id)) {
+        audienceIds.push(id);
+      }
+      if (isDefinedAndNotNullAndNotEmpty(name)) {
+        audienceNames.push(name);
+      }
+    }
+    return {
+      audienceIds: audienceIds.sort((a, b) => a.localeCompare(b)),
+      audienceNames: audienceNames.sort((a, b) => a.localeCompare(b)),
+    };
+  };
+
   sendDataToRudder = campaignState => {
     const { experiment, variation } = campaignState;
     const context = { integrations: { All: true } };
     const { audiences, campaignName, id, isInCampaignHoldback } = campaignState;
-
-    // Reformatting this data structure into hash map so concatenating variation ids and names is easier later
-    const audiencesMap = {};
-    audiences.forEach(audience => {
-      audiencesMap[audience.id] = audience.name;
-    });
-
-    const audienceIds = Object.keys(audiencesMap)
-      .sort((a, b) => a.localeCompare(b))
-      .join();
-    const audienceNames = Object.values(audiencesMap)
-      .sort((a, b) => a.localeCompare(b))
-      .join(', ');
+    const { audienceIds, audienceNames } = this.getAudienceIdsAndNames(audiences);
 
     if (this.sendExperimentTrack) {
       let props = {
@@ -77,8 +89,8 @@ class Optimizely {
         experimentName: experiment.name,
         variationName: variation.name,
         variationId: variation.id,
-        audienceId: audienceIds, // eg. '7527562222,7527111138'
-        audienceName: audienceNames, // eg. 'Peaky Blinders, Trust Tree'
+        audienceId: audienceIds.join(','), // eg. '7527562222,7527111138'
+        audienceName: audienceNames.join(','), // eg. 'Peaky Blinders, Trust Tree'
         isInCampaignHoldback,
       };
 
@@ -123,7 +135,10 @@ class Optimizely {
           sendCampaignData(campaignState);
         }
       } catch (e) {
-        logger.error('Page loaded without Optimizely.');
+        logger.error(
+          `Optimizely not initialized due to transformation error:`,
+          e.message,
+        );
       }
     };
 

--- a/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
@@ -122,9 +122,18 @@ class Optimizely {
   };
 
   initOptimizelyIntegration(referrerOverride, sendCampaignData) {
+    const getState = () => {
+      try {
+        return window?.optimizely?.get('state');
+      } catch (e) {
+        logger.error("Couldn't successfully get state from Optimizely", e);
+        return undefined;
+      }
+    };
+
     const newActiveCampaign = (id, referrer) => {
       try {
-        const state = window?.optimizely?.get('state');
+        const state = getState();
         if (state) {
           const activeCampaigns = state.getCampaignStates({
             isActive: true,
@@ -139,13 +148,7 @@ class Optimizely {
     };
 
     const checkReferrer = () => {
-      let state;
-      try {
-        state = window?.optimizely?.get('state');
-      } catch (e) {
-        logger.error("Couldn't successfully get state when checking referrer from Optimizely", e);
-        state = undefined;
-      }
+      const state = getState();
       if (!state) {
         return undefined;
       }
@@ -173,12 +176,7 @@ class Optimizely {
 
     const registerCurrentlyActiveCampaigns = () => {
       window.optimizely = window.optimizely || [];
-      let state;
-      try {
-        state = window?.optimizely?.get('state');
-      } catch (e) {
-        state = undefined;
-      }
+      const state = getState();
       if (state) {
         const referrer = checkReferrer();
         const activeCampaigns = state.getCampaignStates({

--- a/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
@@ -127,7 +127,6 @@ class Optimizely {
         return window?.optimizely?.get('state');
       } catch (e) {
         logger.error("Couldn't successfully get state from Optimizely", e);
-        return undefined;
       }
     };
 

--- a/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
@@ -135,7 +135,7 @@ class Optimizely {
         }
       } catch (e) {
         logger.error(
-          `Optimizely not initialized due to transformation error:`,
+          "Optimizely not initialized due to transformation error: ",
           e.message,
         );
       }

--- a/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
@@ -134,10 +134,7 @@ class Optimizely {
           sendCampaignData(campaignState);
         }
       } catch (e) {
-        logger.error(
-          "Optimizely not initialized due to transformation error: ",
-          e.message,
-        );
+        logger.error("Couldn't successfully process active campaign data from Optimizely", e);
       }
     };
 
@@ -146,6 +143,7 @@ class Optimizely {
       try {
         state = window?.optimizely?.get('state');
       } catch (e) {
+        logger.error("Couldn't successfully get state when checking referrer from Optimizely", e);
         state = undefined;
       }
       if (!state) {

--- a/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Optimizely/browser.js
@@ -61,12 +61,11 @@ class Optimizely {
     }
 
     for (const audience of audiences) {
-      const { id, name } = audience;
-      if (isDefinedAndNotNullAndNotEmpty(id)) {
-        audienceIds.push(id);
+      if (isDefinedAndNotNullAndNotEmpty(audience?.id)) {
+        audienceIds.push(audience.id);
       }
-      if (isDefinedAndNotNullAndNotEmpty(name)) {
-        audienceNames.push(name);
+      if (isDefinedAndNotNullAndNotEmpty(audience?.name)) {
+        audienceNames.push(audience.name);
       }
     }
     return {


### PR DESCRIPTION
## PR Description

While building the audience name, an error occurred, which caused the integration to fail during initialization.
In this PR, we added a separate function to safely fetch the audience name

## Linear task (optional)

[Resolves INT-5858](https://linear.app/rudderstack/issue/INT-5858/handle-null-audience-names-from-optimizely-in-integration)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and resilience for Optimizely integration state management.
  * Enhanced audience data processing with better handling of edge cases.

* **Tests**
  * Added comprehensive test coverage for Optimizely browser integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->