### PR TITLE
fix(analytics-js-service-worker): bump axios to fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@segment/top-domain": "3.0.1",
         "@vespaiach/axios-fetch-adapter": "0.3.1",
         "assert": "2.1.0",
-        "axios": "1.13.6",
+        "axios": "1.15.1",
         "axios-retry": "4.5.0",
         "component-each": "0.2.6",
         "component-emitter": "2.0.0",
@@ -2406,6 +2406,18 @@
         "conventional-commits-parser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@commitlint/read/node_modules/git-raw-commits": {
@@ -9387,14 +9399,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-retry": {
@@ -23040,10 +23052,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/publint": {
       "version": "0.3.18",
@@ -28340,7 +28355,7 @@
         "@rudderstack/analytics-js-common": "*",
         "@vespaiach/axios-fetch-adapter": "0.3.1",
         "assert": "2.1.0",
-        "axios": "1.13.6",
+        "axios": "1.15.1",
         "axios-retry": "4.5.0",
         "component-type": "2.0.0",
         "join-component": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@segment/top-domain": "3.0.1",
     "@vespaiach/axios-fetch-adapter": "0.3.1",
     "assert": "2.1.0",
-    "axios": "1.13.6",
+    "axios": "1.15.1",
     "axios-retry": "4.5.0",
     "component-each": "0.2.6",
     "component-emitter": "2.0.0",

--- a/packages/analytics-js-service-worker/.size-limit.mjs
+++ b/packages/analytics-js-service-worker/.size-limit.mjs
@@ -25,18 +25,18 @@ export default [
     name: 'Service Worker - Modern - NPM (ESM)',
     path: 'dist/npm/modern/esm/index.mjs',
     import: '*',
-    limit: '26.5 KiB',
+    limit: '27 KiB',
   },
   {
     name: 'Service Worker - Modern - NPM (CJS)',
     path: 'dist/npm/modern/cjs/index.cjs',
     import: '*',
-    limit: '26.5 KiB',
+    limit: '27 KiB',
   },
   {
     name: 'Service Worker - Modern - NPM (UMD)',
     path: 'dist/npm/modern/umd/index.js',
     import: '*',
-    limit: '26.5 KiB',
+    limit: '27 KiB',
   },
 ];

--- a/packages/analytics-js-service-worker/package.json
+++ b/packages/analytics-js-service-worker/package.json
@@ -93,7 +93,7 @@
     "@rudderstack/analytics-js-common": "*",
     "@vespaiach/axios-fetch-adapter": "0.3.1",
     "assert": "2.1.0",
-    "axios": "1.13.6",
+    "axios": "1.15.1",
     "axios-retry": "4.5.0",
     "component-type": "2.0.0",
     "join-component": "1.1.0",


### PR DESCRIPTION
## PR Description

Bumps `axios` from `1.13.6` to `1.15.1` to address two critical-severity security advisories (GHSA-fvcv-3m26-pcqx and GHSA-3p68-rc4w-qgx5). The version is updated in both the root `package.json` (monorepo hoisted dependency) and `packages/analytics-js-service-worker/package.json` (the only package that directly consumes axios). Axios is the HTTP client used in the service worker SDK for sending events to the data plane. The upgrade also pulls in `proxy-from-env` v2.1.0 as a transitive dependency update.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-4758/bump-axios-and-publish-a-new-js-sdk-version

## Cross Browser Tests

This is a server-side/service worker package with no browser UI. The HTTP transport layer is covered by unit tests. Cross-browser testing is not applicable for this change.

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

Addresses:
- GHSA-fvcv-3m26-pcqx — Axios Unrestricted Cloud Metadata Exfiltration via Header Injection Chain
- GHSA-3p68-rc4w-qgx5 — Axios NO_PROXY Hostname Normalization Bypass leading to SSRF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration size limits for Service Worker artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->