### PR TITLE
chore: publish only affected packages to NPM

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -223,7 +223,6 @@ jobs:
           echo "beta_identifier_for_automation_tests=pr-${{ needs.find-pr.outputs.pr_number }}-$SHA_SHORT" >> $GITHUB_OUTPUT
 
   deploy-cdn:
-    if: false
     name: Deploy to CDN
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
@@ -261,7 +260,6 @@ jobs:
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 
   deploy-sanity-suite:
-    if: false
     name: Deploy sanity suite
     needs: [get-deploy-inputs]
     uses: ./.github/workflows/deploy-sanity-suite.yml
@@ -282,7 +280,6 @@ jobs:
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 
   run-e2e-regression-test-suites:
-    if: false
     uses: ./.github/workflows/run-e2e-regression-test-suites.yml
     name: Run E2E Regression Test Suites
     needs: [get-deploy-inputs, deploy-sanity-suite, deploy-cdn]

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -42,6 +42,7 @@ jobs:
     outputs:
       pr_number: ${{ steps.pr-info.outputs.pr_number }}
       pr_url: ${{ steps.pr-info.outputs.pr_url }}
+      pr_base_branch: ${{ steps.pr-info.outputs.pr_base_branch }}
       force_deploy_mode: ${{ steps.check-force-deploy.outputs.force_deploy_mode }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -100,6 +101,7 @@ jobs:
 
               core.setOutput('pr_number', prNumber);
               core.setOutput('pr_url', prUrl);
+              core.setOutput('pr_base_branch', pr.base.ref);
             } else {
               const allowedBranches = 'develop, main, hotfix/*, release/*, hotfix-release/*';
               core.setFailed(`No open PR found for branch ${branch} targeting an allowed base branch (${allowedBranches})`);
@@ -244,13 +246,13 @@ jobs:
   deploy-npm:
     name: Deploy to NPM
     uses: ./.github/workflows/deploy-npm.yml
-    needs: get-deploy-inputs
+    needs: [find-pr, get-deploy-inputs]
     if: ${{ inputs.deploy_to_npm }}
     with:
       environment: beta
       bugsnag_release_stage: beta
       version_suffix: ${{ needs.get-deploy-inputs.outputs.version_suffix }}
-      base_version: develop
+      base_version: ${{ needs.find-pr.outputs.pr_base_branch }}
       head_version: ${{ github.ref_name }}
       trigger_source: ${{ needs.get-deploy-inputs.outputs.trigger_source }}
     secrets:

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -221,6 +221,7 @@ jobs:
           echo "beta_identifier_for_automation_tests=pr-${{ needs.find-pr.outputs.pr_number }}-$SHA_SHORT" >> $GITHUB_OUTPUT
 
   deploy-cdn:
+    if: false
     name: Deploy to CDN
     uses: ./.github/workflows/deploy.yml
     needs: get-deploy-inputs
@@ -258,6 +259,7 @@ jobs:
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 
   deploy-sanity-suite:
+    if: false
     name: Deploy sanity suite
     needs: [get-deploy-inputs]
     uses: ./.github/workflows/deploy-sanity-suite.yml
@@ -278,6 +280,7 @@ jobs:
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID_NON_PROD }}
 
   run-e2e-regression-test-suites:
+    if: false
     uses: ./.github/workflows/run-e2e-regression-test-suites.yml
     name: Run E2E Regression Test Suites
     needs: [get-deploy-inputs, deploy-sanity-suite, deploy-cdn]

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -56,7 +56,7 @@ jobs:
   determine-affected:
     name: Determine Affected Publishable Projects
     runs-on: ubuntu-latest
-    if: ${{ github.workflow_ref != '' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) }}
+    if: ${{ github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) }}
     outputs:
       projects: ${{ steps.affected-projects.outputs.projects }}
       base_version: ${{ steps.resolve-versions.outputs.base_version }}
@@ -77,11 +77,16 @@ jobs:
         id: resolve-versions
         run: |
           if [ -n "${{ inputs.base_version }}" ] && [ -n "${{ inputs.head_version }}" ]; then
-            BASE_VERSION=${{ inputs.base_version }}
-            HEAD_VERSION=${{ inputs.head_version }}
+            BASE_VERSION="${{ inputs.base_version }}"
+            HEAD_VERSION="${{ inputs.head_version }}"
           else
             HEAD_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 1)
             BASE_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 2 | awk 'NR == 2 { print $1 }')
+          fi
+
+          if [ -z "$BASE_VERSION" ]; then
+            echo "::warning::No previous v3* tag found; defaulting BASE_VERSION to HEAD~1"
+            BASE_VERSION="HEAD~1"
           fi
 
           echo "Base version: $BASE_VERSION"
@@ -104,32 +109,48 @@ jobs:
       - name: Determine affected publishable projects
         id: affected-projects
         run: |
-          BASE_VERSION=${{ steps.resolve-versions.outputs.base_version }}
-          HEAD_VERSION=${{ steps.resolve-versions.outputs.head_version }}
+          BASE_VERSION="${{ steps.resolve-versions.outputs.base_version }}"
+          HEAD_VERSION="${{ steps.resolve-versions.outputs.head_version }}"
 
           # Get affected projects between base and head versions
-          AFFECTED=$(npx nx show projects --affected --base="$BASE_VERSION" --head="$HEAD_VERSION" 2>/dev/null || echo "")
+          AFFECTED=""
+          if ! NX_OUTPUT=$(npx nx show projects --affected --base="$BASE_VERSION" --head="$HEAD_VERSION" 2>&1); then
+            echo "::warning::Failed to determine affected projects with nx:"
+            echo "$NX_OUTPUT"
+          else
+            AFFECTED="$NX_OUTPUT"
+          fi
 
           echo "All affected projects:"
           echo "$AFFECTED"
 
           # Filter to only publishable (non-private) packages
           PUBLISHABLE_PROJECTS=""
-          for project in $AFFECTED; do
-            # Find the package.json for this project
-            PROJECT_ROOT=$(npx nx show project "$project" --json 2>/dev/null | jq -r '.root')
-            if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/package.json" ]; then
-              IS_PRIVATE=$(jq -r '.private // false' "$PROJECT_ROOT/package.json")
-              if [ "$IS_PRIVATE" != "true" ]; then
-                echo "Affected publishable project: $project"
-                if [ -n "$PUBLISHABLE_PROJECTS" ]; then
-                  PUBLISHABLE_PROJECTS="$PUBLISHABLE_PROJECTS,$project"
-                else
-                  PUBLISHABLE_PROJECTS="$project"
-                fi
+          while IFS= read -r project; do
+            [ -z "$project" ] && continue
+
+            PROJECT_INFO=$(npx nx show project "$project" --json 2>&1)
+            if [ $? -ne 0 ]; then
+              echo "::warning::Failed to get nx config for project '$project': $PROJECT_INFO"
+              continue
+            fi
+
+            PROJECT_ROOT=$(echo "$PROJECT_INFO" | jq -r '.root // empty')
+            if [ -z "$PROJECT_ROOT" ] || [ ! -f "$PROJECT_ROOT/package.json" ]; then
+              echo "::warning::No package.json found for project '$project' at '$PROJECT_ROOT'"
+              continue
+            fi
+
+            IS_PRIVATE=$(jq -r '.private // "false"' "$PROJECT_ROOT/package.json")
+            if [ "$IS_PRIVATE" != "true" ]; then
+              echo "Affected publishable project: $project"
+              if [ -n "$PUBLISHABLE_PROJECTS" ]; then
+                PUBLISHABLE_PROJECTS="$PUBLISHABLE_PROJECTS,$project"
+              else
+                PUBLISHABLE_PROJECTS="$project"
               fi
             fi
-          done
+          done <<< "$AFFECTED"
 
           echo "Publishable affected projects: $PUBLISHABLE_PROJECTS"
           echo "projects=$PUBLISHABLE_PROJECTS" >> $GITHUB_OUTPUT
@@ -137,7 +158,7 @@ jobs:
   deploy:
     name: Deploy to NPM
     needs: determine-affected
-    if: needs.determine-affected.outputs.projects != ''
+    if: needs.determine-affected.result == 'success' && needs.determine-affected.outputs.projects != ''
     # As we publish the NPM package with provenance, we must use GitHub-hosted runners
     runs-on: ubuntu-latest
 
@@ -225,6 +246,7 @@ jobs:
         env:
           HUSKY: 0
           NPM_CONFIG_PROVENANCE: true
+          PUBLISH_PROJECTS: ${{ needs.determine-affected.outputs.projects }}
         run: |
           # Remove unnecessary fields from package.json before publishing
           ./scripts/make-package-json-publish-ready.sh
@@ -234,10 +256,10 @@ jobs:
             TAG_OPTION="--tag=beta"
           fi
 
-          echo "Publishing projects: ${{ needs.determine-affected.outputs.projects }}"
+          echo "Publishing projects: $PUBLISH_PROJECTS"
           echo "DATE=$(date)" >> $GITHUB_ENV
 
-          npx nx release publish --verbose --projects=${{ needs.determine-affected.outputs.projects }} $TAG_OPTION
+          npx nx release publish --verbose --projects="$PUBLISH_PROJECTS" $TAG_OPTION
 
           # Reset the changes made to package.json
           git reset --hard

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -78,9 +78,25 @@ jobs:
           INPUT_BASE_VERSION: ${{ inputs.base_version }}
           INPUT_HEAD_VERSION: ${{ inputs.head_version }}
         run: |
+          # Resolve a ref to a locally available git reference.
+          # Branch names from inputs (e.g. "develop") only exist as remote refs
+          # (origin/develop) after checkout, so we need to resolve them.
+          resolve_ref() {
+            local ref="$1"
+            # Already resolvable locally (tag, SHA, HEAD~N, etc.)
+            if git rev-parse --verify "$ref" >/dev/null 2>&1; then
+              echo "$ref"
+            # Try as a remote branch
+            elif git rev-parse --verify "origin/$ref" >/dev/null 2>&1; then
+              echo "origin/$ref"
+            else
+              echo "$ref"
+            fi
+          }
+
           if [ -n "$INPUT_BASE_VERSION" ] && [ -n "$INPUT_HEAD_VERSION" ]; then
-            BASE_VERSION="$INPUT_BASE_VERSION"
-            HEAD_VERSION="$INPUT_HEAD_VERSION"
+            BASE_VERSION=$(resolve_ref "$INPUT_BASE_VERSION")
+            HEAD_VERSION=$(resolve_ref "$INPUT_HEAD_VERSION")
           else
             TAGS=$(git tag -l "v3*" --sort=-version:refname)
             HEAD_VERSION=$(echo "$TAGS" | head -n 1)

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -71,7 +71,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.sha }}
 
       - name: Resolve base and head versions
         id: resolve-versions

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -56,7 +56,7 @@ jobs:
   determine-affected:
     name: Determine Affected Publishable Projects
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) }}
+    if: ${{ github.workflow_ref != '' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) }}
     outputs:
       projects: ${{ steps.affected-projects.outputs.projects }}
       base_version: ${{ steps.resolve-versions.outputs.base_version }}

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -75,13 +75,22 @@ jobs:
 
       - name: Resolve base and head versions
         id: resolve-versions
+        env:
+          INPUT_BASE_VERSION: ${{ inputs.base_version }}
+          INPUT_HEAD_VERSION: ${{ inputs.head_version }}
         run: |
-          if [ -n "${{ inputs.base_version }}" ] && [ -n "${{ inputs.head_version }}" ]; then
-            BASE_VERSION="${{ inputs.base_version }}"
-            HEAD_VERSION="${{ inputs.head_version }}"
+          if [ -n "$INPUT_BASE_VERSION" ] && [ -n "$INPUT_HEAD_VERSION" ]; then
+            BASE_VERSION="$INPUT_BASE_VERSION"
+            HEAD_VERSION="$INPUT_HEAD_VERSION"
           else
-            HEAD_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 1)
-            BASE_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 2 | awk 'NR == 2 { print $1 }')
+            TAGS=$(git tag -l "v3*" --sort=-version:refname)
+            HEAD_VERSION=$(echo "$TAGS" | head -n 1)
+            BASE_VERSION=$(echo "$TAGS" | head -n 2 | awk 'NR == 2 { print $1 }')
+          fi
+
+          if [ -z "$HEAD_VERSION" ]; then
+            echo "::warning::No v3* tag found; defaulting HEAD_VERSION to HEAD"
+            HEAD_VERSION="HEAD"
           fi
 
           if [ -z "$BASE_VERSION" ]; then

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -53,11 +53,93 @@ env:
   NODE_OPTIONS: '--no-warnings'
 
 jobs:
-  deploy:
-    name: Deploy to NPM
-    # As we publish the NPM package with provenance, we must use GitHub-hosted runners
+  determine-affected:
+    name: Determine Affected Publishable Projects
     runs-on: ubuntu-latest
     if: ${{ github.workflow_ref != '' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) }}
+    outputs:
+      projects: ${{ steps.affected-projects.outputs.projects }}
+      base_version: ${{ steps.resolve-versions.outputs.base_version }}
+      head_version: ${{ steps.resolve-versions.outputs.head_version }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Resolve base and head versions
+        id: resolve-versions
+        run: |
+          if [ -n "${{ inputs.base_version }}" ] && [ -n "${{ inputs.head_version }}" ]; then
+            BASE_VERSION=${{ inputs.base_version }}
+            HEAD_VERSION=${{ inputs.head_version }}
+          else
+            HEAD_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 1)
+            BASE_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 2 | awk 'NR == 2 { print $1 }')
+          fi
+
+          echo "Base version: $BASE_VERSION"
+          echo "Head version: $HEAD_VERSION"
+
+          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
+          echo "head_version=$HEAD_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        env:
+          HUSKY: 0
+        run: npm ci --ignore-scripts
+
+      - name: Determine affected publishable projects
+        id: affected-projects
+        run: |
+          BASE_VERSION=${{ steps.resolve-versions.outputs.base_version }}
+          HEAD_VERSION=${{ steps.resolve-versions.outputs.head_version }}
+
+          # Get affected projects between base and head versions
+          AFFECTED=$(npx nx show projects --affected --base="$BASE_VERSION" --head="$HEAD_VERSION" 2>/dev/null || echo "")
+
+          echo "All affected projects:"
+          echo "$AFFECTED"
+
+          # Filter to only publishable (non-private) packages
+          PUBLISHABLE_PROJECTS=""
+          for project in $AFFECTED; do
+            # Find the package.json for this project
+            PROJECT_ROOT=$(npx nx show project "$project" --json 2>/dev/null | jq -r '.root')
+            if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/package.json" ]; then
+              IS_PRIVATE=$(jq -r '.private // false' "$PROJECT_ROOT/package.json")
+              if [ "$IS_PRIVATE" != "true" ]; then
+                echo "Affected publishable project: $project"
+                if [ -n "$PUBLISHABLE_PROJECTS" ]; then
+                  PUBLISHABLE_PROJECTS="$PUBLISHABLE_PROJECTS,$project"
+                else
+                  PUBLISHABLE_PROJECTS="$project"
+                fi
+              fi
+            fi
+          done
+
+          echo "Publishable affected projects: $PUBLISHABLE_PROJECTS"
+          echo "projects=$PUBLISHABLE_PROJECTS" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to NPM
+    needs: determine-affected
+    if: needs.determine-affected.outputs.projects != ''
+    # As we publish the NPM package with provenance, we must use GitHub-hosted runners
+    runs-on: ubuntu-latest
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -139,25 +221,6 @@ jobs:
           npm run build:package
           npm run build:package:modern
 
-      - name: Get the monorepo versions for the base and head versions
-        run: |
-          # If both base and head versions are provided, use them
-          if [ -n "${{ inputs.base_version }}" ] && [ -n "${{ inputs.head_version }}" ]; then
-            LAST_VERSION=${{ inputs.base_version }}
-            CURRENT_VERSION=${{ inputs.head_version }}
-          else
-            # Otherwise, get the two latest monorepo versions
-            CURRENT_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 1)
-            LAST_VERSION=$(git tag -l "v3*" --sort=-version:refname | head -n 2 | awk 'NR == 2 { print $1 }')
-          fi
-
-          echo "Current version: $CURRENT_VERSION"
-          echo "Previous version: $LAST_VERSION"
-
-          echo "current_monorepo_version=$(echo $CURRENT_VERSION)" >> $GITHUB_ENV
-          echo "last_monorepo_version=$(echo $LAST_VERSION)" >> $GITHUB_ENV
-          echo "DATE=$(date)" >> $GITHUB_ENV
-
       - name: Publish package to NPM
         env:
           HUSKY: 0
@@ -171,7 +234,10 @@ jobs:
             TAG_OPTION="--tag=beta"
           fi
 
-          npx nx release publish --verbose --projects=@rudderstack/analytics-js $TAG_OPTION
+          echo "Publishing projects: ${{ needs.determine-affected.outputs.projects }}"
+          echo "DATE=$(date)" >> $GITHUB_ENV
+
+          npx nx release publish --verbose --projects=${{ needs.determine-affected.outputs.projects }} $TAG_OPTION
 
           # Reset the changes made to package.json
           git reset --hard

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -139,11 +139,11 @@ jobs:
           # Get affected projects between base and head versions
           AFFECTED=""
           if ! NX_OUTPUT=$(npx nx show projects --affected --base="$BASE_VERSION" --head="$HEAD_VERSION" 2>&1); then
-            echo "::warning::Failed to determine affected projects with nx:"
+            echo "::error::Failed to determine affected projects with nx:"
             echo "$NX_OUTPUT"
-          else
-            AFFECTED="$NX_OUTPUT"
+            exit 1
           fi
+          AFFECTED="$NX_OUTPUT"
 
           echo "All affected projects:"
           echo "$AFFECTED"

--- a/packages/analytics-js/src/index.ts
+++ b/packages/analytics-js/src/index.ts
@@ -34,4 +34,3 @@ declare global {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
   }
 }
-

--- a/packages/analytics-js/src/index.ts
+++ b/packages/analytics-js/src/index.ts
@@ -34,3 +34,4 @@ declare global {
     rudderanalytics: RudderAnalytics | RudderAnalyticsPreloader | undefined;
   }
 }
+


### PR DESCRIPTION
## Summary
- Split `deploy-npm` workflow into two jobs: **`determine-affected`** and **`deploy`**
- The `determine-affected` job uses `nx show projects --affected` to detect changed packages between base and head versions, then filters to only non-private (publishable) packages
- The `deploy` job is gated on the output — it only runs when there are affected publishable packages
- Previously, `nx release publish` was hardcoded to `--projects=@rudderstack/analytics-js`; now it dynamically publishes only the affected packages

## Changes to `deploy-npm.yml`
- **New `determine-affected` job**: Resolves base/head versions, installs dependencies, runs `nx show projects --affected`, and filters to publishable packages
- **Ref resolution**: A `resolve_ref` helper converts branch names (e.g. `develop`) to their `origin/` counterparts since `actions/checkout` only creates local refs for the checked-out branch
- **Empty guards**: Defaults `HEAD_VERSION` to `HEAD` and `BASE_VERSION` to `HEAD~1` when no v3* tags exist
- **Security hardening**: Workflow inputs routed through `env` vars to prevent template expression injection in shell contexts; publish projects value passed via `env` block to prevent script injection in `run` blocks
- **Gated deploy job**: `deploy` job only runs when `determine-affected` succeeds and produces a non-empty projects list

## Changes to `deploy-beta.yml`
- **Dynamic base version**: Instead of hardcoding `base_version: develop`, the `find-pr` job now outputs `pr_base_branch` (the PR's target branch) and passes it to `deploy-npm`
- **Multi-branch PR support**: Expanded PR search to support PRs targeting `develop`, `main`, `hotfix/*`, `release/*`, and `hotfix-release/*` (from PR #2790)

## Test plan
- [x] Verify `determine-affected` job correctly identifies affected publishable packages
- [ ] Verify `deploy` job is skipped when no publishable packages are affected
- [ ] Verify branch name refs (e.g. `develop`) resolve correctly to `origin/develop` for nx affected diff
- [ ] Verify tag-based refs (e.g. `v3.x.x`) resolve correctly without `origin/` prefix
- [ ] Test beta deploy with a PR targeting `develop` branch
- [ ] Test beta deploy with a PR targeting a non-`develop` base branch