### PR TITLE
feat(analytics-js-integrations): add accountId threshold loading for sc v3

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/VWO/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/VWO/browser.test.js
@@ -1,4 +1,5 @@
 import VWO from '../../../src/integrations/VWO/browser';
+import { loadNativeSdk } from '../../../src/integrations/VWO/nativeSdkLoader';
 
 const destinationInfo = {
   areTransformationsConnected: false,
@@ -139,5 +140,51 @@ describe('VWO Identify Event', () => {
         source: 'rudderstack',
       },
     );
+  });
+});
+
+describe('VWO SmartCode v3 loader sanity', () => {
+  const ACCOUNT_ID_THRESHOLD = 1200000;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    delete window._vwo_code;
+    // SmartCode v3 assigns `code` without declaration; declare it for strict-mode Jest runtime
+    globalThis.eval('var code;');
+    if (typeof performance.getEntriesByName !== 'function') {
+      performance.getEntriesByName = () => [];
+    }
+    window.document.head.querySelectorAll('script,style').forEach(el => el.remove());
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    delete globalThis.code;
+    jest.useRealTimers();
+  });
+
+  test('uses SmartCode v3.0 when accountId is greater than threshold', () => {
+    const accountId = ACCOUNT_ID_THRESHOLD + 1;
+
+    loadNativeSdk(accountId, 2000, 2500, false, 1);
+
+    const code = window._vwo_code;
+    expect(code).toBeDefined();
+    expect(code.getVersion()).toBe(3);
+  });
+
+  test('v3.0 sanity: injects hide style and tag script', () => {
+    const accountId = ACCOUNT_ID_THRESHOLD + 42;
+
+    loadNativeSdk(accountId, 2000, 2500, false, 1);
+
+    const style = window.document.head.querySelector('#_vis_opt_path_hides');
+    expect(style).not.toBeNull();
+    expect(style.textContent).toContain('opacity:0');
+
+    const script = window.document.head.querySelector(
+      'script[src*="visualwebsiteoptimizer.com/tag/"]',
+    );
+    expect(script).not.toBeNull();
   });
 });

--- a/packages/analytics-js-integrations/__tests__/integrations/VWO/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/VWO/browser.test.js
@@ -149,17 +149,22 @@ describe('VWO SmartCode v3 loader sanity', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     delete window._vwo_code;
-    // SmartCode v3 assigns `code` without declaration; declare it for strict-mode Jest runtime
-    globalThis.eval('var code;');
     if (typeof performance.getEntriesByName !== 'function') {
-      performance.getEntriesByName = () => [];
+      Object.defineProperty(performance, 'getEntriesByName', {
+        value: () => [],
+        configurable: true,
+      });
     }
     window.document.head.querySelectorAll('script,style').forEach(el => el.remove());
   });
 
   afterEach(() => {
     jest.runOnlyPendingTimers();
-    delete globalThis.code;
+    if (typeof originalGetEntriesByName === 'function') {
+      performance.getEntriesByName = originalGetEntriesByName;
+    } else {
+      delete performance.getEntriesByName;
+    }
     jest.useRealTimers();
   });
 

--- a/packages/analytics-js-integrations/src/integrations/VWO/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/nativeSdkLoader.js
@@ -33,7 +33,7 @@ function loadNativeSdk(
       try {
           e = Object.assign(JSON.parse(localStorage.getItem('_vwo_' + account_id + '_config')), e)
       } catch (e) {}
-      code = {
+      var code = {
           nonce: o && o.nonce,
           settings_tolerance: function() {
               return e.sT
@@ -65,7 +65,8 @@ function loadNativeSdk(
               var e = n.createElement('style');
               e.setAttribute('id', '_vis_opt_path_hides'), e.type = 'text/css', code && code.nonce && e.setAttribute('nonce', code.nonce), e.appendChild(n.createTextNode(this.hide_element() + this.hide_element_style())), n.head.appendChild(e), this.addScript('https://dev.visualwebsiteoptimizer.com/tag/' + account_id + '.js')
           }
-      }, t._vwo_code = code;
+      };
+      t._vwo_code = code;
       code.init();
     })();
     return;

--- a/packages/analytics-js-integrations/src/integrations/VWO/nativeSdkLoader.js
+++ b/packages/analytics-js-integrations/src/integrations/VWO/nativeSdkLoader.js
@@ -1,5 +1,7 @@
 import { LOAD_ORIGIN } from '@rudderstack/analytics-js-legacy-utilities/constants';
 
+const ACCOUNT_ID_THRESHOLD = 1200000;
+
 function loadNativeSdk(
   account_id,
   settings_tolerance,
@@ -7,6 +9,69 @@ function loadNativeSdk(
   use_existing_jquery,
   isSPA,
 ) {
+
+  if (Number(account_id) > ACCOUNT_ID_THRESHOLD) {
+    window._vwo_code || (function() {
+      var account_id = account_id,
+          version = 3.0,
+          settings_tolerance = settings_tolerance,
+          hide_element = 'body',
+          hide_element_style =
+          'opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;transition:none !important';
+
+      /* DO NOT EDIT BELOW THIS LINE */
+      var t = window,
+          n = document;
+      if (-1 < n.URL.indexOf('__vwo_disable__') || t._vwo_code) return;
+      var i = !1,
+          o = n.currentScript,
+          e = {
+              sT: settings_tolerance,
+              hES: hide_element_style,
+              hE: hide_element
+          };
+      try {
+          e = Object.assign(JSON.parse(localStorage.getItem('_vwo_' + account_id + '_config')), e)
+      } catch (e) {}
+      code = {
+          nonce: o && o.nonce,
+          settings_tolerance: function() {
+              return e.sT
+          },
+          hide_element: function() {
+              return performance.getEntriesByName('first-contentful-paint')[0] ? '' : e.hE
+          },
+          hide_element_style: function() {
+              return '{' + e.hES + '}'
+          },
+          getVersion: function() {
+              return version
+          },
+          finish: function() {
+              var e;
+              i || (i = !0, (e = n.getElementById('_vis_opt_path_hides')) && e.parentNode && e.parentNode.removeChild(e))
+          },
+          finished: function() {
+              return i
+          },
+          addScript: function(e) {
+              var t = n.createElement('script');
+              t.type = 'text/javascript', t.src = e, o && o.nonce && t.setAttribute('nonce', o.nonce), n.getElementsByTagName('head')[0].appendChild(t)
+          },
+          init: function() {
+              t._vwo_settings_timer = setTimeout(function() {
+                  code.finish()
+              }, this.settings_tolerance());
+              var e = n.createElement('style');
+              e.setAttribute('id', '_vis_opt_path_hides'), e.type = 'text/css', code && code.nonce && e.setAttribute('nonce', code.nonce), e.appendChild(n.createTextNode(this.hide_element() + this.hide_element_style())), n.head.appendChild(e), this.addScript('https://dev.visualwebsiteoptimizer.com/tag/' + account_id + '.js')
+          }
+      }, t._vwo_code = code;
+      code.init();
+    })();
+    return;
+  }
+
+  // Existing loader (for older VWO accounts)
   window._vwo_code = (function () {
     let f = false;
     const d = document;


### PR DESCRIPTION
## PR Description

This PR updates the VWO SmartCode in the project to version 3.0, conditionally loading VWO SmartCode version 3.0 for the latest accounts only with VWO’s latest features and improvements. The update is backward-compatible, with testing successfully completed in a local environment. New test cases were added for the account id based smartcode loading and for the basic sanity.

## Linear task (optional)

Linear task link

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [x] Firefox
- [x] IE11

## Sanity Suite

- [x] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new SmartCode v3 loader for large accounts for improved initialization and persisted configuration.
* **Behavioral**
  * v3 loader injects optimized experiment tag and page-hide styling to reduce visual flicker and speed startup.
* **Tests**
  * Added browser-level sanity tests verifying v3 initialization, tag injection, and hide-style behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->