### PR TITLE
chore(vuln): fix bot-conditions in dependabot auto-merge (SEC-162)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0


### PR DESCRIPTION
Fixes zizmor bot-conditions finding. Changes `github.actor` (mutable/spoofable) to `github.event.pull_request.user.login` (immutable PR creator).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated workflow configuration for dependency management reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->