### PR TITLE
docs: fix typo in rudder-transformer link text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ RudderStack primarily supports two [connection modes](https://www.rudderstack.co
 2. **Device Mode Integration**: Events are sent directly from the client to the destination in this mode. Depending upon the client where you are collecting events from, the respective RudderStack client SDK (e.g. `rudder-sdk-js` for the web client) is responsible to transform and deliver these events (using the destination SDK).
 
 ## Developing _cloud mode_ RudderStack integration
-Follow the guide in [Contributing.md of the `rudder-transfomer` repo](https://github.com/rudderlabs/rudder-transformer/blob/docs-contrib-guide/CONTRIBUTING.md#building-your-first-custom-rudderStack-destination-integration) as
+Follow the guide in [Contributing.md of the `rudder-transformer` repo](https://github.com/rudderlabs/rudder-transformer/blob/docs-contrib-guide/CONTRIBUTING.md#building-your-first-custom-rudderStack-destination-integration) as
 the `rudder-transformer` is responsible for the **cloud mode** transformation.
 
 ## Developing _device mode_ RudderStack integration


### PR DESCRIPTION
## PR Description

This PR fixes a typo in `CONTRIBUTING.md`. In the "Developing _cloud mode_ RudderStack integration" section, the link text referencing the `rudder-transformer` repo was misspelled as "rudder-transfomer". The text has been corrected to "rudder-transformer" so the documentation reads correctly. This is a documentation-only change with no functional impact on the SDK.

## Linear task (optional)

SDK-4935

## Cross Browser Tests

Documentation-only change; no browser-specific behavior is affected.

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

Documentation-only change; no impact on the sanity suite.

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed an incorrect repository reference link in the contributing guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->