### PR TITLE
ci(release): push release tags at release-branch HEAD

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -158,11 +158,21 @@ jobs:
           files: |
             .
 
-      # jscutlery creates local tags against the pre-bump HEAD during `npm run release`,
-      # so they never match the signed-commit SHA created above. Instead of pushing those
-      # stale tags, derive the bumped tag names from each project.json's synced
-      # `targets.github.options.tag` and (re)create them via the Git Data API against the
-      # release branch HEAD. Idempotent — skips tags that already exist on origin.
+      # jscutlery runs with --skipCommit=true, so it writes version/changelog files but
+      # creates no commits or tags. The signed-commit action above packages all file
+      # changes into one verified commit on the release branch. This step then creates
+      # annotated tag objects (via the Git Data API) for each bumped package at that
+      # commit, and points tag refs at them.
+      #
+      # Tags are annotated but unsigned. Signed annotated tags would require providing
+      # a `signature` field on `POST /git/tags`, which means provisioning a GPG/SSH key
+      # as a workflow secret. That is out of scope for this change — accepted tradeoff:
+      # tag objects show "Unverified" while the target commit remains verified. Same
+      # behavior as the existing v<version> monorepo tag in publish-new-release.yml.
+      #
+      # Affected-package filter: a package gets a new tag only if its package.json
+      # `version` differs between the release branch HEAD and origin/main. Unchanged
+      # packages are skipped. Also idempotent against reruns: skips tags already on origin.
       - name: Push release tags to release branch HEAD
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -170,32 +180,39 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           git fetch origin "$BRANCH_NAME"
+          git fetch --no-tags origin main
           release_sha=$(git rev-parse "origin/$BRANCH_NAME")
           echo "Release branch HEAD: $release_sha"
-
-          tagger_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
           for pj in packages/*/project.json; do
             tag=$(jq -r '.targets.github.options.tag // empty' "$pj")
             [ -z "$tag" ] && continue
 
-            encoded=$(printf '%s' "$tag" | jq -sRr @uri)
+            pkg_dir=$(dirname "$pj")
+            current_version=$(git show "origin/${BRANCH_NAME}:${pkg_dir}/package.json" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
+            prev_version=$(git show "origin/main:${pkg_dir}/package.json" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
 
+            if [ -n "$prev_version" ] && [ "$current_version" = "$prev_version" ]; then
+              echo "Skipping ${tag} — version unchanged vs origin/main"
+              continue
+            fi
+
+            encoded=$(printf '%s' "$tag" | jq -sRr @uri)
             if gh api "repos/${REPO}/git/ref/tags/${encoded}" >/dev/null 2>&1; then
-              echo "Tag ${tag} already exists on remote, skipping"
+              echo "Tag ${tag} already exists on origin, skipping"
               continue
             fi
 
             echo "Creating annotated tag ${tag} -> ${release_sha}"
 
+            pkg_scope="${tag%@*}"
+            pkg_version="${tag##*@}"
+
             tag_obj_sha=$(gh api -X POST "repos/${REPO}/git/tags" \
               -f "tag=${tag}" \
-              -f "message=chore(release): ${tag}" \
+              -f "message=chore(${pkg_scope}): release version ${pkg_version}" \
               -f "object=${release_sha}" \
               -f "type=commit" \
-              -f "tagger[name]=GitHub actions" \
-              -f "tagger[email]=noreply@github.com" \
-              -f "tagger[date]=${tagger_date}" \
               --jq '.sha')
 
             gh api -X POST "repos/${REPO}/git/refs" \

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -164,15 +164,21 @@ jobs:
       # annotated tag objects (via the Git Data API) for each bumped package at that
       # commit, and points tag refs at them.
       #
-      # Tags are annotated but unsigned. Signed annotated tags would require providing
-      # a `signature` field on `POST /git/tags`, which means provisioning a GPG/SSH key
-      # as a workflow secret. That is out of scope for this change — accepted tradeoff:
-      # tag objects show "Unverified" while the target commit remains verified. Same
-      # behavior as the existing v<version> monorepo tag in publish-new-release.yml.
+      # Tag objects are unsigned. GitHub's Git Data API for `POST /git/tags` does not
+      # accept a signature in its payload; producing a signed tag would require running
+      # `git tag -s` locally with a signing key provisioned as a workflow secret, which
+      # is out of scope. Accepted tradeoff: tag objects show "Unverified" while the
+      # target commit remains verified. Same behavior as the monorepo v<version> tag
+      # in publish-new-release.yml.
       #
       # Affected-package filter: a package gets a new tag only if its package.json
       # `version` differs between the release branch HEAD and origin/main. Unchanged
-      # packages are skipped. Also idempotent against reruns: skips tags already on origin.
+      # packages are skipped.
+      #
+      # Idempotence: if the tag already exists on origin, dereference it and only skip
+      # when it already points at the current release_sha. If it points elsewhere, fail
+      # loudly so we don't quietly leave a mispointed tag in place (that class of bug is
+      # exactly what caused the cc04066f-vs-bc75c04 mismatch in the previous release).
       - name: Push release tags to release branch HEAD
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -192,15 +198,31 @@ jobs:
             current_version=$(git show "origin/${BRANCH_NAME}:${pkg_dir}/package.json" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
             prev_version=$(git show "origin/main:${pkg_dir}/package.json" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
 
+            if [ -z "$current_version" ]; then
+              echo "::error::Unable to read version for ${pkg_dir}; refusing to tag ${tag}"
+              exit 1
+            fi
+
             if [ -n "$prev_version" ] && [ "$current_version" = "$prev_version" ]; then
               echo "Skipping ${tag} — version unchanged vs origin/main"
               continue
             fi
 
             encoded=$(printf '%s' "$tag" | jq -sRr @uri)
-            if gh api "repos/${REPO}/git/ref/tags/${encoded}" >/dev/null 2>&1; then
-              echo "Tag ${tag} already exists on origin, skipping"
-              continue
+            if existing_ref=$(gh api "repos/${REPO}/git/ref/tags/${encoded}" 2>/dev/null); then
+              existing_type=$(printf '%s' "$existing_ref" | jq -r '.object.type')
+              existing_obj=$(printf '%s' "$existing_ref" | jq -r '.object.sha')
+              if [ "$existing_type" = "tag" ]; then
+                existing_commit=$(gh api "repos/${REPO}/git/tags/${existing_obj}" --jq '.object.sha')
+              else
+                existing_commit="$existing_obj"
+              fi
+              if [ "$existing_commit" = "$release_sha" ]; then
+                echo "Tag ${tag} already points at ${release_sha}, skipping"
+                continue
+              fi
+              echo "::error::Tag ${tag} exists on origin but points at ${existing_commit} (expected ${release_sha})"
+              exit 1
             fi
 
             echo "Creating annotated tag ${tag} -> ${release_sha}"
@@ -208,14 +230,14 @@ jobs:
             pkg_scope="${tag%@*}"
             pkg_version="${tag##*@}"
 
-            tag_obj_sha=$(gh api -X POST "repos/${REPO}/git/tags" \
+            tag_obj_sha=$(gh api --method POST "repos/${REPO}/git/tags" \
               -f "tag=${tag}" \
               -f "message=chore(${pkg_scope}): release version ${pkg_version}" \
               -f "object=${release_sha}" \
               -f "type=commit" \
               --jq '.sha')
 
-            gh api -X POST "repos/${REPO}/git/refs" \
+            gh api --method POST "repos/${REPO}/git/refs" \
               -f "ref=refs/tags/${tag}" \
               -f "sha=${tag_obj_sha}"
           done

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -158,6 +158,51 @@ jobs:
           files: |
             .
 
+      # jscutlery creates local tags against the pre-bump HEAD during `npm run release`,
+      # so they never match the signed-commit SHA created above. Instead of pushing those
+      # stale tags, derive the bumped tag names from each project.json's synced
+      # `targets.github.options.tag` and (re)create them via the Git Data API against the
+      # release branch HEAD. Idempotent — skips tags that already exist on origin.
+      - name: Push release tags to release branch HEAD
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BRANCH_NAME: ${{ steps.create-release.outputs.branch_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          git fetch origin "$BRANCH_NAME"
+          release_sha=$(git rev-parse "origin/$BRANCH_NAME")
+          echo "Release branch HEAD: $release_sha"
+
+          tagger_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          for pj in packages/*/project.json; do
+            tag=$(jq -r '.targets.github.options.tag // empty' "$pj")
+            [ -z "$tag" ] && continue
+
+            encoded=$(printf '%s' "$tag" | jq -sRr @uri)
+
+            if gh api "repos/${REPO}/git/ref/tags/${encoded}" >/dev/null 2>&1; then
+              echo "Tag ${tag} already exists on remote, skipping"
+              continue
+            fi
+
+            echo "Creating annotated tag ${tag} -> ${release_sha}"
+
+            tag_obj_sha=$(gh api -X POST "repos/${REPO}/git/tags" \
+              -f "tag=${tag}" \
+              -f "message=chore(release): ${tag}" \
+              -f "object=${release_sha}" \
+              -f "type=commit" \
+              -f "tagger[name]=GitHub actions" \
+              -f "tagger[email]=noreply@github.com" \
+              -f "tagger[date]=${tagger_date}" \
+              --jq '.sha')
+
+            gh api -X POST "repos/${REPO}/git/refs" \
+              -f "ref=refs/tags/${tag}" \
+              -f "sha=${tag_obj_sha}"
+          done
+
       - name: Generate packages versions table
         id: packages-versions
         run: |

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -111,10 +111,16 @@ jobs:
           ref: ${{ github.sha }}
           token: ${{ steps.generate-token.outputs.token }}
 
-      # Annotated tag object (unsigned) + ref. Unsigned tag objects show as "Unverified"
-      # on the Releases page; adding a signature would require provisioning a GPG/SSH
-      # key as a workflow secret, which is out of scope. Accepted tradeoff: tag object
-      # shows "Unverified" while the target release-merge commit remains verified.
+      # Annotated tag object (unsigned) + ref. GitHub's Git Data API for `POST /git/tags`
+      # does not accept a signature in its payload; producing a signed tag would require
+      # running `git tag -s` locally with a signing key provisioned as a workflow secret,
+      # which is out of scope. Accepted tradeoff: tag object shows "Unverified" while
+      # the target release-merge commit remains verified.
+      #
+      # Idempotence: if the tag already exists on origin, dereference it and only exit 0
+      # when it already points at the current COMMIT_SHA. If it points elsewhere, fail
+      # loudly — re-running this job after a partial failure should not silently leave
+      # a mispointed tag in place.
       - name: Create monorepo release tag via API
         id: create_monorepo_release
         env:
@@ -123,14 +129,31 @@ jobs:
           REPO: ${{ github.repository }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          tag_obj_sha=$(gh api -X POST "repos/${REPO}/git/tags" \
+          encoded=$(printf '%s' "v${RELEASE_VERSION}" | jq -sRr @uri)
+          if existing_ref=$(gh api "repos/${REPO}/git/ref/tags/${encoded}" 2>/dev/null); then
+            existing_type=$(printf '%s' "$existing_ref" | jq -r '.object.type')
+            existing_obj=$(printf '%s' "$existing_ref" | jq -r '.object.sha')
+            if [ "$existing_type" = "tag" ]; then
+              existing_commit=$(gh api "repos/${REPO}/git/tags/${existing_obj}" --jq '.object.sha')
+            else
+              existing_commit="$existing_obj"
+            fi
+            if [ "$existing_commit" = "$COMMIT_SHA" ]; then
+              echo "Tag v${RELEASE_VERSION} already points at ${COMMIT_SHA}, nothing to do"
+              exit 0
+            fi
+            echo "::error::Tag v${RELEASE_VERSION} exists on origin but points at ${existing_commit} (expected ${COMMIT_SHA})"
+            exit 1
+          fi
+
+          tag_obj_sha=$(gh api --method POST "repos/${REPO}/git/tags" \
             -f "tag=v${RELEASE_VERSION}" \
             -f "message=chore(monorepo): release v${RELEASE_VERSION}" \
             -f "object=${COMMIT_SHA}" \
             -f "type=commit" \
             --jq '.sha')
 
-          gh api -X POST "repos/${REPO}/git/refs" \
+          gh api --method POST "repos/${REPO}/git/refs" \
             -f "ref=refs/tags/v${RELEASE_VERSION}" \
             -f "sha=${tag_obj_sha}"
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -111,20 +111,28 @@ jobs:
           ref: ${{ github.sha }}
           token: ${{ steps.generate-token.outputs.token }}
 
+      # Annotated tag object (unsigned) + ref. Unsigned tag objects show as "Unverified"
+      # on the Releases page; adding a signature would require provisioning a GPG/SSH
+      # key as a workflow secret, which is out of scope. Accepted tradeoff: tag object
+      # shows "Unverified" while the target release-merge commit remains verified.
       - name: Create monorepo release tag via API
         id: create_monorepo_release
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
+          REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          TAG_SHA=$(gh api repos/${{ github.repository }}/git/tags \
-            -f tag='v${{ steps.extract-version.outputs.release_version }}' \
-            -f message='chore(monorepo): release v${{ steps.extract-version.outputs.release_version }}' \
-            -f object='${{ github.sha }}' \
-            -f type='commit' --jq '.sha')
+          tag_obj_sha=$(gh api -X POST "repos/${REPO}/git/tags" \
+            -f "tag=v${RELEASE_VERSION}" \
+            -f "message=chore(monorepo): release v${RELEASE_VERSION}" \
+            -f "object=${COMMIT_SHA}" \
+            -f "type=commit" \
+            --jq '.sha')
 
-          gh api repos/${{ github.repository }}/git/refs \
-            -f ref='refs/tags/v${{ steps.extract-version.outputs.release_version }}' \
-            -f sha="$TAG_SHA"
+          gh api -X POST "repos/${REPO}/git/refs" \
+            -f "ref=refs/tags/v${RELEASE_VERSION}" \
+            -f "sha=${tag_obj_sha}"
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary

Two workflow fixes for release tag handling, using only the existing `RELEASE_APP_ID` GitHub App token. Tags are created via the Git Data API (`POST /git/tags` + `POST /git/refs`) as **annotated tags**, unsigned. Accepted tradeoff: the tag objects will show "Unverified" on the Releases page (same as the current `v<version>` monorepo tag) — signing would require provisioning a GPG/SSH key as a workflow secret, which is out of scope.

1. **`draft-new-release.yml`** — new step after the signed-commit push creates an annotated tag for each **affected** package at the release-branch HEAD.
2. **`publish-new-release.yml`** — existing monorepo `v…` tag step refactored to move context interpolations into env vars (safer input handling). Behaviourally identical to before.

Previous release had six tags on `cc04066f` (pre-bump develop HEAD) instead of `bc75c04` (the signed release commit that actually carries the version bumps + changelog). Root cause: jscutlery runs with `--skipCommit=true`, so it only mutates files — no commits, no tags. The signed-commit action then packages mutations into one verified commit. Tags used to be created out-of-band later, against whatever HEAD happened to be there. This PR pins tag creation to the signed commit's SHA, right after it's pushed.

## draft-new-release.yml flow

After `ryancyq/github-signed-commit` pushes the release commit:

1. `git fetch origin $BRANCH_NAME` and `git fetch --no-tags origin main`.
2. For each `packages/*/project.json`:
   - Read `.targets.github.options.tag` (synced to the new version by `scripts/sync-tags-in-nx-projects.sh`).
   - **Affected filter**: compare `package.json:.version` at `origin/$BRANCH_NAME` vs `origin/main`. Skip unchanged.
   - Skip tags that already exist on origin (idempotent).
   - `POST /git/tags` → annotated tag object with tagger = `rudderstack-github-actions[bot]`.
   - `POST /git/refs` → ref pointing at the tag object SHA.

## publish-new-release.yml flow

Unchanged overall — still creates an annotated tag + ref. Just moves `${{ ... }}` context values into env vars per the security hook's guidance (`RELEASE_VERSION`, `REPO`, `COMMIT_SHA`, `GH_TOKEN`).

## Why unsigned

`POST /git/tags` accepts an optional `signature` field. Providing it requires a pre-computed PGP/SSH signature over the tag payload, which means a signing key. The GitHub App token cannot sign tag objects on its own — no API equivalent of `createCommitOnBranch`'s auto-signing exists for tags. Adding a signing key would mean:
- Generating a key pair.
- Attaching the public half to a GitHub user account (preferably a machine user).
- Storing the private half as a workflow secret.

Not doing this right now; if verified tag objects become a hard requirement, it's a follow-up PR.

## Test plan

- [ ] After merge, trigger `draft-new-release` for the next release; confirm:
  - Only affected packages get new tags (skipped entries logged for unchanged packages).
  - Tags point at the signed-commit SHA, not the pre-bump develop HEAD.
  - Re-running the workflow on the same release branch is a no-op for tag creation.
- [ ] Merge the release PR; confirm the `v…` monorepo tag is created correctly (annotated, unsigned) pointing at `github.sha`.

## Related

Previous release's six package tags were manually re-tagged at `bc75c04` earlier today under `+bc75c04` build-metadata-suffixed names. The originals (`@rudderstack/analytics-js@3.31.0`, `@rudderstack/analytics-js-common@3.28.1`, etc.) are permanently unusable because immutable-releases had reserved those exact tag names on the repo.