### PR TITLE
ci(release): allow entire SDK team to trigger workflows [SDK-4972]

### DIFF
--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/validate-actor.yml
     with:
-      team_names: 'js-sdk,integrations'
+      team_names: 'sdk_team,integrations'
     secrets:
       RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/heads/') }}
     uses: ./.github/workflows/validate-actor.yml
     with:
-      team_names: 'js-sdk,integrations'
+      team_names: 'sdk_team,integrations'
     secrets:
       RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/')
     uses: ./.github/workflows/validate-actor.yml
     with:
-      team_names: 'js-sdk,integrations'
+      team_names: 'sdk_team,integrations'
     secrets:
       RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -27,7 +27,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     uses: ./.github/workflows/validate-actor.yml
     with:
-      team_names: 'js-sdk,integrations'
+      team_names: 'sdk_team,integrations'
     secrets:
       RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       team_names:
-        description: 'Comma-separated list of team names'
+        description: 'Comma-separated list of GitHub team slugs (URL slug, not display name)'
         type: string
         default: 'sdk_team'
     secrets:

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -6,7 +6,7 @@ on:
       team_names:
         description: 'Comma-separated list of team names'
         type: string
-        default: 'js-sdk'
+        default: 'sdk_team'
     secrets:
       RELEASE_PRIVATE_KEY:
         required: true


### PR DESCRIPTION
## PR Description

The manual-dispatch (`workflow_dispatch`) release workflows gate the triggering user through `validate-actor.yml`, which checks GitHub org team membership. They were configured to allow only the `js-sdk` team (3 members), so other SDK-team members who own a release could not trigger them — during the v3.111.0 release (SDK-4971) the release owner was blocked from running `Draft a new release` and had to ask a `js-sdk` member to trigger it.

This change replaces the `js-sdk` team with the broader `sdk_team` (the entire SDK team, a superset of `js-sdk`) in the actor allow-list, so any SDK-team member can trigger the release-related workflows. The `integrations` team continues to be allowed.

Updated workflows:
- `draft-new-release.yml` — `team_names: 'sdk_team,integrations'`
- `create-hotfix-branch.yml` — `team_names: 'sdk_team,integrations'`
- `deploy-beta.yml` — `team_names: 'sdk_team,integrations'`
- `rollback.yml` — `team_names: 'sdk_team,integrations'`
- `validate-actor.yml` — default `team_names` updated to `'sdk_team'`

No change to the validation logic itself, the branch restrictions, or any release behaviour — only the set of teams permitted to trigger.

> Note: `sdk_team` is a superset of `js-sdk`, so no existing trigger access is removed. For a previously-excluded member to actually trigger a workflow they must be a member of the `sdk_team` GitHub org team (an org-level membership concern, outside this PR).

## Linear task (optional)

[SDK-4972](https://linear.app/rudderstack/issue/SDK-4972/allow-the-entire-sdk-team-to-trigger-release-github-actions-workflows)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

> N/A — CI/workflow configuration change only, no SDK runtime code affected.

## Sanity Suite

- [ ] All sanity suite test cases pass locally

> N/A — no SDK code changes.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

The actor validation mechanism is unchanged; access is broadened from one SDK sub-team to the parent SDK team only. Branch/tag restrictions on each workflow remain intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow team configuration: replaced an internal team identifier with a new one and clarified that team names should use GitHub team slugs (URL slug, not display name).
  * Applied these updates across deployment, release drafting, rollback, beta, and validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->