### PR TITLE
chore(release): create remote branches via API

### DIFF
--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -40,6 +40,9 @@ jobs:
           git config user.email noreply@github.com
 
       - name: Create hotfix branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           chmod +x scripts/create-hotfix-branch.sh
           ./scripts/create-hotfix-branch.sh "${{ github.event.inputs.hotfix_branch_name }}"

--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -21,27 +21,31 @@ jobs:
     name: Create a new hotfix branch
     runs-on: [self-hosted, Linux, X64]
     needs: validate-actor
+    permissions:
+      contents: write # to create branch ref via API
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create branch ref via API
+
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Create hotfix branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           chmod +x scripts/create-hotfix-branch.sh

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -83,6 +83,7 @@ jobs:
         id: create-release
         env:
           HUSKY: 0
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF#refs/heads/}
           release_type=release
@@ -104,6 +105,13 @@ jobs:
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
           git checkout -b "$branch_name"
+
+          # Create branch via GitHub API (not git push)
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/$branch_name" \
+            -f sha="$BASE_SHA"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -95,7 +95,7 @@ jobs:
 
           npm run bump-version:monorepo
           new_version=$(jq -r .version package.json)
-          git reset --hard
+          git reset --hard ORIG_HEAD
 
           branch_name="${release_type}/${new_version}-${{ github.event.inputs.release_ticket_id }}"
 
@@ -105,13 +105,6 @@ jobs:
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
           git checkout -b "$branch_name"
-
-          # Create branch via GitHub API (not git push)
-          BASE_SHA=$(git rev-parse HEAD)
-          gh api repos/${{ github.repository }}/git/refs \
-            --method POST \
-            -f ref="refs/heads/$branch_name" \
-            -f sha="$BASE_SHA"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -83,7 +83,6 @@ jobs:
         id: create-release
         env:
           HUSKY: 0
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF#refs/heads/}
           release_type=release

--- a/scripts/create-hotfix-branch.sh
+++ b/scripts/create-hotfix-branch.sh
@@ -73,7 +73,7 @@ if gh api "repos/${REPO_SLUG}/git/ref/heads/${FULL_BRANCH_NAME}" >/dev/null 2>&1
       -f "sha=${sha}" \
       -F "force=true"
 else
-    gh api repos/${REPO_SLUG}/git/refs \
+    gh api "repos/${REPO_SLUG}/git/refs" \
       --method POST \
       -f "ref=refs/heads/${FULL_BRANCH_NAME}" \
       -f "sha=${sha}"

--- a/scripts/create-hotfix-branch.sh
+++ b/scripts/create-hotfix-branch.sh
@@ -38,28 +38,49 @@ if [ ${#FULL_BRANCH_NAME} -gt 255 ]; then
     error "Full branch name ($FULL_BRANCH_NAME) is too long (maximum 255 characters)"
 fi
 
-# Check if branch already exists
+# Check if branch already exists locally
 if git show-ref --verify --quiet refs/heads/$FULL_BRANCH_NAME; then
-    error "Branch ($FULL_BRANCH_NAME) already exists"
+    error "Branch ($FULL_BRANCH_NAME) already exists locally"
 fi
 
-# Create the branch
+# Create the branch locally
 git checkout -b $FULL_BRANCH_NAME
 
-# Push the branch and handle potential errors
-if ! git push origin $FULL_BRANCH_NAME; then
-    error "Failed to push branch ($FULL_BRANCH_NAME) to remote. Please check your permissions and try again."
+# Ensure required environment variables for GitHub API are present
+if [ -z "$GH_TOKEN" ]; then
+    error "GH_TOKEN environment variable is required to create remote branch via GitHub API"
 fi
 
-# Verify the branch exists remotely
-if ! git ls-remote --heads origin $FULL_BRANCH_NAME | grep -q $FULL_BRANCH_NAME; then
-    error "Branch ($FULL_BRANCH_NAME) was not pushed to remote successfully"
+# Determine repository slug (owner/repo)
+REPO_SLUG="${REPO:-$GITHUB_REPOSITORY}"
+if [ -z "$REPO_SLUG" ]; then
+    # Fallback to parsing from git remote if not provided
+    REMOTE_URL=$(git config --get remote.origin.url)
+    REMOTE_URL=${REMOTE_URL#git@github.com:}
+    REMOTE_URL=${REMOTE_URL#https://github.com/}
+    REPO_SLUG=${REMOTE_URL%.git}
 fi
 
-# Get the repository URL
-REPO_URL=$(git config --get remote.origin.url)
-REPO_URL=${REPO_URL#git@github.com:}
-REPO_URL=${REPO_URL%.git}
+if [ -z "$REPO_SLUG" ]; then
+    error "Unable to determine repository slug for GitHub API"
+fi
 
-success "Successfully created hotfix branch!"
-echo "Branch URL: https://github.com/$REPO_URL/tree/$FULL_BRANCH_NAME" 
+# Create or update the remote branch ref via GitHub API before any future commits
+sha=$(git rev-parse HEAD)
+if gh api "repos/${REPO_SLUG}/git/ref/heads/${FULL_BRANCH_NAME}" >/dev/null 2>&1; then
+    gh api "repos/${REPO_SLUG}/git/refs/heads/${FULL_BRANCH_NAME}" \
+      --method PATCH \
+      -f "sha=${sha}" \
+      -F "force=true"
+else
+    gh api repos/${REPO_SLUG}/git/refs \
+      --method POST \
+      -f "ref=refs/heads/${FULL_BRANCH_NAME}" \
+      -f "sha=${sha}"
+fi
+
+# Get the repository URL for success message
+REPO_URL="https://github.com/$REPO_SLUG"
+
+success "Successfully created hotfix branch locally and ensured remote branch via GitHub API."
+echo "Branch URL: $REPO_URL/tree/$FULL_BRANCH_NAME"


### PR DESCRIPTION
## Summary
Adjusts release and hotfix workflows so remote branch creation is consistent and the draft release branch is based on the source branch (e.g. develop) only. Hotfix branch creation is handled in the script via `gh api`.

## Changes

### draft-new-release workflow
- **Reset**: Use `git reset --hard ORIG_HEAD` after reading `new_version` so the release branch is created from the source branch tip (develop or hotfix/xxx), not from the merge commit. The merge is only used to compute the next version; the actual branch base is the pre-merge state.
- **Remote ref**: Remove the early "create remote ref via API" block from the **Create release branch** step. The remote branch is created/updated in the **Create release branch on remote** step (idempotent POST/PATCH with current HEAD after changelog).

### create-hotfix-branch workflow & script
- **Script** (`scripts/create-hotfix-branch.sh`): Creates the remote branch via `gh api` (POST/PATCH refs) using `GH_TOKEN` and `REPO` (or `GITHUB_REPOSITORY` / git remote). Idempotent create or update.
- **Workflow**: Passes `GH_TOKEN` and `REPO` into the script; no separate "Create hotfix branch on remote" step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflows with improved GitHub token-based authentication.
  * Implemented GitHub API-driven approach for branch creation and management in release and hotfix processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->