### PR TITLE
chore(deps): add cooldown and auto-merge for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
           - "*"
 
   - package-ecosystem: "npm"
+    cooldown:
+      default-days: 5
     directory: "/"
     schedule:
       interval: "cron"
@@ -51,6 +53,8 @@ updates:
 
   # All sample applications managed together (excluding gatsby)
   - package-ecosystem: "npm"
+    cooldown:
+      default-days: 5
     directories:
       - "/examples/angular/sample-app"
       - "/examples/nextjs/hooks/sample-app"
@@ -88,6 +92,8 @@ updates:
 
   # Gatsby sample applications with special dependency ignores
   - package-ecosystem: "npm"
+    cooldown:
+      default-days: 5
     directories:
       - "/examples/gatsby/sample-gatsby-plugin-usage"
       - "/examples/gatsby/sample-gatsby-site"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,6 +30,7 @@ jobs:
           fi
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
@@ -37,4 +38,5 @@ jobs:
         run: gh pr merge --auto --squash "$PR_NUMBER"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot Auto-Merge (Sample Apps)
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Check if PR only touches example apps
+        id: check
+        run: |
+          files=$(gh pr diff "$PR_NUMBER" --name-only)
+          non_example_files=$(echo "$files" | grep -v '^examples/' || true)
+          if [ -z "$non_example_files" ]; then
+            echo "only_examples=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "only_examples=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.check.outputs.only_examples == 'true'
+        run: gh pr merge --auto --squash "$PR_NUMBER"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,9 +9,15 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Check if PR only touches example apps
         id: check
         run: |

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
       - develop
+    paths:
+      - 'examples/**'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   auto-merge:


### PR DESCRIPTION
## Summary

- Add 5-day cooldown to all npm dependabot entries to throttle PR creation frequency
- Add new workflow to auto-merge dependabot PRs that only touch example app directories

## Test plan

- [ ] Verify dependabot respects the cooldown setting on next scheduled run
- [ ] Verify auto-merge workflow triggers on dependabot PRs targeting `develop`
- [ ] Verify auto-merge is skipped for PRs touching non-example files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied a 5-day cooldown to Dependabot npm update scheduling across project sample and root directories to reduce update frequency.
  * Added an automated workflow to auto-merge Dependabot pull requests for sample applications when changes are confined to example files, with checks to ensure only example paths are modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->