### PR TITLE
chore: fix Slack release thread notifications

### DIFF
--- a/.github/actions/release-thread-integration/action.yml
+++ b/.github/actions/release-thread-integration/action.yml
@@ -250,7 +250,7 @@ runs:
           {
             "channel": "${{ steps.extract-info.outputs.channel_id }}",
             "thread_ts": "${{ steps.extract-info.outputs.thread_ts }}",
-            "text": "${{ inputs.title }}: <${{ steps.extract-message-url.outputs.message_url }}|${{ inputs.link_text }}>\n\nCC: ${{ inputs.slack_slugs }}",
+            "text": "${{ inputs.title }}\n<${{ steps.extract-message-url.outputs.message_url }}|${{ inputs.link_text }}>\n\nCC: ${{ inputs.slack_slugs }}",
             "blocks": [
               {
                 "type": "section",

--- a/.github/actions/release-thread-integration/action.yml
+++ b/.github/actions/release-thread-integration/action.yml
@@ -11,11 +11,15 @@ inputs:
   slack_bot_token:
     description: 'Slack bot token for posting messages'
     required: true
-  deployment_name:
-    description: 'Name of the deployment (e.g., "JS SDK", "Sanity Suite", "NPM Package")'
+  title:
+    description: 'Title for the Slack message (e.g., ":white_check_mark: JS SDK deployment completed")'
     required: true
+  link_text:
+    description: 'Text for the Slack message link (e.g., "View deployment details", "View test results")'
+    required: false
+    default: 'View details'
   slack_message_url:
-    description: 'Slack message URL for the deployment'
+    description: 'Slack message URL'
     required: false
   slack_api_response:
     description: 'JSON response from Slack API containing message details'
@@ -246,13 +250,13 @@ runs:
           {
             "channel": "${{ steps.extract-info.outputs.channel_id }}",
             "thread_ts": "${{ steps.extract-info.outputs.thread_ts }}",
-            "text": ":white_check_mark: ${{ inputs.deployment_name }} deployment completed: <${{ steps.extract-message-url.outputs.message_url }}|View deployment details>\n\nCC: ${{ inputs.slack_slugs }}",
+            "text": "${{ inputs.title }}: <${{ steps.extract-message-url.outputs.message_url }}|${{ inputs.link_text }}>\n\nCC: ${{ inputs.slack_slugs }}",
             "blocks": [
               {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": ":white_check_mark: *${{ inputs.deployment_name }} deployment completed*${{ inputs.custom_message != '' && format('\n\n{0}', inputs.custom_message) || '' }}\n<${{ steps.extract-message-url.outputs.message_url }}|View deployment details>\n\nCC: ${{ inputs.slack_slugs }}"
+                  "text": "*${{ inputs.title }}*${{ inputs.custom_message != '' && format('\n\n{0}', inputs.custom_message) || '' }}\n<${{ steps.extract-message-url.outputs.message_url }}|${{ inputs.link_text }}>\n\nCC: ${{ inputs.slack_slugs }}"
                 }
               }
             ]

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -399,7 +399,8 @@ jobs:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}
           release_ticket_id: ${{ inputs.release_ticket_id }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          deployment_name: 'JS SDK NPM Package'
+          title: ':white_check_mark: JS SDK NPM Package deployment completed'
+          link_text: 'View deployment details'
           slack_api_response: ${{ steps.slack.outputs.response }}
 
       - name: Send message to Slack channel for Service Worker

--- a/.github/workflows/deploy-sanity-suite.yml
+++ b/.github/workflows/deploy-sanity-suite.yml
@@ -233,6 +233,7 @@ jobs:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}
           release_ticket_id: ${{ inputs.release_ticket_id }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          deployment_name: 'Sanity Suite'
+          title: ':white_check_mark: Sanity Suite deployment completed'
+          link_text: 'View deployment details'
           slack_api_response: ${{ steps.slack.outputs.response }}
           slack_slugs: '<!subteam^S0555JBV36D> <!subteam^S03SW7DM8P3>'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -363,7 +363,8 @@ jobs:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}
           release_ticket_id: ${{ inputs.release_ticket_id }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          deployment_name: 'JS SDK Browser Package'
+          title: ':white_check_mark: JS SDK Browser Package deployment completed'
+          link_text: 'View deployment details'
           slack_api_response: ${{ steps.slack.outputs.response }}
           custom_message: ${{ inputs.environment == 'production' && 'Proceed to perform post-release testing of your changes.' || inputs.environment == 'staging' && 'Proceed to perform pre-release testing of your changes.' || '' }}
 

--- a/.github/workflows/run-e2e-regression-test-suites.yml
+++ b/.github/workflows/run-e2e-regression-test-suites.yml
@@ -159,7 +159,8 @@ jobs:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}
           release_ticket_id: ${{ inputs.release_ticket_id }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          deployment_name: ${{ format('{0} Sanity E2E Regression Tests', steps.extract-sanity-results.outputs.test_success == 'true' && ':white_check_mark:' || ':warning:') }}
+          title: ${{ format('{0} Sanity E2E Regression Tests completed', steps.extract-sanity-results.outputs.test_success == 'true' && ':white_check_mark:' || ':x:') }}
+          link_text: 'View test results'
           slack_message_url: ${{ steps.extract-sanity-results.outputs.slack_message_url }}
           custom_message: ${{ steps.extract-sanity-results.outputs.test_success == 'true' && 'All tests passed successfully. Proceed to the next step.' || 'There are some test failures. Please review them and proceed to the next step.' }}
 
@@ -244,6 +245,7 @@ jobs:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}
           release_ticket_id: ${{ inputs.release_ticket_id }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          deployment_name: ${{ format('{0} Full E2E Regression Tests', steps.extract-e2e-results.outputs.test_success == 'true' && ':white_check_mark:' || ':warning:') }}
+          title: ${{ format('{0} Full E2E Regression Tests completed', steps.extract-e2e-results.outputs.test_success == 'true' && ':white_check_mark:' || ':x:') }}
+          link_text: 'View test results'
           slack_message_url: ${{ steps.extract-e2e-results.outputs.slack_message_url }}
           custom_message: ${{ steps.extract-e2e-results.outputs.test_success == 'true' && 'All tests passed successfully. Proceed to the next step.' || 'There are some test failures. Please review them and proceed to the next step.' }}

--- a/.github/workflows/run-e2e-regression-test-suites.yml
+++ b/.github/workflows/run-e2e-regression-test-suites.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Extract sanity test results
         id: extract-sanity-results
         continue-on-error: true
-        if: steps.run_sanity_tests.outputs.has_outputs == 'true'
+        if: always() && steps.run_sanity_tests.outputs.has_outputs == 'true'
         run: |
           # Extract all fields from job outputs
           slack_message_url=$(echo '${{ steps.run_sanity_tests.outputs.job_outputs }}' | jq -r '.slack_message_url')
@@ -153,7 +153,7 @@ jobs:
 
       - name: Post sanity test results to release thread
         continue-on-error: true
-        if: ${{ inputs.monorepo_release_version != '' && inputs.release_ticket_id != '' && steps.extract-sanity-results.outputs.slack_message_url != '' }}
+        if: ${{ always() && inputs.monorepo_release_version != '' && inputs.release_ticket_id != '' && steps.extract-sanity-results.outputs.slack_message_url != '' }}
         uses: ./.github/actions/release-thread-integration
         with:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}
@@ -219,7 +219,7 @@ jobs:
 
       - name: Extract E2E test results
         id: extract-e2e-results
-        if: steps.run_e2e_tests.outputs.has_outputs == 'true'
+        if: always() && steps.run_e2e_tests.outputs.has_outputs == 'true'
         run: |
           # Extract all fields from job outputs
           slack_message_url=$(echo '${{ steps.run_e2e_tests.outputs.job_outputs }}' | jq -r '.slack_message_url')
@@ -238,7 +238,7 @@ jobs:
 
       - name: Post E2E test results to release thread
         continue-on-error: true
-        if: ${{ inputs.monorepo_release_version != '' && inputs.release_ticket_id != '' && steps.extract-e2e-results.outputs.slack_message_url != '' }}
+        if: ${{ always() && inputs.monorepo_release_version != '' && inputs.release_ticket_id != '' && steps.extract-e2e-results.outputs.slack_message_url != '' }}
         uses: ./.github/actions/release-thread-integration
         with:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}

--- a/.github/workflows/run-e2e-regression-test-suites.yml
+++ b/.github/workflows/run-e2e-regression-test-suites.yml
@@ -137,7 +137,7 @@ jobs:
         if: always() && steps.run_sanity_tests.outputs.has_outputs == 'true'
         run: |
           # Extract all fields from job outputs
-          slack_message_url=$(echo '${{ steps.run_sanity_tests.outputs.job_outputs }}' | jq -r '.slack_message_url')
+          slack_message_url=$(echo '${{ steps.run_sanity_tests.outputs.job_outputs }}' | jq -r '.slack_message_url // ""')
           test_passed=$(echo '${{ steps.run_sanity_tests.outputs.job_outputs }}' | jq -r '.test_status.passed // ""')
           test_total=$(echo '${{ steps.run_sanity_tests.outputs.job_outputs }}' | jq -r '.test_status.total // ""')
           test_percentage=$(echo '${{ steps.run_sanity_tests.outputs.job_outputs }}' | jq -r '.test_status.percentage // ""')
@@ -153,7 +153,7 @@ jobs:
 
       - name: Post sanity test results to release thread
         continue-on-error: true
-        if: ${{ always() && inputs.monorepo_release_version != '' && inputs.release_ticket_id != '' && steps.extract-sanity-results.outputs.slack_message_url != '' }}
+        if: ${{ !cancelled() && always() && inputs.monorepo_release_version != '' && inputs.release_ticket_id != '' && steps.extract-sanity-results.outputs.slack_message_url != '' }}
         uses: ./.github/actions/release-thread-integration
         with:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}
@@ -220,10 +220,11 @@ jobs:
 
       - name: Extract E2E test results
         id: extract-e2e-results
+        continue-on-error: true
         if: always() && steps.run_e2e_tests.outputs.has_outputs == 'true'
         run: |
           # Extract all fields from job outputs
-          slack_message_url=$(echo '${{ steps.run_e2e_tests.outputs.job_outputs }}' | jq -r '.slack_message_url')
+          slack_message_url=$(echo '${{ steps.run_e2e_tests.outputs.job_outputs }}' | jq -r '.slack_message_url // ""')
           test_passed=$(echo '${{ steps.run_e2e_tests.outputs.job_outputs }}' | jq -r '.test_status.passed // ""')
           test_total=$(echo '${{ steps.run_e2e_tests.outputs.job_outputs }}' | jq -r '.test_status.total // ""')
           test_percentage=$(echo '${{ steps.run_e2e_tests.outputs.job_outputs }}' | jq -r '.test_status.percentage // ""')
@@ -239,7 +240,7 @@ jobs:
 
       - name: Post E2E test results to release thread
         continue-on-error: true
-        if: ${{ always() && inputs.monorepo_release_version != '' && inputs.release_ticket_id != '' && steps.extract-e2e-results.outputs.slack_message_url != '' }}
+        if: ${{ !cancelled() && always() && inputs.monorepo_release_version != '' && inputs.release_ticket_id != '' && steps.extract-e2e-results.outputs.slack_message_url != '' }}
         uses: ./.github/actions/release-thread-integration
         with:
           monorepo_release_version: ${{ inputs.monorepo_release_version }}


### PR DESCRIPTION
## Summary
- Fix Slack notifications not being sent when regression tests fail
- Make the release-thread-integration action generic and caller-controlled
- Fix duplicate icon in Slack notification messages

## Changes

### Notification on test failure (`run-e2e-regression-test-suites.yml`)
- Add `always()` to the `if` conditions of result extraction and Slack notification steps
- Previously, when the test step failed (non-zero exit), GitHub Actions skipped all subsequent steps by default, silently dropping Slack notifications
- The `workflow-utils` composite action already retrieves outputs with `if: always()`, so the data was available but not consumed

### Generic release-thread-integration action
- Replace `deployment_name` input with `title` and `link_text` inputs
- Remove hardcoded `:white_check_mark:` icon and `"deployment completed"` / `"View deployment details"` text from the action template
- Callers now control the full message content, making the action reusable for non-deployment contexts like test results

### Updated callers
- **Regression tests**: Use `:white_check_mark:` / `:x:` icons with `"View test results"` link text
- **Deploy workflows** (CDN, NPM, Sanity Suite): Use `:white_check_mark:` icon with `"View deployment details"` link text

## Test plan
- [ ] Trigger a regression test run where tests fail and verify Slack notification is sent with :x: icon
- [ ] Trigger a regression test run where tests pass and verify Slack notification uses :white_check_mark: icon
- [ ] Verify deployment workflows still send correct notifications with proper icon and link text
- [ ] Verify no duplicate icons appear in any Slack messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure test result extraction and posting always evaluate so CI test outcomes are consistently reported.
  * Update release/notification messages to use clearer, completion-style titles and customizable link text for viewing results.
  * Standardize success/failure iconography in notifications for clearer status indication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->