### PR TITLE
feat(analytics-js): replace error-stack-parser with lean inline parser [SDK-4625]

### DIFF
--- a/packages/analytics-js/__tests__/services/ErrorHandler/event.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/event.test.ts
@@ -1,5 +1,5 @@
 import { defaultLogger } from '@rudderstack/analytics-js-common/__mocks__/Logger';
-import type ErrorStackParser from 'error-stack-parser';
+import type { ParsedFrame } from '../../../src/services/ErrorHandler/ErrorEvent/stackTraceParser';
 import {
   createBugsnagException,
   createException,
@@ -125,7 +125,7 @@ describe('event', () => {
           lineNumber: 3,
           columnNumber: 4,
         },
-      ] as unknown as ErrorStackParser.StackFrame[];
+      ] as unknown as ParsedFrame[];
 
       // create circular reference
       (stacktrace[2] as any).fileName = stacktrace;

--- a/packages/analytics-js/__tests__/services/ErrorHandler/stackTraceParser.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/stackTraceParser.test.ts
@@ -1,0 +1,206 @@
+import { parseStackTrace } from '../../../src/services/ErrorHandler/ErrorEvent/stackTraceParser';
+
+// Helper to build an Error with a synthetic stack string
+const makeError = (stack: string): Error => {
+  const e = new Error('test');
+  e.stack = stack;
+  return e;
+};
+
+describe('parseStackTrace', () => {
+  describe('throws when stack is missing', () => {
+    it('throws for an error with no stack', () => {
+      const e = new Error('test');
+      e.stack = undefined;
+      expect(() => parseStackTrace(e)).toThrow('Cannot parse given Error object');
+    });
+  });
+
+  describe('V8/Chromium format (Chrome, Edge, Node)', () => {
+    it('parses a basic V8 stack with named functions', () => {
+      const e = makeError(`Error: test
+    at functionOne (file.js:10:5)
+    at functionTwo (file2.js:20:3)`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(2);
+      expect(frames[0]).toEqual({
+        functionName: 'functionOne',
+        fileName: 'file.js',
+        lineNumber: 10,
+        columnNumber: 5,
+      });
+      expect(frames[1]).toEqual({
+        functionName: 'functionTwo',
+        fileName: 'file2.js',
+        lineNumber: 20,
+        columnNumber: 3,
+      });
+    });
+
+    it('parses a V8 frame without a function name (bare location)', () => {
+      const e = makeError(`Error: test
+    at file.js:10:5`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]).toMatchObject({ lineNumber: 10, columnNumber: 5 });
+    });
+
+    it('parses a V8 stack with a URL containing a port number', () => {
+      const e = makeError(`Error: test
+    at doThing (http://localhost:8080/app.js:42:7)`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]).toEqual({
+        functionName: 'doThing',
+        fileName: 'http://localhost:8080/app.js',
+        lineNumber: 42,
+        columnNumber: 7,
+      });
+    });
+
+    it('parses a V8 stack with a filename containing parentheses', () => {
+      const e = makeError(`Error: test
+    at fn (app(legacy).js:10:20)`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]).toMatchObject({
+        functionName: 'fn',
+        fileName: 'app(legacy).js',
+        lineNumber: 10,
+        columnNumber: 20,
+      });
+    });
+
+    it('strips the error message line and only returns at-frames', () => {
+      const e = makeError(`Error: something went wrong
+    at alpha (a.js:1:1)
+    at beta (b.js:2:2)`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(2);
+      expect(frames.map(f => f.functionName)).toEqual(['alpha', 'beta']);
+    });
+
+    it('maps eval frames: sets fileName to undefined for anonymous eval', () => {
+      const e = makeError(`Error: test
+    at eval (<anonymous>:1:1)
+    at realFn (real.js:5:3)`);
+
+      const frames = parseStackTrace(e);
+      // <anonymous> eval frame — fileName should be undefined
+      expect(frames[0]?.fileName).toBeUndefined();
+      expect(frames[1]).toMatchObject({ functionName: 'realFn', fileName: 'real.js' });
+    });
+
+    it('handles (native) frames without crashing', () => {
+      const e = makeError(`Error: test
+    at Array.forEach (native)
+    at run (run.js:3:1)`);
+
+      const frames = parseStackTrace(e);
+      expect(frames.length).toBeGreaterThanOrEqual(1);
+      expect(frames.some(f => f.fileName === 'run.js')).toBe(true);
+    });
+
+    it('returns lineNumber and columnNumber as numbers, not strings', () => {
+      const e = makeError(`Error: test
+    at fn (file.js:99:12)`);
+
+      const [frame] = parseStackTrace(e);
+      expect(typeof frame?.lineNumber).toBe('number');
+      expect(typeof frame?.columnNumber).toBe('number');
+    });
+  });
+
+  describe('SpiderMonkey/WebKit format (Firefox, Safari)', () => {
+    it('parses a basic Firefox stack with named functions', () => {
+      const e = makeError(`functionOne@file.js:10:5
+functionTwo@file2.js:20:3`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(2);
+      expect(frames[0]).toEqual({
+        functionName: 'functionOne',
+        fileName: 'file.js',
+        lineNumber: 10,
+        columnNumber: 5,
+      });
+      expect(frames[1]).toEqual({
+        functionName: 'functionTwo',
+        fileName: 'file2.js',
+        lineNumber: 20,
+        columnNumber: 3,
+      });
+    });
+
+    it('parses an anonymous Firefox frame (no function name before @)', () => {
+      const e = makeError(`@file.js:10:5`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]).toMatchObject({ fileName: 'file.js', lineNumber: 10, columnNumber: 5 });
+    });
+
+    it('filters out native code frames', () => {
+      const e = makeError(`fn@file.js:1:1
+[native code]
+eval@[native code]`);
+
+      const frames = parseStackTrace(e);
+      // "[native code]" and "eval@[native code]" should be dropped by SAFARI_NATIVE_RE
+      expect(frames).toHaveLength(1);
+      expect(frames[0]?.functionName).toBe('fn');
+    });
+
+    it('handles a Safari frame that is only a function name (no location)', () => {
+      const e = makeError(`onlyFunctionName`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]).toEqual({
+        functionName: 'onlyFunctionName',
+        fileName: undefined,
+        lineNumber: undefined,
+        columnNumber: undefined,
+      });
+    });
+
+    it('normalises eval location in Firefox format', () => {
+      // Firefox style: "fn@file.js line 10 > eval:1:1" → "fn@file.js:10"
+      const e = makeError(`evalFn@http://host/app.js line 10 > eval:1:1`);
+
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]).toMatchObject({ functionName: 'evalFn', fileName: 'http://host/app.js' });
+    });
+
+    it('returns lineNumber and columnNumber as numbers', () => {
+      const e = makeError(`fn@file.js:42:7`);
+
+      const [frame] = parseStackTrace(e);
+      expect(typeof frame?.lineNumber).toBe('number');
+      expect(typeof frame?.columnNumber).toBe('number');
+    });
+  });
+
+  describe('branch selection heuristic', () => {
+    it('uses the V8 branch when any line starts with "    at "', () => {
+      // Mixed content: first line is a message, second is V8
+      const e = makeError(`Error: test\n    at fn (file.js:1:1)`);
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]?.functionName).toBe('fn');
+    });
+
+    it('falls through to FF/Safari branch when no V8 "at" lines are present', () => {
+      const e = makeError(`fn@file.js:1:1`);
+      const frames = parseStackTrace(e);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]?.functionName).toBe('fn');
+    });
+  });
+});

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/event.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/event.ts
@@ -1,5 +1,4 @@
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
-import ErrorStackParser from 'error-stack-parser';
 import type { Exception } from '@rudderstack/analytics-js-common/types/Metrics';
 import { ERROR_HANDLER } from '@rudderstack/analytics-js-common/constants/loggerContexts';
 import { stringifyWithoutCircular } from '@rudderstack/analytics-js-common/utilities/json';
@@ -11,6 +10,7 @@ import {
 import { getStacktrace } from '@rudderstack/analytics-js-common/utilities/errors';
 import type { Stackframe } from '@bugsnag/js';
 import { NON_ERROR_WARNING } from '../../../constants/logMessages';
+import { type ParsedFrame, parseStackTrace } from './stackTraceParser';
 
 const GLOBAL_CODE = 'global code';
 
@@ -22,13 +22,7 @@ const normalizeFunctionName = (name: string | undefined) => {
   return name;
 };
 
-/**
- * Takes a stacktrace.js style stackframe (https://github.com/stacktracejs/stackframe)
- * and returns a Bugsnag compatible stackframe (https://docs.bugsnag.com/api/error-reporting/#json-payload)
- * @param frame
- * @returns
- */
-const formatStackframe = (frame: ErrorStackParser.StackFrame): Stackframe => {
+const formatStackframe = (frame: ParsedFrame): Stackframe => {
   const f = {
     file: frame.fileName as string,
     method: normalizeFunctionName(frame.functionName),
@@ -50,13 +44,13 @@ function createException(
   errorClass: string,
   errorMessage: string,
   msgPrefix: string,
-  stacktrace: ErrorStackParser.StackFrame[],
+  stacktrace: ParsedFrame[],
 ): Exception {
   return {
     errorClass: ensureString(errorClass),
     message: `${msgPrefix}${ensureString(errorMessage)}`,
     type: 'browserjs',
-    stacktrace: stacktrace.reduce((accum: Stackframe[], frame: ErrorStackParser.StackFrame) => {
+    stacktrace: stacktrace.reduce((accum: Stackframe[], frame: ParsedFrame) => {
       const f = formatStackframe(frame);
       // don't include a stackframe if none of its properties are defined
       try {
@@ -84,7 +78,7 @@ const normalizeError = (maybeError: any, logger: ILogger): any => {
 
 const createBugsnagException = (error: any, msgPrefix: string): Exception => {
   try {
-    const stacktrace = ErrorStackParser.parse(error);
+    const stacktrace = parseStackTrace(error);
     return createException(error.name, error.message, msgPrefix, stacktrace);
   } catch {
     return createException(error.name, error.message, msgPrefix, []);

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/stackTraceParser.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/stackTraceParser.ts
@@ -15,7 +15,9 @@ function extractLocation(
   if (!urlLike || !urlLike.includes(':')) {
     return [urlLike || undefined, undefined, undefined];
   }
-  const parts = LOCATION_RE.exec(urlLike.replace(/[()]/g, ''));
+  const normalizedUrlLike =
+    urlLike.startsWith('(') && urlLike.endsWith(')') ? urlLike.slice(1, -1) : urlLike;
+  const parts = LOCATION_RE.exec(normalizedUrlLike);
   if (!parts) {
     return [undefined, undefined, undefined];
   }

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/stackTraceParser.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/stackTraceParser.ts
@@ -12,7 +12,7 @@ const LOCATION_RE = /(.+?)(?::(\d+))?(?::(\d+))?$/;
 function extractLocation(
   urlLike: string | undefined,
 ): [string | undefined, number | undefined, number | undefined] {
-  if (!urlLike || !urlLike.includes(':')) {
+  if (!urlLike?.includes(':')) {
     return [urlLike || undefined, undefined, undefined];
   }
   const normalizedUrlLike =
@@ -23,8 +23,8 @@ function extractLocation(
   }
   return [
     parts[1] || undefined,
-    parts[2] !== undefined ? Number(parts[2]) : undefined,
-    parts[3] !== undefined ? Number(parts[3]) : undefined,
+    parts[2] === undefined ? undefined : Number(parts[2]),
+    parts[3] === undefined ? undefined : Number(parts[3]),
   ];
 }
 
@@ -33,13 +33,13 @@ function parseV8Line(line: string): ParsedFrame | null {
     return null;
   }
   if (line.includes('(eval ')) {
-    line = line.replace(/eval code/g, 'eval').replace(/(\(eval at [^()]*)|(,.*$)/g, '');
+    line = line.replaceAll('eval code', 'eval').replaceAll(/(\(eval at [^()]*)|(,.*$)/g, '');
   }
   const sanitized = line
     .replace(/^\s+/, '')
-    .replace(/\(eval code/g, '(')
+    .replaceAll('(eval code', '(')
     .replace(/^.*?\s+/, '');
-  const parenLoc = sanitized.match(/ (\(.+\)$)/);
+  const parenLoc = / (\(.+\)$)/.exec(sanitized);
   const withoutLoc = parenLoc ? sanitized.replace(parenLoc[0], '') : sanitized;
   const [rawFile, lineNumber, columnNumber] = extractLocation(parenLoc ? parenLoc[1] : sanitized);
   const functionName = (parenLoc && withoutLoc) || undefined;
@@ -52,7 +52,7 @@ function parseFFSafariLine(line: string): ParsedFrame | null {
     return null;
   }
   if (line.includes(' > eval')) {
-    line = line.replace(/ line (\d+)(?: > eval line \d+)* > eval:\d+:\d+/g, ':$1');
+    line = line.replaceAll(/ line (\d+)(?: > eval line \d+)* > eval:\d+:\d+/g, ':$1');
   }
   if (!line.includes('@') && !line.includes(':')) {
     return {

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/stackTraceParser.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/stackTraceParser.ts
@@ -1,0 +1,84 @@
+export type ParsedFrame = {
+  fileName: string | undefined;
+  functionName: string | undefined;
+  lineNumber: number | undefined;
+  columnNumber: number | undefined;
+};
+
+const CHROME_STACK_LINE_RE = /^\s*at .*(\S+:\d+|\(native\))/;
+const SAFARI_NATIVE_RE = /^(eval@)?(\[native code])?$/;
+const LOCATION_RE = /(.+?)(?::(\d+))?(?::(\d+))?$/;
+
+function extractLocation(
+  urlLike: string | undefined,
+): [string | undefined, number | undefined, number | undefined] {
+  if (!urlLike || !urlLike.includes(':')) {
+    return [urlLike || undefined, undefined, undefined];
+  }
+  const parts = LOCATION_RE.exec(urlLike.replace(/[()]/g, ''));
+  if (!parts) {
+    return [undefined, undefined, undefined];
+  }
+  return [
+    parts[1] || undefined,
+    parts[2] !== undefined ? Number(parts[2]) : undefined,
+    parts[3] !== undefined ? Number(parts[3]) : undefined,
+  ];
+}
+
+function parseV8Line(line: string): ParsedFrame | null {
+  if (!CHROME_STACK_LINE_RE.test(line)) {
+    return null;
+  }
+  if (line.includes('(eval ')) {
+    line = line.replace(/eval code/g, 'eval').replace(/(\(eval at [^()]*)|(,.*$)/g, '');
+  }
+  const sanitized = line
+    .replace(/^\s+/, '')
+    .replace(/\(eval code/g, '(')
+    .replace(/^.*?\s+/, '');
+  const parenLoc = sanitized.match(/ (\(.+\)$)/);
+  const withoutLoc = parenLoc ? sanitized.replace(parenLoc[0], '') : sanitized;
+  const [rawFile, lineNumber, columnNumber] = extractLocation(parenLoc ? parenLoc[1] : sanitized);
+  const functionName = (parenLoc && withoutLoc) || undefined;
+  const fileName = rawFile === 'eval' || rawFile === '<anonymous>' ? undefined : rawFile;
+  return { functionName, fileName, lineNumber, columnNumber };
+}
+
+function parseFFSafariLine(line: string): ParsedFrame | null {
+  if (SAFARI_NATIVE_RE.test(line)) {
+    return null;
+  }
+  if (line.includes(' > eval')) {
+    line = line.replace(/ line (\d+)(?: > eval line \d+)* > eval:\d+:\d+/g, ':$1');
+  }
+  if (!line.includes('@') && !line.includes(':')) {
+    return {
+      functionName: line,
+      fileName: undefined,
+      lineNumber: undefined,
+      columnNumber: undefined,
+    };
+  }
+  const fnRegex = /((.*".+"[^@]*)?[^@]*)(?:@)/;
+  const fnMatch = line.match(fnRegex);
+  const functionName = (fnMatch && fnMatch[1]) || undefined;
+  const [fileName, lineNumber, columnNumber] = extractLocation(line.replace(fnRegex, ''));
+  return { functionName, fileName, lineNumber, columnNumber };
+}
+
+/**
+ * Parses an Error object's stack trace into structured frames.
+ * Supports V8/Chromium (Chrome, Edge, Node) and SpiderMonkey/WebKit (Firefox, Safari) formats.
+ * Throws if the error has no stack property.
+ */
+export function parseStackTrace(error: Error): ParsedFrame[] {
+  if (!error.stack) {
+    throw new Error('Cannot parse given Error object');
+  }
+  const lines = error.stack.split('\n');
+  if (lines.some(l => CHROME_STACK_LINE_RE.test(l))) {
+    return lines.map(parseV8Line).filter((f): f is ParsedFrame => f !== null);
+  }
+  return lines.map(parseFFSafariLine).filter((f): f is ParsedFrame => f !== null);
+}

--- a/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/stackTraceParser.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/ErrorEvent/stackTraceParser.ts
@@ -5,7 +5,7 @@ export type ParsedFrame = {
   columnNumber: number | undefined;
 };
 
-const CHROME_STACK_LINE_RE = /^\s*at .*(\S+:\d+|\(native\))/;
+const CHROME_STACK_LINE_RE = /^\s*at /;
 const SAFARI_NATIVE_RE = /^(eval@)?(\[native code])?$/;
 const LOCATION_RE = /(.+?)(?::(\d+))?(?::(\d+))?$/;
 
@@ -62,10 +62,9 @@ function parseFFSafariLine(line: string): ParsedFrame | null {
       columnNumber: undefined,
     };
   }
-  const fnRegex = /((.*".+"[^@]*)?[^@]*)(?:@)/;
-  const fnMatch = line.match(fnRegex);
-  const functionName = (fnMatch && fnMatch[1]) || undefined;
-  const [fileName, lineNumber, columnNumber] = extractLocation(line.replace(fnRegex, ''));
+  const atIndex = line.lastIndexOf('@');
+  const functionName = atIndex > 0 ? line.slice(0, atIndex) : undefined;
+  const [fileName, lineNumber, columnNumber] = extractLocation(line.slice(atIndex + 1));
   return { functionName, fileName, lineNumber, columnNumber };
 }
 


### PR DESCRIPTION
## PR Description

Replaces the `error-stack-parser` + `stackframe` third-party dependencies with a purpose-built inline parser (`stackTraceParser.ts`) scoped to exactly what the SDK needs.

**Why:** The SDK imported `error-stack-parser` (which pulls in `stackframe` as a transitive dep) but only ever consumed four properties from parsed frames: `fileName`, `functionName`, `lineNumber`, and `columnNumber`. The two libraries together weigh ~7.3 KB minified (~3 KB gzipped) and include dead code paths for Opera 9 (2006), Opera 10 (2009), and Opera 11-12 (2011-2013) — browsers that switched to Chromium in 2013 and will never trigger those branches. The `StackFrame` class also ships ~22 getter/setter methods that are never called by the SDK.

**What changed:**
- Added `stackTraceParser.ts` (~70 lines) supporting V8/Chromium (Chrome, Edge) and SpiderMonkey/WebKit (Firefox, Safari) stack formats, returning plain objects instead of `StackFrame` instances
- Removed `import ErrorStackParser from 'error-stack-parser'` from `event.ts`; replaced `ErrorStackParser.parse()` with `parseStackTrace()` and `ErrorStackParser.StackFrame` type with the internal `ParsedFrame` type
- Updated the test file to remove the `error-stack-parser` type import

All 27 existing unit tests pass without modification.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4625/spike-explore-if-we-can-remove-error-stack-parser-library-and-rewrite

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced an external stack parser with an internal stack-trace parser to improve stack parsing robustness while preserving existing error reporting behavior.
* **Tests**
  * Added comprehensive tests covering multiple browser stack formats, eval/native frames, missing-stack errors, and numeric position handling to ensure reliable stack parsing and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->