### PR TITLE
fix(PinterestTag): event_id missing for Pinterest page and identify events

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/PinterestTag/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/PinterestTag/browser.test.js
@@ -1,0 +1,155 @@
+import PinterestTag from '../../../src/integrations/PinterestTag/browser';
+
+const destinationInfo = {
+  areTransformationsConnected: false,
+  destinationId: 'sample-destination-id',
+};
+
+const analytics = {
+  logLevel: 'debug',
+  getUserTraits: () => ({}),
+  userTraits: {},
+};
+
+const basicConfig = {
+  tagId: '123456',
+  enhancedMatch: false,
+  customProperties: [],
+  eventsMapping: [],
+  sendAsCustomEvent: false,
+};
+
+const defaultContext = { traits: {} };
+
+describe('PinterestTag', () => {
+  beforeEach(() => {
+    window.pintrk = jest.fn();
+    const scriptElement = document.createElement('script');
+    scriptElement.type = 'text/javascript';
+    scriptElement.id = 'dummyScript';
+    const headElements = document.getElementsByTagName('head');
+    headElements[0].insertBefore(scriptElement, headElements[0].firstChild);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    const dummyScript = document.getElementById('dummyScript');
+    if (dummyScript) {
+      dummyScript.remove();
+    }
+  });
+
+  describe('event_id deduplication', () => {
+    describe('track', () => {
+      it.each([
+        {
+          scenario: 'no deduplicationKey configured',
+          config: basicConfig,
+          properties: { customId: 'custom-456' },
+          expectedEventId: 'msg-track-123',
+        },
+        {
+          scenario: 'custom deduplicationKey resolves',
+          config: { ...basicConfig, deduplicationKey: 'properties.customId' },
+          properties: { customId: 'custom-456' },
+          expectedEventId: 'custom-456',
+        },
+        {
+          scenario: 'deduplicationKey resolves to a falsy value',
+          config: { ...basicConfig, deduplicationKey: 'properties.customId' },
+          properties: { customId: 0 },
+          expectedEventId: 0,
+        },
+        {
+          scenario: 'deduplicationKey path does not resolve',
+          config: { ...basicConfig, deduplicationKey: 'properties.nonExistent' },
+          properties: {},
+          expectedEventId: 'msg-track-123',
+        },
+      ])('should set event_id correctly when $scenario', ({ config, properties, expectedEventId }) => {
+        const pinterestTag = new PinterestTag(config, analytics, destinationInfo);
+        pinterestTag.init();
+
+        pinterestTag.track({
+          message: {
+            event: 'TestEvent',
+            messageId: 'msg-track-123',
+            context: defaultContext,
+            properties,
+          },
+        });
+
+        const pintrkCall = window.pintrk.mock.calls.find(
+          (call) => call[0] === 'track' && call[1] === 'TestEvent',
+        );
+        expect(pintrkCall).toBeDefined();
+        expect(pintrkCall[2].event_id).toBe(expectedEventId);
+      });
+    });
+
+    describe('page', () => {
+      it.each([
+        {
+          scenario: 'no deduplicationKey configured',
+          config: basicConfig,
+          message: { name: 'Home', messageId: 'msg-page-123', context: defaultContext },
+          expectedEventId: 'msg-page-123',
+        },
+        {
+          scenario: 'custom deduplicationKey resolves',
+          config: { ...basicConfig, deduplicationKey: 'properties.customId' },
+          message: { name: 'Home', messageId: 'msg-page-123', context: defaultContext, properties: { customId: 'custom-page-789' } },
+          expectedEventId: 'custom-page-789',
+        },
+        {
+          scenario: 'deduplicationKey path does not resolve',
+          config: { ...basicConfig, deduplicationKey: 'properties.nonExistent' },
+          message: { name: 'Home', messageId: 'msg-page-123', context: defaultContext },
+          expectedEventId: 'msg-page-123',
+        },
+      ])('should set event_id correctly when $scenario', ({ config, message, expectedEventId }) => {
+        const pinterestTag = new PinterestTag(config, analytics, destinationInfo);
+        pinterestTag.init();
+
+        pinterestTag.page({ message });
+
+        const pintrkCall = window.pintrk.mock.calls.find((call) => call[0] === 'track');
+        expect(pintrkCall).toBeDefined();
+        expect(pintrkCall[2].event_id).toBe(expectedEventId);
+      });
+    });
+
+    describe('identify', () => {
+      const identifyTraits = { email: 'test@example.com' };
+
+      it.each([
+        {
+          scenario: 'no deduplicationKey configured',
+          config: basicConfig,
+          expectedEventId: 'msg-identify-123',
+        },
+        {
+          scenario: 'custom deduplicationKey resolves',
+          config: { ...basicConfig, deduplicationKey: 'context.traits.email' },
+          expectedEventId: 'test@example.com',
+        },
+      ])('should set event_id correctly when $scenario', ({ config, expectedEventId }) => {
+        const pinterestTag = new PinterestTag(config, analytics, destinationInfo);
+        pinterestTag.init();
+
+        pinterestTag.identify({
+          message: {
+            messageId: 'msg-identify-123',
+            context: { traits: identifyTraits },
+          },
+        });
+
+        const setCall = window.pintrk.mock.calls.find(
+          (call) => call[0] === 'set' && call[1]?.em === identifyTraits.email,
+        );
+        expect(setCall).toBeDefined();
+        expect(setCall[1].event_id).toBe(expectedEventId);
+      });
+    });
+  });
+});

--- a/packages/analytics-js-integrations/src/integrations/PinterestTag/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/PinterestTag/browser.js
@@ -111,6 +111,10 @@ export default class PinterestTag {
     window.pintrk('track', eventName, pinterestObject);
   }
 
+  setEventId(payload, message) {
+    payload.event_id = get(message, `${this.deduplicationKey}`) ?? message.messageId;
+  }
+
   /**
    * Send rudder property and mappings array. This function will return data mapping destination property
    * @param {*} properties
@@ -199,7 +203,7 @@ export default class PinterestTag {
     if (!message?.event) {
       return;
     }
-    const { properties, event, messageId } = message;
+    const { properties, event } = message;
     const destEventArray = getDestinationEventName(
       event,
       this.userDefinedEventsMapping,
@@ -207,31 +211,35 @@ export default class PinterestTag {
     );
     destEventArray.forEach(eventName => {
       const pinterestObject = this.generatePinterestObject(properties);
-      pinterestObject.event_id = get(message, `${this.deduplicationKey}`) || messageId;
+      this.setEventId(pinterestObject, message);
       this.setLdp(message);
       this.sendPinterestTrack(eventName, pinterestObject);
     });
   }
 
   page(rudderElement) {
-    const { category, name } = rudderElement.message;
+    const { message } = rudderElement;
+    const { category, name } = message;
     const pageObject = { name: name || '' };
     let event = 'PageVisit';
     if (category) {
       pageObject.category = category;
       event = 'ViewCategory';
     }
-    this.setLdp(rudderElement.message);
+    this.setEventId(pageObject, message);
+    this.setLdp(message);
     window.pintrk('track', event, pageObject);
   }
 
   identify(rudderElement) {
-    const { context } = rudderElement.message;
-    const userTraits = context?.traits || {};
+    const { message } = rudderElement;
+    const userTraits = message.context?.traits || {};
     const { email } = userTraits;
     if (email) {
       const ldpObject = this.generateLdpObject();
-      window.pintrk('set', { em: email, ...ldpObject });
+      const payload = { em: email, ...ldpObject };
+      this.setEventId(payload, message);
+      window.pintrk('set', payload);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Pinterest device mode `page()` and `identify()` events were missing `event_id`, preventing deduplication — only `track()` set it
- Added `setEventId(payload, message)` helper that resolves `event_id` from configurable `deduplicationKey` or falls back to `messageId`
- Applied `setEventId` to all event types (track, page, identify)
- Used nullish coalescing (`??`) so falsy-but-valid dedup values (e.g. `0`) are preserved

Resolves [INT-6364](https://linear.app/rudderstack/issue/INT-6364/check-if-duplication-key-for-pinterest-supports-device-mode)

## Test plan
- [x] Table-driven unit tests covering `event_id` across track, page, and identify (9 test cases)
- [x] Verified default `messageId` fallback, custom `deduplicationKey` resolution, falsy value preservation, and unresolvable key fallback
- [x] All 966 integration tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)