### PR TITLE
chore(monorepo): remove commit-message prefixes from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 10
-    commit-message:
-      prefix: "chore(ci)"
     groups:
       github-actions-deps:
         patterns:
@@ -30,10 +28,6 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
-    commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
-      include: "scope"
     groups:
       npm-dev-deps:
         patterns:
@@ -83,8 +77,6 @@ updates:
       - "dependencies"
       - "sample-apps"
     open-pull-requests-limit: 10
-    commit-message:
-      prefix: "chore(sample-apps-deps)"
     groups:
       sample-apps-npm-deps:
         patterns:
@@ -109,8 +101,6 @@ updates:
       - "dependencies"
       - "sample-apps"
     open-pull-requests-limit: 10
-    commit-message:
-      prefix: "chore(gatsby-sample-apps-deps)"
     groups:
       gatsby-sample-apps-npm-deps:
         patterns:


### PR DESCRIPTION
## Summary

- Remove `commit-message` prefix configuration from all Dependabot entries
- Dependabot auto-generates PR titles that include the group name (e.g. `bump the npm-dev-deps group...`), which duplicated the configured `commit-message` prefix resulting in broken/redundant titles

## Test plan

- [ ] Verify next Dependabot PR titles are clean and not duplicated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Dependabot pull request titles and commit messages now use default formatting instead of custom per-group prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->