### PR TITLE
feat: add BeaconQueue plugin into the lite variant

### DIFF
--- a/packages/analytics-js/rollup.config.mjs
+++ b/packages/analytics-js/rollup.config.mjs
@@ -118,7 +118,7 @@ const getExternalsConfig = () => {
     return externalGlobalsConfig;
   }
 
-  // Lite build: exclude device mode, storage legacy, beacon, and linker plugins
+  // Lite build: exclude device mode, storage legacy, and linker plugins
   if (isLiteBuild) {
     externalGlobalsConfig['@rudderstack/analytics-js-plugins/deviceModeDestinations'] = '{}';
     externalGlobalsConfig['@rudderstack/analytics-js-plugins/deviceModeTransformation'] = '{}';

--- a/packages/analytics-js/rollup.config.mjs
+++ b/packages/analytics-js/rollup.config.mjs
@@ -123,7 +123,6 @@ const getExternalsConfig = () => {
     externalGlobalsConfig['@rudderstack/analytics-js-plugins/deviceModeDestinations'] = '{}';
     externalGlobalsConfig['@rudderstack/analytics-js-plugins/deviceModeTransformation'] = '{}';
     externalGlobalsConfig['@rudderstack/analytics-js-plugins/nativeDestinationQueue'] = '{}';
-    externalGlobalsConfig['@rudderstack/analytics-js-plugins/beaconQueue'] = '{}';
     externalGlobalsConfig['@rudderstack/analytics-js-plugins/googleLinker'] = '{}';
     externalGlobalsConfig['@rudderstack/analytics-js-plugins/storageEncryptionLegacy'] = '{}';
     externalGlobalsConfig['@rudderstack/analytics-js-plugins/storageMigrator'] = '{}';


### PR DESCRIPTION
## PR Description

Added BeaconQueue plugin into the "lite" variant. It does not have any significant impact on the bundle size.
So, users can appropriate switch the transport mechanism.

Extends, https://github.com/rudderlabs/rudder-sdk-js/pull/2745.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4586/include-beaconqueue-plugin-in-the-lite-variant

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing analytics plugin support in lite builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->