### PR TITLE
ci(deps): consolidate dependabot npm entries for root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,12 @@ updates:
         patterns:
           - "*"
 
-  # Runtime (shipped) prod deps + dev deps for the monorepo root.
+  # All deps for the monorepo root (prod + dev, including toolchain).
   # Prod bumps are committed as `fix(deps):` so the release pipeline's conventional-commit
-  # analyzer picks them up and bumps the packages that consume them (dev bumps stay as chore).
-  # Toolchain packages (@nx/*, @rollup/rollup-*, @swc/core-*) are excluded here and handled below.
+  # analyzer picks them up and bumps the packages that consume them; dev bumps stay as `chore`.
+  # Override the PR title manually when a bump shouldn't trigger a release (e.g. toolchain-only).
+  # Note: Dependabot does not allow two npm entries for the same directory + target-branch,
+  # so per-group commit prefixes are not possible — keep this as a single entry.
   - package-ecosystem: "npm"
     cooldown:
       default-days: 5
@@ -38,10 +40,6 @@ updates:
       prefix: "fix"
       prefix-development: "chore"
       include: "scope"
-    ignore:
-      - dependency-name: "@nx/*"
-      - dependency-name: "@rollup/rollup-*"
-      - dependency-name: "@swc/core-*"
     groups:
       npm-dev-deps:
         patterns:
@@ -62,37 +60,6 @@ updates:
         update-types:
           - "major"
         dependency-type: "production"
-
-  # Build toolchain packages — Nx (JS tooling + native runners) and Rollup/SWC native
-  # binaries. None of these ship in published bundles, so bumps are committed as
-  # `chore(deps):` and intentionally skipped by the release analyzer.
-  - package-ecosystem: "npm"
-    cooldown:
-      default-days: 5
-    directory: "/"
-    schedule:
-      interval: "cron"
-      # every wednesday at 00:01 UTC
-      cronjob: "1 0 * * 3"
-      timezone: "UTC"
-    target-branch: "develop"
-    labels:
-      - "dependencies"
-      - "toolchain"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    allow:
-      - dependency-name: "@nx/*"
-      - dependency-name: "@rollup/rollup-*"
-      - dependency-name: "@swc/core-*"
-    groups:
-      npm-toolchain-deps:
-        patterns:
-          - "@nx/*"
-          - "@rollup/rollup-*"
-          - "@swc/core-*"
 
   # All sample applications managed together (excluding gatsby)
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary

- Drop the second `package-ecosystem: "npm"` entry for `/` + `develop` that was introduced in #2968. Dependabot does not support two npm entries that share the same directory + target-branch, so the toolchain block was silently inactive: no `npm-toolchain-deps` PR has ever been opened, and toolchain packages (`@rollup/rollup-*`, `@swc/core-*`, `@nx/nx-*`) were still being grouped into `npm-prod-deps` with a `chore` prefix instead of the configured `fix`.
- Remove the `ignore` list as well — all root npm deps now flow through a single entry. Prod bumps land as `fix(deps):` (so the release pipeline's conventional-commit analyzer picks them up); dev bumps stay as `chore(deps-dev):`. PR titles can be overridden manually for toolchain-only bumps that shouldn't trigger a release.
- Update the inline comment to document the single-entry constraint so it doesn't get re-split.

## Why this matters

Since #2968 was merged, every `npm-prod-deps` PR (#2979, #2994, #3007) contained only toolchain packages and shipped as `chore(deps):`. Zero `fix(deps):` PRs have been produced from Dependabot — meaning the release pipeline has not been auto-bumping consumers for any runtime prod-dep change. This restores that behavior.

## Test plan

- [ ] Wait for the next Wednesday Dependabot run and confirm prod-dep bumps appear as `fix(deps):` and dev-dep bumps as `chore(deps-dev):`.
- [ ] Confirm toolchain bumps now also flow through (and override the PR title manually if a given bump shouldn't drive a release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated Dependabot configuration to clarify dependency bump labeling practices between production and development environments and streamline toolchain package update handling within the monorepo's primary dependency management system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rudderlabs/rudder-sdk-js/pull/3014)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->