### PR TITLE
ci(deps): split dependabot npm groups by runtime vs toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
   # Runtime (shipped) prod deps + dev deps for the monorepo root.
   # Prod bumps are committed as `fix(deps):` so the release pipeline's conventional-commit
   # analyzer picks them up and bumps the packages that consume them (dev bumps stay as chore).
-  # Toolchain native binaries (@nx/*, @rollup/*, @swc/*) are excluded here and handled below.
+  # Toolchain packages (@nx/*, @rollup/rollup-*, @swc/core-*) are excluded here and handled below.
   - package-ecosystem: "npm"
     cooldown:
       default-days: 5
@@ -63,8 +63,9 @@ updates:
           - "major"
         dependency-type: "production"
 
-  # Build toolchain native binaries. These never ship in published bundles, so bumps
-  # are committed as `chore(deps):` and intentionally skipped by the release analyzer.
+  # Build toolchain packages — Nx (JS tooling + native runners) and Rollup/SWC native
+  # binaries. None of these ship in published bundles, so bumps are committed as
+  # `chore(deps):` and intentionally skipped by the release analyzer.
   - package-ecosystem: "npm"
     cooldown:
       default-days: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
         patterns:
           - "*"
 
+  # Runtime (shipped) prod deps + dev deps for the monorepo root.
+  # Prod bumps are committed as `fix(deps):` so the release pipeline's conventional-commit
+  # analyzer picks them up and bumps the packages that consume them (dev bumps stay as chore).
+  # Toolchain native binaries (@nx/*, @rollup/*, @swc/*) are excluded here and handled below.
   - package-ecosystem: "npm"
     cooldown:
       default-days: 5
@@ -30,6 +34,14 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "@nx/*"
+      - dependency-name: "@rollup/rollup-*"
+      - dependency-name: "@swc/core-*"
     groups:
       npm-dev-deps:
         patterns:
@@ -50,6 +62,36 @@ updates:
         update-types:
           - "major"
         dependency-type: "production"
+
+  # Build toolchain native binaries. These never ship in published bundles, so bumps
+  # are committed as `chore(deps):` and intentionally skipped by the release analyzer.
+  - package-ecosystem: "npm"
+    cooldown:
+      default-days: 5
+    directory: "/"
+    schedule:
+      interval: "cron"
+      # every wednesday at 00:01 UTC
+      cronjob: "1 0 * * 3"
+      timezone: "UTC"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "toolchain"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    allow:
+      - dependency-name: "@nx/*"
+      - dependency-name: "@rollup/rollup-*"
+      - dependency-name: "@swc/core-*"
+    groups:
+      npm-toolchain-deps:
+        patterns:
+          - "@nx/*"
+          - "@rollup/rollup-*"
+          - "@swc/core-*"
 
   # All sample applications managed together (excluding gatsby)
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary

Splits the root `npm` dependabot entry into two entries that differ on commit-message prefix:

- **Runtime (shipped) prod deps + dev deps** → `fix` prefix for prod, `chore` prefix for dev. Excludes `@nx/*`, `@rollup/rollup-*`, `@swc/core-*` via `ignore`.
- **Build toolchain native binaries** (`@nx/*`, `@rollup/rollup-*`, `@swc/core-*`) → separate entry with `chore` prefix and `allow`-scoped to just those patterns.

## Why

In the last release (#2966 — closed), prod-dep bumps were committed as `chore(deps): bump the npm-prod-deps group …`. The release pipeline uses `nx affected --target=version --skipCommitTypes=docs,ci,chore,test` combined with `@jscutlery/semver:version` — so `chore`-typed commits are intentionally skipped by the conventional-commit analyzer. The single `npm-prod-deps` group lumped shipped runtime deps (e.g. `@preact/signals-core`) together with build-only native binaries (Nx/Rollup/SWC platform artifacts) under one `chore(deps):` subject, so packages whose shipped runtime deps had actually changed (e.g. `@rudderstack/analytics-js`, `@rudderstack/analytics-js-common`) silently missed their patch bump.

With this split:
- Future runtime-dep PRs land as `fix(deps): …` → analyzer accepts → direct consumers patch-bump → `trackDeps: true` on each project's `version` target cascades bumps to transitive consumers via the Nx dep graph.
- Toolchain native-binary PRs remain `chore(deps): …` → analyzer skips, which is correct because those binaries never ship in published bundles.

## Notes

- The toolchain patterns are pinned to current consumers of root `optionalDependencies` in `package.json`; expand the `allow` list if new native-binary families are added.
- This PR only changes dependabot routing. The existing `chore(deps)` commits for `@preact/signals-core` already on `develop` still need a one-time bridging `fix(deps)` commit before the next `draft-new-release` run is triggered — tracked separately.

## Test plan

- [ ] CI lint on `.github/dependabot.yml` passes
- [ ] After merge, verify dependabot's next scheduled run opens runtime-dep PRs with a `fix(deps):` title and toolchain PRs with a `chore(deps):` title
- [ ] Confirm `draft-new-release` picks up `fix(deps)` runtime bumps and produces a populated version table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split automated dependency updates into separate streams for runtime and toolchain packages, enabling distinct scheduling and limits for each.
  * Adjusted update labeling and commit-message behavior to use different prefixes per stream, and narrowed each stream’s scope to target appropriate package groups for clearer, more controlled PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->