### PR TITLE
chore: fix "Draft a new release" workflow startup failure [SDK-4587]

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -22,7 +22,8 @@ permissions:
 
 jobs:
   validate-actor:
-    permissions: {}
+    permissions:
+      contents: read
     # Only allow to draft a new release from develop and hotfix branches
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/')
     uses: ./.github/workflows/validate-actor.yml


### PR DESCRIPTION
# ci: fix "Draft a new release" workflow startup failure [SDK-4587]

## PR Description

Fixes a `startup_failure` in the **Draft a new release** GitHub Actions workflow.

That PR added `permissions: contents: read` to the root of `validate-actor.yml` (the reusable workflow), but left `permissions: {}` on the caller job in `draft-new-release.yml`. GitHub Actions enforces that a reusable workflow cannot request more permissions than the caller grants — so the workflow was rejected at parse time with:

> *"The workflow is requesting 'contents: read', but is only allowed 'contents: none'."*

The fix grants `contents: read` on the `validate-actor` caller job, aligning it with what the reusable workflow declares.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4587/fix-fix-draft-a-new-release-workflow-startup-failure-due-to

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow permissions for enhanced security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->