### PR TITLE
refactor(analytics-js): remove dead browser compat code [SDK-4625]

### DIFF
--- a/packages/analytics-js-common/__tests__/utilities/errors.test.ts
+++ b/packages/analytics-js-common/__tests__/utilities/errors.test.ts
@@ -21,56 +21,12 @@ describe('Errors - utilities', () => {
       expect(dispatchEventMock).toHaveBeenCalledWith(new ErrorEvent('error', { error }));
       expect((error.stack as string).endsWith('[SDK DISPATCHED ERROR]')).toBeTruthy();
     });
-
-    it('should decorate stacktrace before dispatching error event', () => {
-      const error = new Error('Test error');
-      // @ts-expect-error need to set the value for testing
-      error.stacktrace = error.stack;
-      delete error.stack;
-
-      dispatchErrorEvent(error);
-
-      // @ts-expect-error need to check the stacktrace property
-      expect((error.stacktrace as string).endsWith('[SDK DISPATCHED ERROR]')).toBeTruthy();
-    });
-
-    it('should decorate opera sourceloc before dispatching error event', () => {
-      const error = new Error('Test error');
-      // @ts-expect-error need to set the value for testing
-      error['opera#sourceloc'] = error.stack;
-      delete error.stack;
-
-      dispatchErrorEvent(error);
-
-      // @ts-expect-error need to check the opera sourceloc property
-      expect((error['opera#sourceloc'] as string).endsWith('[SDK DISPATCHED ERROR]')).toBeTruthy();
-    });
   });
 
   describe('getStacktrace', () => {
     it('should return stack if it is a string', () => {
       const error = new Error('Test error');
       expect(getStacktrace(error)).toBe(error.stack);
-    });
-
-    it('should return stacktrace if it is a string', () => {
-      const error = new Error('Test error');
-      // @ts-expect-error need to set the value for testing
-      error.stacktrace = error.stack;
-      delete error.stack;
-
-      // @ts-expect-error need to check the stacktrace property
-      expect(getStacktrace(error)).toBe(error.stacktrace);
-    });
-
-    it('should return opera sourceloc if it is a string', () => {
-      const error = new Error('Test error');
-      // @ts-expect-error need to set the value for testing
-      error['opera#sourceloc'] = error.stack;
-      delete error.stack;
-
-      // @ts-expect-error need to check the opera sourceloc property
-      expect(getStacktrace(error)).toBe(error['opera#sourceloc']);
     });
 
     it('should return undefined if none of the properties are strings', () => {
@@ -165,30 +121,6 @@ describe('Errors - utilities', () => {
       expect(result.message).toBe('Test Issue: Original message');
       expect(result).not.toBe(originalError);
       // Should not throw even if property copy fails
-    });
-
-    it('should handle stacktrace property (non-standard)', () => {
-      const originalError = new Error('Original message') as any;
-      originalError.stacktrace = 'custom stacktrace';
-      delete originalError.stack;
-      const issue = 'Test Issue';
-
-      const result = getMutatedError(originalError, issue) as any;
-
-      expect(result.stacktrace).toBe('custom stacktrace');
-      expect(result.message).toBe('Test Issue: Original message');
-    });
-
-    it('should handle opera#sourceloc property', () => {
-      const originalError = new Error('Original message') as any;
-      originalError['opera#sourceloc'] = 'opera location';
-      delete originalError.stack;
-      const issue = 'Test Issue';
-
-      const result = getMutatedError(originalError, issue) as any;
-
-      expect(result['opera#sourceloc']).toBe('opera location');
-      expect(result.message).toBe('Test Issue: Original message');
     });
 
     it('should fallback to generic Error when constructor fails', () => {

--- a/packages/analytics-js-common/src/types/ApplicationState.ts
+++ b/packages/analytics-js-common/src/types/ApplicationState.ts
@@ -34,7 +34,6 @@ export type CapabilitiesState = {
   isLegacyDOM: Signal<boolean>;
   isUaCHAvailable: Signal<boolean>;
   isCryptoAvailable: Signal<boolean>;
-  isIE11: Signal<boolean>;
   /**
    * This is used to track if the ad blocker detection is in progress.
    * It is used to avoid multiple ad blocker detection requests.

--- a/packages/analytics-js-common/src/utilities/errors.ts
+++ b/packages/analytics-js-common/src/utilities/errors.ts
@@ -4,11 +4,9 @@ import { stringifyWithoutCircular } from './json';
 const MANUAL_ERROR_IDENTIFIER = '[SDK DISPATCHED ERROR]';
 
 const getStacktrace = (err: any): string | undefined => {
-  const { stack, stacktrace, 'opera#sourceloc': operaSourceloc } = err;
-  const stackString = stack ?? stacktrace ?? operaSourceloc;
-
-  if (!!stackString && typeof stackString === 'string') {
-    return stackString;
+  const { stack } = err;
+  if (typeof stack === 'string' && stack) {
+    return stack;
   }
   return undefined;
 };
@@ -56,23 +54,8 @@ const dispatchErrorEvent = (error: any) => {
   if (isTypeOfError(error)) {
     const errStack = getStacktrace(error);
     if (errStack) {
-      const { stack, stacktrace, 'opera#sourceloc': operaSourceloc } = error;
-
-      switch (errStack) {
-        case stack:
-          // eslint-disable-next-line no-param-reassign
-          error.stack = `${stack}\n${MANUAL_ERROR_IDENTIFIER}`;
-          break;
-        case stacktrace:
-          // eslint-disable-next-line no-param-reassign
-          error.stacktrace = `${stacktrace}\n${MANUAL_ERROR_IDENTIFIER}`;
-          break;
-        case operaSourceloc:
-        default:
-          // eslint-disable-next-line no-param-reassign
-          error['opera#sourceloc'] = `${operaSourceloc}\n${MANUAL_ERROR_IDENTIFIER}`;
-          break;
-      }
+      // eslint-disable-next-line no-param-reassign
+      error.stack = `${errStack}\n${MANUAL_ERROR_IDENTIFIER}`;
     }
   }
 

--- a/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
+++ b/packages/analytics-js/__tests__/components/capabilitiesManager/CapabilitiesManager.test.ts
@@ -30,7 +30,6 @@ jest.mock('../../../src/components/capabilitiesManager/detection', () => {
     hasBeacon: jest.fn(() => true),
     hasCrypto: jest.fn(() => true),
     hasUAClientHints: jest.fn(() => false),
-    isIE11: jest.fn(() => false),
     getScreenDetails: jest.fn(() => ({
       width: 1920,
       height: 1080,
@@ -154,7 +153,6 @@ describe('CapabilitiesManager', () => {
       expect(state.capabilities.isBeaconAvailable.value).toBe(true);
       expect(state.capabilities.isCryptoAvailable.value).toBe(true);
       expect(state.capabilities.isUaCHAvailable.value).toBe(false);
-      expect(state.capabilities.isIE11.value).toBe(false);
       expect(state.capabilities.storage.isCookieStorageAvailable.value).toBe(true);
       expect(state.capabilities.storage.isLocalStorageAvailable.value).toBe(true);
       expect(state.capabilities.storage.isSessionStorageAvailable.value).toBe(true);

--- a/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
@@ -454,7 +454,6 @@ describe('Error Reporting utilities', () => {
                 isAdBlockerDetectionInProgress: false,
                 isBeaconAvailable: false,
                 isCryptoAvailable: false,
-                isIE11: false,
                 isLegacyDOM: false,
                 isOnline: true,
                 isUaCHAvailable: false,

--- a/packages/analytics-js/src/components/capabilitiesManager/CapabilitiesManager.ts
+++ b/packages/analytics-js/src/components/capabilitiesManager/CapabilitiesManager.ts
@@ -13,7 +13,6 @@ import { getTimezone } from '@rudderstack/analytics-js-common/utilities/timezone
 import { isValidURL } from '@rudderstack/analytics-js-common/utilities/url';
 import { isDefinedAndNotNull } from '@rudderstack/analytics-js-common/utilities/checks';
 import type { IHttpClient } from '@rudderstack/analytics-js-common/types/HttpClient';
-import { isIE11 } from '@rudderstack/analytics-js-common/utilities/detect';
 import { isStorageAvailable } from '@rudderstack/analytics-js-common/utilities/storage';
 import {
   INVALID_POLYFILL_URL_WARNING,
@@ -83,7 +82,6 @@ class CapabilitiesManager implements ICapabilitiesManager {
       state.capabilities.isBeaconAvailable.value = hasBeacon();
       state.capabilities.isUaCHAvailable.value = hasUAClientHints();
       state.capabilities.isCryptoAvailable.value = hasCrypto();
-      state.capabilities.isIE11.value = isIE11();
       state.capabilities.isOnline.value = globalThis.navigator.onLine;
 
       // Get page context details

--- a/packages/analytics-js/src/state/slices/capabilities.ts
+++ b/packages/analytics-js/src/state/slices/capabilities.ts
@@ -12,7 +12,6 @@ const capabilitiesState: CapabilitiesState = {
   isLegacyDOM: signal(false),
   isUaCHAvailable: signal(false),
   isCryptoAvailable: signal(false),
-  isIE11: signal(false),
   isAdBlockerDetectionInProgress: signal<boolean>(false),
   isAdBlocked: signal<boolean | undefined>(undefined),
   cspBlockedURLs: signal<string[]>([]),


### PR DESCRIPTION
## Summary

- Drop `opera#sourceloc` and `error.stacktrace` fallbacks from `getStacktrace()` and `dispatchErrorEvent()` in `errors.ts` — these are Opera Presto / old Firefox-era properties from an engine that reached EOL in 2013 and are unreachable in any supported browser
- Remove `isIE11` signal from `CapabilitiesState` type, state slice, and `CapabilitiesManager` — the signal was set but never read anywhere in the codebase
- Remove corresponding test assertions for the deleted code

## Test plan

- [x] `analytics-js-common` tests pass (errors utility tests updated)
- [x] `analytics-js` tests pass (CapabilitiesManager + ErrorHandler utils tests updated)
- [x] Pre-commit hook (affected tests + bundle size checks) passed

Closes [SDK-4625](https://linear.app/rudderstack/issue/SDK-4625)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed tests for non-standard error property decoration and browser capability detection assertions.

* **Refactor**
  * Simplified error handling to exclusively process standard error stack properties.
  * Removed browser capability detection and associated state tracking from the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->