### PR TITLE
feat: braze ecommerce events onboarding

### DIFF
--- a/packages/analytics-js-integrations/.size-limit.mjs
+++ b/packages/analytics-js-integrations/.size-limit.mjs
@@ -6,7 +6,7 @@ export default [
   {
     name: 'All Integrations - Legacy - CDN',
     path: 'dist/cdn/legacy/js-integrations/*.min.js',
-    limit: '97 KiB',
+    limit: '98.5 KiB',
   },
   {
     name: 'All Integrations - Modern - CDN',

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1399,7 +1399,7 @@ describe('track - recommended ecommerce events', () => {
     expect(globalThis.braze.logCustomEvent.mock.calls[0][1]).not.toHaveProperty('products');
   });
 
-  it('honors an explicit valid properties.source override', () => {
+  it('always reports source as web, ignoring a caller-supplied properties.source', () => {
     const braze = buildBraze();
     trackEvent(braze, 'Product Viewed', {
       product_id: 'p1',
@@ -1407,24 +1407,13 @@ describe('track - recommended ecommerce events', () => {
       variant: 'v1',
       price: 15.99,
       currency: 'USD',
-      source: 'ios',
+      source: 'ios', // this is the web SDK — the override must be ignored
     });
 
-    expect(globalThis.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
-  });
-
-  it('honors an explicit properties.source with surrounding whitespace', () => {
-    const braze = buildBraze();
-    trackEvent(braze, 'Product Viewed', {
-      product_id: 'p1',
-      name: 'Game',
-      variant: 'v1',
-      price: 15.99,
-      currency: 'USD',
-      source: 'ios ',
-    });
-
-    expect(globalThis.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.source).toBe('web');
+    // the ignored value must not leak into metadata either
+    expect(props.metadata).toBeUndefined();
   });
 
   it('warns and scrubs a required field provided as an empty object', () => {

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1084,7 +1084,7 @@ describe('track - recommended ecommerce events', () => {
     enableBrazeLogging: false,
     dataCenter: 'US-03',
     allowUserSuppliedJavascript: false,
-    useRecommendedEcommerceEvents: true,
+    useEcommerceRecommendedEvents: true,
   };
 
   const buildBraze = (configOverrides = {}) => {
@@ -1521,6 +1521,22 @@ describe('track - recommended ecommerce events', () => {
     expect(warnMock.mock.calls[0][0]).toContain('type (expected stringArray)');
   });
 
+  it('does not coerce a boolean to string; sends it as-is and warns', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Viewed', {
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      price: 15.99,
+      currency: true, // boolean on a string field — not coerced
+    });
+
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.currency).toBe(true); // sent verbatim, not "true"
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('currency (expected string)');
+  });
+
   it('falls through to legacy custom-event path for unmapped events (Cart Updated)', () => {
     const braze = buildBraze();
     trackEvent(braze, 'Cart Updated', { cart_id: 'c1', value: 10 });
@@ -1532,7 +1548,7 @@ describe('track - recommended ecommerce events', () => {
   });
 
   it('falls through to legacy purchase path when the flag is off', () => {
-    const braze = buildBraze({ useRecommendedEcommerceEvents: false });
+    const braze = buildBraze({ useEcommerceRecommendedEvents: false });
     trackEvent(braze, 'order completed', {
       currency: 'USD',
       products: [{ product_id: 'p1', price: 15.99, quantity: 1 }],

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1107,7 +1107,7 @@ describe('track - recommended ecommerce events', () => {
       currency: 'USD',
       image_url: 'https://img/p1.png',
       url: 'https://shop/p1',
-      type: 'digital',
+      type: ['price_drop'],
       campaign: 'summer',
     });
 
@@ -1120,7 +1120,7 @@ describe('track - recommended ecommerce events', () => {
       currency: 'USD',
       image_url: 'https://img/p1.png',
       product_url: 'https://shop/p1',
-      type: 'digital',
+      type: ['price_drop'],
       source: 'web',
       metadata: { campaign: 'summer' },
     });
@@ -1443,6 +1443,82 @@ describe('track - recommended ecommerce events', () => {
     expect(warnMock.mock.calls[0][0]).toContain('currency');
     // ...and never reaches the sent payload.
     expect(globalThis.braze.logCustomEvent.mock.calls[0][1]).not.toHaveProperty('currency');
+  });
+
+  it('coerces safe/lossless type mismatches and does not warn', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Order Completed', {
+      order_id: 12345, // number -> string
+      total: '99.99', // numeric string -> float
+      currency: 'USD',
+      products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: '2', price: '15.99' }],
+    });
+
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.order_id).toBe('12345');
+    expect(props.total_value).toBe(99.99);
+    expect(props.products[0].quantity).toBe(2);
+    expect(props.products[0].price).toBe(15.99);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('sends un-coercible type mismatches as-is and warns (event-level and per-product)', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Order Completed', {
+      order_id: 'o1',
+      total: 'free', // non-numeric string -> stays, float mismatch
+      currency: 'USD',
+      products: [
+        { product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2.5, price: 15.99 }, // 2.5 not integer
+      ],
+    });
+
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
+    // un-coercible values are sent verbatim
+    expect(props.total_value).toBe('free');
+    expect(props.products[0].quantity).toBe(2.5);
+    // ...and surfaced via the type-mismatch warning
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    const warnMessage = warnMock.mock.calls[0][0];
+    expect(warnMessage).toContain('type-mismatched');
+    expect(warnMessage).toContain('total_value (expected float)');
+    expect(warnMessage).toContain('products.quantity (expected integer)');
+  });
+
+  it('leaves an integer-valued string with a fractional part un-coerced for an integer field', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Added', {
+      cart_id: 'c1',
+      currency: 'USD',
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      quantity: '2.5', // not a pure integer literal -> stays "2.5"
+      price: '15.99', // numeric string -> 15.99
+    });
+
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.products[0].quantity).toBe('2.5');
+    expect(props.products[0].price).toBe(15.99);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('products.quantity (expected integer)');
+  });
+
+  it('warns when product_viewed type is not an array of strings', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Viewed', {
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      price: 15.99,
+      currency: 'USD',
+      type: 'price_drop', // bare string, expected array of strings
+    });
+
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.type).toBe('price_drop'); // sent as-is
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('type (expected stringArray)');
   });
 
   it('falls through to legacy custom-event path for unmapped events (Cart Updated)', () => {

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1231,10 +1231,13 @@ describe('track - recommended ecommerce events', () => {
 
   it('does not emit an empty product object when cart_updated has no product fields', () => {
     const braze = buildBraze();
-    trackEvent(braze, 'Cart Updated', { cart_id: 'c1' });
+    // `Product Added` maps to ecommerce.cart_updated; with no product fields the
+    // single-product wrap must not emit a degenerate `[{}]`.
+    trackEvent(braze, 'Product Added', { cart_id: 'c1' });
 
+    const [eventName, props] = window.braze.logCustomEvent.mock.calls[0];
+    expect(eventName).toBe('ecommerce.cart_updated');
     // no degenerate `[{}]` — the empty products array is scrubbed off entirely
-    const props = window.braze.logCustomEvent.mock.calls[0][1];
     expect(props.products).toBeUndefined();
   });
 

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1111,8 +1111,8 @@ describe('track - recommended ecommerce events', () => {
       campaign: 'summer',
     });
 
-    expect(window.braze.logCustomEvent).toHaveBeenCalledTimes(1);
-    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.product_viewed', {
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledTimes(1);
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.product_viewed', {
       product_id: 'p1',
       product_name: 'Game',
       variant_id: 'v1',
@@ -1141,7 +1141,7 @@ describe('track - recommended ecommerce events', () => {
       list_id: 'wishlist',
     });
 
-    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.cart_updated', {
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.cart_updated', {
       cart_id: 'c1',
       currency: 'USD',
       source: 'web',
@@ -1173,7 +1173,7 @@ describe('track - recommended ecommerce events', () => {
       price: 15.99,
     });
 
-    const [eventName, props] = window.braze.logCustomEvent.mock.calls[0];
+    const [eventName, props] = globalThis.braze.logCustomEvent.mock.calls[0];
     expect(eventName).toBe('ecommerce.cart_updated');
     expect(props.action).toBe('remove');
   });
@@ -1189,7 +1189,7 @@ describe('track - recommended ecommerce events', () => {
       products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99 }],
     });
 
-    const props = window.braze.logCustomEvent.mock.calls[0][1];
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
     // array is mapped, not the top-level wrap
     expect(props.products).toEqual([
       { product_id: 'p1', product_name: 'Game', variant_id: 'v1', quantity: 2, price: 15.99 },
@@ -1211,7 +1211,7 @@ describe('track - recommended ecommerce events', () => {
       action: 'caller-supplied',
     });
 
-    const props = window.braze.logCustomEvent.mock.calls[0][1];
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
     expect(props.action).toBe('add');
     expect(props.metadata).toBeUndefined();
   });
@@ -1226,7 +1226,7 @@ describe('track - recommended ecommerce events', () => {
       products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 1, price: 15.99 }],
     });
 
-    expect(window.braze.logCustomEvent.mock.calls[0][1].total_discounts).toBe(3);
+    expect(globalThis.braze.logCustomEvent.mock.calls[0][1].total_discounts).toBe(3);
   });
 
   it('does not emit an empty product object when cart_updated has no product fields', () => {
@@ -1235,7 +1235,7 @@ describe('track - recommended ecommerce events', () => {
     // single-product wrap must not emit a degenerate `[{}]`.
     trackEvent(braze, 'Product Added', { cart_id: 'c1' });
 
-    const [eventName, props] = window.braze.logCustomEvent.mock.calls[0];
+    const [eventName, props] = globalThis.braze.logCustomEvent.mock.calls[0];
     expect(eventName).toBe('ecommerce.cart_updated');
     // no degenerate `[{}]` — the empty products array is scrubbed off entirely
     expect(props.products).toBeUndefined();
@@ -1264,7 +1264,7 @@ describe('track - recommended ecommerce events', () => {
       ],
     });
 
-    const props = window.braze.logCustomEvent.mock.calls[0][1];
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
     expect(props.metadata).toEqual({ campaign: 'spring' });
     expect(props.products[0].metadata).toEqual({ finish: 'matte' });
   });
@@ -1279,7 +1279,7 @@ describe('track - recommended ecommerce events', () => {
       products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99 }],
     });
 
-    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.checkout_started', {
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.checkout_started', {
       checkout_id: 'ck1',
       cart_id: 'c1',
       total_value: 31.98,
@@ -1304,8 +1304,8 @@ describe('track - recommended ecommerce events', () => {
       ],
     });
 
-    expect(window.braze.logPurchase).not.toHaveBeenCalled();
-    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.order_placed', {
+    expect(globalThis.braze.logPurchase).not.toHaveBeenCalled();
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.order_placed', {
       order_id: 'o1',
       total_value: 31.98,
       currency: 'USD',
@@ -1335,7 +1335,7 @@ describe('track - recommended ecommerce events', () => {
       products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99 }],
     });
 
-    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.order_refunded', {
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.order_refunded', {
       order_id: 'o1',
       total_value: 31.98,
       currency: 'USD',
@@ -1359,7 +1359,7 @@ describe('track - recommended ecommerce events', () => {
       products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99 }],
     });
 
-    const [eventName, props] = window.braze.logCustomEvent.mock.calls[0];
+    const [eventName, props] = globalThis.braze.logCustomEvent.mock.calls[0];
     expect(eventName).toBe('ecommerce.order_cancelled');
     expect(props.cancel_reason).toBe('changed mind');
     expect(warnMock).not.toHaveBeenCalled();
@@ -1375,7 +1375,7 @@ describe('track - recommended ecommerce events', () => {
       variant: 'v1',
     });
 
-    expect(window.braze.logCustomEvent).toHaveBeenCalledTimes(1);
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledTimes(1);
     expect(warnMock).toHaveBeenCalledTimes(1);
     const warnMessage = warnMock.mock.calls[0][0];
     expect(warnMessage).toContain('ecommerce.cart_updated');
@@ -1393,10 +1393,10 @@ describe('track - recommended ecommerce events', () => {
       products: [],
     });
 
-    expect(window.braze.logCustomEvent).toHaveBeenCalledTimes(1);
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledTimes(1);
     expect(warnMock.mock.calls[0][0]).toContain('products');
     // empty products[] is scrubbed before send
-    expect(window.braze.logCustomEvent.mock.calls[0][1]).not.toHaveProperty('products');
+    expect(globalThis.braze.logCustomEvent.mock.calls[0][1]).not.toHaveProperty('products');
   });
 
   it('honors an explicit valid properties.source override', () => {
@@ -1410,7 +1410,7 @@ describe('track - recommended ecommerce events', () => {
       source: 'ios',
     });
 
-    expect(window.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
+    expect(globalThis.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
   });
 
   it('honors an explicit properties.source with surrounding whitespace', () => {
@@ -1424,7 +1424,7 @@ describe('track - recommended ecommerce events', () => {
       source: 'ios ',
     });
 
-    expect(window.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
+    expect(globalThis.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
   });
 
   it('warns and scrubs a required field provided as an empty object', () => {
@@ -1437,19 +1437,19 @@ describe('track - recommended ecommerce events', () => {
       currency: {},
     });
 
-    expect(window.braze.logCustomEvent).toHaveBeenCalledTimes(1);
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledTimes(1);
     // empty-object required value is reported as missing...
     expect(warnMock).toHaveBeenCalledTimes(1);
     expect(warnMock.mock.calls[0][0]).toContain('currency');
     // ...and never reaches the sent payload.
-    expect(window.braze.logCustomEvent.mock.calls[0][1]).not.toHaveProperty('currency');
+    expect(globalThis.braze.logCustomEvent.mock.calls[0][1]).not.toHaveProperty('currency');
   });
 
   it('falls through to legacy custom-event path for unmapped events (Cart Updated)', () => {
     const braze = buildBraze();
     trackEvent(braze, 'Cart Updated', { cart_id: 'c1', value: 10 });
 
-    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('Cart Updated', {
+    expect(globalThis.braze.logCustomEvent).toHaveBeenCalledWith('Cart Updated', {
       cart_id: 'c1',
       value: 10,
     });
@@ -1462,8 +1462,8 @@ describe('track - recommended ecommerce events', () => {
       products: [{ product_id: 'p1', price: 15.99, quantity: 1 }],
     });
 
-    expect(window.braze.logPurchase).toHaveBeenCalledTimes(1);
-    expect(window.braze.logCustomEvent).not.toHaveBeenCalled();
+    expect(globalThis.braze.logPurchase).toHaveBeenCalledTimes(1);
+    expect(globalThis.braze.logCustomEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1077,6 +1077,273 @@ describe('track', () => {
   });
 });
 
+describe('track - recommended ecommerce events', () => {
+  const baseConfig = {
+    appKey: 'APP_KEY',
+    trackAnonymousUser: true,
+    enableBrazeLogging: false,
+    dataCenter: 'US-03',
+    allowUserSuppliedJavascript: false,
+    useRecommendedEcommerceEvents: true,
+  };
+
+  const buildBraze = (configOverrides = {}) => {
+    const braze = new Braze({ ...baseConfig, ...configOverrides }, {}, {});
+    mockBrazeSDK();
+    return braze;
+  };
+
+  const trackEvent = (braze, event, properties) => {
+    braze.track({ message: { userId: 'user123', event, properties } });
+  };
+
+  it('maps Product Viewed to ecommerce.product_viewed (flat, no products array)', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Viewed', {
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      price: 15.99,
+      currency: 'USD',
+      image_url: 'https://img/p1.png',
+      url: 'https://shop/p1',
+      type: 'digital',
+      campaign: 'summer',
+    });
+
+    expect(window.braze.logCustomEvent).toHaveBeenCalledTimes(1);
+    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.product_viewed', {
+      product_id: 'p1',
+      product_name: 'Game',
+      variant_id: 'v1',
+      price: 15.99,
+      currency: 'USD',
+      image_url: 'https://img/p1.png',
+      product_url: 'https://shop/p1',
+      type: 'digital',
+      source: 'web',
+      metadata: { campaign: 'summer' },
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('maps Product Added to ecommerce.cart_updated with action add (single-product wrap)', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Added', {
+      cart_id: 'c1',
+      currency: 'USD',
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      quantity: 2,
+      price: 15.99,
+      url: 'https://shop/p1',
+      list_id: 'wishlist',
+    });
+
+    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.cart_updated', {
+      cart_id: 'c1',
+      currency: 'USD',
+      source: 'web',
+      action: 'add',
+      products: [
+        {
+          product_id: 'p1',
+          product_name: 'Game',
+          variant_id: 'v1',
+          quantity: 2,
+          price: 15.99,
+          product_url: 'https://shop/p1',
+        },
+      ],
+      metadata: { list_id: 'wishlist' },
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('maps Product Removed to ecommerce.cart_updated with action remove', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Removed', {
+      cart_id: 'c1',
+      currency: 'USD',
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      quantity: 1,
+      price: 15.99,
+    });
+
+    const [eventName, props] = window.braze.logCustomEvent.mock.calls[0];
+    expect(eventName).toBe('ecommerce.cart_updated');
+    expect(props.action).toBe('remove');
+  });
+
+  it('maps Checkout Started to ecommerce.checkout_started with products array', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Checkout Started', {
+      checkout_id: 'ck1',
+      cart_id: 'c1',
+      total: 31.98,
+      currency: 'USD',
+      products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99 }],
+    });
+
+    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.checkout_started', {
+      checkout_id: 'ck1',
+      cart_id: 'c1',
+      total_value: 31.98,
+      currency: 'USD',
+      source: 'web',
+      products: [
+        { product_id: 'p1', product_name: 'Game', variant_id: 'v1', quantity: 2, price: 15.99 },
+      ],
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('maps Order Completed to ecommerce.order_placed (precedence over legacy purchases)', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'order completed', {
+      order_id: 'o1',
+      total: 31.98,
+      currency: 'USD',
+      coupon: 'SAVE10',
+      products: [
+        { product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99, color: 'red' },
+      ],
+    });
+
+    expect(window.braze.logPurchase).not.toHaveBeenCalled();
+    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.order_placed', {
+      order_id: 'o1',
+      total_value: 31.98,
+      currency: 'USD',
+      source: 'web',
+      products: [
+        {
+          product_id: 'p1',
+          product_name: 'Game',
+          variant_id: 'v1',
+          quantity: 2,
+          price: 15.99,
+          metadata: { color: 'red' },
+        },
+      ],
+      metadata: { coupon: 'SAVE10' },
+    });
+  });
+
+  it('maps Order Refunded with optional total_discounts and discounts passthrough', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Order Refunded', {
+      order_id: 'o1',
+      total: 31.98,
+      currency: 'USD',
+      total_discounts: 5,
+      discounts: [{ code: 'SAVE10', amount: 5 }],
+      products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99 }],
+    });
+
+    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('ecommerce.order_refunded', {
+      order_id: 'o1',
+      total_value: 31.98,
+      currency: 'USD',
+      total_discounts: 5,
+      discounts: [{ code: 'SAVE10', amount: 5 }],
+      source: 'web',
+      products: [
+        { product_id: 'p1', product_name: 'Game', variant_id: 'v1', quantity: 2, price: 15.99 },
+      ],
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('maps Order Cancelled with cancel_reason fallback to reason', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Order Cancelled', {
+      order_id: 'o1',
+      total: 31.98,
+      currency: 'USD',
+      reason: 'changed mind',
+      products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99 }],
+    });
+
+    const [eventName, props] = window.braze.logCustomEvent.mock.calls[0];
+    expect(eventName).toBe('ecommerce.order_cancelled');
+    expect(props.cancel_reason).toBe('changed mind');
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('warns with the missing required field names but still sends the event', () => {
+    const braze = buildBraze();
+    // Product Added missing required `currency`, and product missing `quantity`/`price`.
+    trackEvent(braze, 'Product Added', {
+      cart_id: 'c1',
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+    });
+
+    expect(window.braze.logCustomEvent).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    const warnMessage = warnMock.mock.calls[0][0];
+    expect(warnMessage).toContain('ecommerce.cart_updated');
+    expect(warnMessage).toContain('currency');
+    expect(warnMessage).toContain('products.quantity');
+    expect(warnMessage).toContain('products.price');
+  });
+
+  it('reports empty products array as a missing field and strips it from the payload', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Order Completed', {
+      order_id: 'o1',
+      total: 10,
+      currency: 'USD',
+      products: [],
+    });
+
+    expect(window.braze.logCustomEvent).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('products');
+    // empty products[] is scrubbed before send
+    expect(window.braze.logCustomEvent.mock.calls[0][1]).not.toHaveProperty('products');
+  });
+
+  it('honors an explicit valid properties.source override', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Viewed', {
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      price: 15.99,
+      currency: 'USD',
+      source: 'ios',
+    });
+
+    expect(window.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
+  });
+
+  it('falls through to legacy custom-event path for unmapped events (Cart Updated)', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Cart Updated', { cart_id: 'c1', value: 10 });
+
+    expect(window.braze.logCustomEvent).toHaveBeenCalledWith('Cart Updated', {
+      cart_id: 'c1',
+      value: 10,
+    });
+  });
+
+  it('falls through to legacy purchase path when the flag is off', () => {
+    const braze = buildBraze({ useRecommendedEcommerceEvents: false });
+    trackEvent(braze, 'order completed', {
+      currency: 'USD',
+      products: [{ product_id: 'p1', price: 15.99, quantity: 1 }],
+    });
+
+    expect(window.braze.logPurchase).toHaveBeenCalledTimes(1);
+    expect(window.braze.logCustomEvent).not.toHaveBeenCalled();
+  });
+});
+
 describe('page', () => {
   it('should call the necessary Braze methods to custom event', () => {
     const config = {

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1521,6 +1521,37 @@ describe('track - recommended ecommerce events', () => {
     expect(warnMock.mock.calls[0][0]).toContain('type (expected stringArray)');
   });
 
+  it('flags Infinity as a float type mismatch', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Viewed', {
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      price: Infinity, // not JSON-serializable — must not pass as a valid float
+      currency: 'USD',
+    });
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('price (expected float)');
+  });
+
+  it('does not coerce an overflowing numeric string to Infinity', () => {
+    const braze = buildBraze();
+    const hugeNumber = new Array(401).join('9'); // 400 digits — Number(...) overflows to Infinity
+    trackEvent(braze, 'Product Viewed', {
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      price: hugeNumber,
+      currency: 'USD',
+    });
+
+    const props = globalThis.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.price).toBe(hugeNumber); // left verbatim, not Infinity
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('price (expected float)');
+  });
+
   it('does not coerce a boolean to string; sends it as-is and warns', () => {
     const braze = buildBraze();
     trackEvent(braze, 'Product Viewed', {

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1413,6 +1413,38 @@ describe('track - recommended ecommerce events', () => {
     expect(window.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
   });
 
+  it('honors an explicit properties.source with surrounding whitespace', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Viewed', {
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      price: 15.99,
+      currency: 'USD',
+      source: 'ios ',
+    });
+
+    expect(window.braze.logCustomEvent.mock.calls[0][1].source).toBe('ios');
+  });
+
+  it('warns and scrubs a required field provided as an empty object', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Viewed', {
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      price: 15.99,
+      currency: {},
+    });
+
+    expect(window.braze.logCustomEvent).toHaveBeenCalledTimes(1);
+    // empty-object required value is reported as missing...
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('currency');
+    // ...and never reaches the sent payload.
+    expect(window.braze.logCustomEvent.mock.calls[0][1]).not.toHaveProperty('currency');
+  });
+
   it('falls through to legacy custom-event path for unmapped events (Cart Updated)', () => {
     const braze = buildBraze();
     trackEvent(braze, 'Cart Updated', { cart_id: 'c1', value: 10 });

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1229,6 +1229,43 @@ describe('track - recommended ecommerce events', () => {
     expect(window.braze.logCustomEvent.mock.calls[0][1].total_discounts).toBe(3);
   });
 
+  it('does not emit an empty product object when cart_updated has no product fields', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Cart Updated', { cart_id: 'c1' });
+
+    // no degenerate `[{}]` — the empty products array is scrubbed off entirely
+    const props = window.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.products).toBeUndefined();
+  });
+
+  it('scrubs null/empty values out of event-level and per-product metadata', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Order Completed', {
+      order_id: 'o1',
+      total: 31.98,
+      currency: 'USD',
+      coupon: '',
+      note: null,
+      campaign: 'spring',
+      products: [
+        {
+          product_id: 'p1',
+          name: 'Game',
+          variant: 'v1',
+          quantity: 2,
+          price: 15.99,
+          color: '',
+          shade: null,
+          finish: 'matte',
+        },
+      ],
+    });
+
+    const props = window.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.metadata).toEqual({ campaign: 'spring' });
+    expect(props.products[0].metadata).toEqual({ finish: 'matte' });
+  });
+
   it('maps Checkout Started to ecommerce.checkout_started with products array', () => {
     const braze = buildBraze();
     trackEvent(braze, 'Checkout Started', {

--- a/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/Braze/browser.test.js
@@ -1178,6 +1178,57 @@ describe('track - recommended ecommerce events', () => {
     expect(props.action).toBe('remove');
   });
 
+  it('cart_updated with an explicit products[] maps the array and keeps top-level fields in metadata', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Added', {
+      cart_id: 'c1',
+      currency: 'USD',
+      // top-level product-like fields coexisting with an explicit products[] array
+      product_id: 'top-level-pid',
+      name: 'top-level-name',
+      products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 2, price: 15.99 }],
+    });
+
+    const props = window.braze.logCustomEvent.mock.calls[0][1];
+    // array is mapped, not the top-level wrap
+    expect(props.products).toEqual([
+      { product_id: 'p1', product_name: 'Game', variant_id: 'v1', quantity: 2, price: 15.99 },
+    ]);
+    // top-level product-like fields were NOT consumed, so they flow to metadata
+    expect(props.metadata).toEqual({ product_id: 'top-level-pid', name: 'top-level-name' });
+  });
+
+  it('does not leak a caller-provided properties.action into metadata', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Product Added', {
+      cart_id: 'c1',
+      currency: 'USD',
+      product_id: 'p1',
+      name: 'Game',
+      variant: 'v1',
+      quantity: 1,
+      price: 15.99,
+      action: 'caller-supplied',
+    });
+
+    const props = window.braze.logCustomEvent.mock.calls[0][1];
+    expect(props.action).toBe('add');
+    expect(props.metadata).toBeUndefined();
+  });
+
+  it('accepts total_discounts under either properties.discount or properties.total_discounts', () => {
+    const braze = buildBraze();
+    trackEvent(braze, 'Order Refunded', {
+      order_id: 'o1',
+      total: 10,
+      currency: 'USD',
+      total_discounts: 3,
+      products: [{ product_id: 'p1', name: 'Game', variant: 'v1', quantity: 1, price: 15.99 }],
+    });
+
+    expect(window.braze.logCustomEvent.mock.calls[0][1].total_discounts).toBe(3);
+  });
+
   it('maps Checkout Started to ecommerce.checkout_started with products array', () => {
     const braze = buildBraze();
     trackEvent(braze, 'Checkout Started', {

--- a/packages/analytics-js-integrations/src/integrations/Braze/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/browser.js
@@ -38,7 +38,7 @@ class Braze {
       }
     }
     this.endPoint = '';
-    this.useRecommendedEcommerceEvents = config.useRecommendedEcommerceEvents || false;
+    this.useEcommerceRecommendedEvents = config.useEcommerceRecommendedEvents || false;
     this.isHybridModeEnabled = config.connectionMode === 'hybrid';
     this.isReadyStatus = {
       hasLoggedErrorForAlias: false,
@@ -359,7 +359,7 @@ class Braze {
       canSendCustomEvent = true;
     }
     if (eventName && canSendCustomEvent) {
-      const ecommerceMapping = this.useRecommendedEcommerceEvents
+      const ecommerceMapping = this.useEcommerceRecommendedEvents
         ? getEcommerceMapping(eventName)
         : undefined;
       if (ecommerceMapping) {

--- a/packages/analytics-js-integrations/src/integrations/Braze/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/browser.js
@@ -38,7 +38,7 @@ class Braze {
       }
     }
     this.endPoint = '';
-    this.useEcommerceRecommendedEvents = config.useEcommerceRecommendedEvents || false;
+    this.useEcommerceRecommendedEvents = config.useEcommerceRecommendedEvents === true;
     this.isHybridModeEnabled = config.connectionMode === 'hybrid';
     this.isReadyStatus = {
       hasLoggedErrorForAlias: false,

--- a/packages/analytics-js-integrations/src/integrations/Braze/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/browser.js
@@ -7,6 +7,7 @@ import Logger from '../../utils/logger';
 import { isObject } from '../../utils/utils';
 import { isNotEmpty } from '../../utils/commonUtils';
 import { handlePurchase, formatGender, handleReservedProperties } from './utils';
+import { getEcommerceMapping, buildEcommerceEventProperties } from './ecommerceUtil';
 import { loadNativeSdk } from './nativeSdkLoader';
 
 const logger = new Logger(DISPLAY_NAME);
@@ -37,6 +38,7 @@ class Braze {
       }
     }
     this.endPoint = '';
+    this.useRecommendedEcommerceEvents = config.useRecommendedEcommerceEvents || false;
     this.isHybridModeEnabled = config.connectionMode === 'hybrid';
     this.isReadyStatus = {
       hasLoggedErrorForAlias: false,
@@ -357,7 +359,19 @@ class Braze {
       canSendCustomEvent = true;
     }
     if (eventName && canSendCustomEvent) {
-      if (eventName.toLowerCase() === 'order completed') {
+      const ecommerceMapping = this.useRecommendedEcommerceEvents
+        ? getEcommerceMapping(eventName)
+        : undefined;
+      if (ecommerceMapping) {
+        const { brazeEvent, action } = ecommerceMapping;
+        const ecommerceProperties = buildEcommerceEventProperties(
+          rudderElement.message,
+          brazeEvent,
+          action,
+          logger,
+        );
+        globalThis.braze.logCustomEvent(brazeEvent, ecommerceProperties);
+      } else if (eventName.toLowerCase() === 'order completed') {
         handlePurchase(properties);
       } else {
         properties = handleReservedProperties(properties);

--- a/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
@@ -1,0 +1,347 @@
+import { constructPayload } from '../../utils/utils';
+import { removeUndefinedAndNullAndEmptyValues } from '../../utils/commonUtils';
+
+/**
+ * Braze recommended ecommerce event names.
+ * https://www.braze.com/docs/user_guide/data/activation/events/recommended_events
+ */
+export const BRAZE_ECOMMERCE_EVENTS = {
+  PRODUCT_VIEWED: 'ecommerce.product_viewed',
+  CART_UPDATED: 'ecommerce.cart_updated',
+  CHECKOUT_STARTED: 'ecommerce.checkout_started',
+  ORDER_PLACED: 'ecommerce.order_placed',
+  ORDER_REFUNDED: 'ecommerce.order_refunded',
+  ORDER_CANCELLED: 'ecommerce.order_cancelled',
+};
+
+const BRAZE_SOURCE_VALUES = ['web', 'ios', 'android'];
+
+// Case-insensitive RS event name -> Braze recommended event mapping.
+// Keys are lowercased RS event names. `Cart Viewed` and `Cart Updated` are
+// intentionally absent — both fall through to the legacy custom-event path.
+const EVENT_NAME_TO_BRAZE = {
+  'product viewed': { brazeEvent: BRAZE_ECOMMERCE_EVENTS.PRODUCT_VIEWED },
+  'product added': { brazeEvent: BRAZE_ECOMMERCE_EVENTS.CART_UPDATED, action: 'add' },
+  'product removed': { brazeEvent: BRAZE_ECOMMERCE_EVENTS.CART_UPDATED, action: 'remove' },
+  'checkout started': { brazeEvent: BRAZE_ECOMMERCE_EVENTS.CHECKOUT_STARTED },
+  'order completed': { brazeEvent: BRAZE_ECOMMERCE_EVENTS.ORDER_PLACED },
+  'order refunded': { brazeEvent: BRAZE_ECOMMERCE_EVENTS.ORDER_REFUNDED },
+  'order cancelled': { brazeEvent: BRAZE_ECOMMERCE_EVENTS.ORDER_CANCELLED },
+};
+
+// ---------------------------------------------------------------------------
+// Per-event field mappings (mirror of the cloud `Braze*Config.json` files).
+// Each entry is built via `m(destKey, sourceKeys, required)`:
+//   - `destKey`/`sourceKeys` are the `constructPayload` contract.
+//   - `req` flags Braze-required fields (consumed by collectMissingRequiredFields).
+// `sourceKeys` arrays are ordered fallback chains (first resolved value wins).
+// ---------------------------------------------------------------------------
+
+const m = (destKey, sourceKeys, req = false) => ({ destKey, sourceKeys, req });
+
+// Shared fallback chain reused across checkout/order events.
+const TOTAL_VALUE_SOURCES = ['properties.total', 'properties.revenue', 'properties.value'];
+
+const PRODUCT_VIEWED_MAPPING = [
+  m('product_id', ['properties.product_id', 'properties.sku'], true),
+  m('product_name', 'properties.name', true),
+  m('variant_id', ['properties.variant', 'properties.sku', 'properties.product_id'], true),
+  m('price', 'properties.price', true),
+  m('currency', 'properties.currency', true),
+  m('image_url', 'properties.image_url'),
+  m('product_url', 'properties.url'),
+  m('type', 'properties.type'),
+];
+
+const CART_UPDATED_MAPPING = [
+  m('cart_id', 'properties.cart_id', true),
+  m('total_value', ['properties.total', 'properties.value']),
+  m('subtotal_value', 'properties.subtotal_value'),
+  m('tax', 'properties.tax'),
+  m('shipping', 'properties.shipping'),
+  m('currency', 'properties.currency', true),
+];
+
+const CHECKOUT_STARTED_MAPPING = [
+  m('checkout_id', ['properties.checkout_id', 'properties.order_id'], true),
+  m('cart_id', 'properties.cart_id'),
+  m('total_value', TOTAL_VALUE_SOURCES, true),
+  m('subtotal_value', 'properties.subtotal_value'),
+  m('tax', 'properties.tax'),
+  m('shipping', 'properties.shipping'),
+  m('currency', 'properties.currency', true),
+];
+
+const ORDER_PLACED_MAPPING = [
+  m('order_id', 'properties.order_id', true),
+  m('total_value', TOTAL_VALUE_SOURCES, true),
+  m('currency', 'properties.currency', true),
+  m('cart_id', 'properties.cart_id'),
+  m('tax', 'properties.tax'),
+  m('shipping', 'properties.shipping'),
+  m('total_discounts', 'properties.discount'),
+  m('subtotal_value', 'properties.subtotal_value'),
+  m('discounts', 'properties.discounts'),
+];
+
+const ORDER_REFUNDED_MAPPING = [
+  m('order_id', 'properties.order_id', true),
+  m('total_value', TOTAL_VALUE_SOURCES, true),
+  m('currency', 'properties.currency', true),
+  m('total_discounts', 'properties.total_discounts'),
+  m('discounts', 'properties.discounts'),
+];
+
+const ORDER_CANCELLED_MAPPING = [
+  m('order_id', 'properties.order_id', true),
+  m('total_value', TOTAL_VALUE_SOURCES, true),
+  m('currency', 'properties.currency', true),
+  m('cancel_reason', ['properties.cancel_reason', 'properties.reason'], true),
+  m('tax', 'properties.tax'),
+  m('shipping', 'properties.shipping'),
+  m('total_discounts', 'properties.discount'),
+  m('subtotal_value', 'properties.subtotal_value'),
+  m('discounts', 'properties.discounts'),
+];
+
+// Shared per-product mapping (bare keys — read from each `products[i]` /
+// `properties` directly, no `properties.` prefix).
+const ECOMMERCE_PRODUCT_MAPPING = [
+  m('product_id', ['product_id', 'sku'], true),
+  m('product_name', 'name', true),
+  m('variant_id', ['variant', 'sku', 'product_id'], true),
+  m('quantity', 'quantity', true),
+  m('price', 'price', true),
+  m('image_url', 'image_url'),
+  m('product_url', 'url'),
+];
+
+const PER_EVENT_MAPPING = {
+  [BRAZE_ECOMMERCE_EVENTS.PRODUCT_VIEWED]: PRODUCT_VIEWED_MAPPING,
+  [BRAZE_ECOMMERCE_EVENTS.CART_UPDATED]: CART_UPDATED_MAPPING,
+  [BRAZE_ECOMMERCE_EVENTS.CHECKOUT_STARTED]: CHECKOUT_STARTED_MAPPING,
+  [BRAZE_ECOMMERCE_EVENTS.ORDER_PLACED]: ORDER_PLACED_MAPPING,
+  [BRAZE_ECOMMERCE_EVENTS.ORDER_REFUNDED]: ORDER_REFUNDED_MAPPING,
+  [BRAZE_ECOMMERCE_EVENTS.ORDER_CANCELLED]: ORDER_CANCELLED_MAPPING,
+};
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror `constructPayload`'s truthiness rule: `0` and `false` are valid values; only
+ * undefined/null/empty-string count as missing.
+ */
+const isResolvedValue = value => {
+  if (value === 0 || value === false) return true;
+  if (value === undefined || value === null) return false;
+  return !(typeof value === 'string' && value.length === 0);
+};
+
+/**
+ * Return the subset of `source` whose keys are not in `consumed`.
+ * Used to derive the `metadata` pass-through.
+ */
+const pickUnmappedKeys = (source, consumed) => {
+  const result = {};
+  Object.keys(source).forEach(key => {
+    if (!consumed.has(key) && source[key] !== undefined) {
+      result[key] = source[key];
+    }
+  });
+  return result;
+};
+
+/**
+ * Compute the set of source keys referenced by a per-product mapping. Product mappings
+ * use bare keys (`product_id`, `name`, ...), so no prefix-stripping is required.
+ */
+const consumedKeysFromMapping = mapping => {
+  const consumed = new Set();
+  mapping.forEach(entry => {
+    const sources = Array.isArray(entry.sourceKeys) ? entry.sourceKeys : [entry.sourceKeys];
+    sources.forEach(src => {
+      if (typeof src === 'string') {
+        consumed.add(src);
+      }
+    });
+  });
+  return consumed;
+};
+
+/**
+ * Compute the set of message-property keys "consumed" by the event-level mapping (so
+ * they aren't duplicated into `metadata`). Includes the `properties.`-prefixed source
+ * keys, the `source` key (always derived), the `products` key for product-bearing
+ * events, and (for cart_updated) the top-level product field keys folded into products[0].
+ */
+const consumedTopLevelKeysForEvent = (brazeEvent, eventMapping, hasProducts) => {
+  const consumed = new Set();
+  consumed.add('source');
+
+  eventMapping.forEach(entry => {
+    const sources = Array.isArray(entry.sourceKeys) ? entry.sourceKeys : [entry.sourceKeys];
+    sources.forEach(src => {
+      if (typeof src === 'string' && src.startsWith('properties.')) {
+        consumed.add(src.slice('properties.'.length));
+      }
+    });
+  });
+
+  if (hasProducts) {
+    consumed.add('products');
+  }
+
+  // cart_updated uses top-level product fields as the single wrapped product;
+  // mark those keys as consumed so they don't duplicate into event-level metadata.
+  if (brazeEvent === BRAZE_ECOMMERCE_EVENTS.CART_UPDATED && hasProducts) {
+    consumedKeysFromMapping(ECOMMERCE_PRODUCT_MAPPING).forEach(key => consumed.add(key));
+  }
+
+  return consumed;
+};
+
+/**
+ * Build the `products[]` array for the outgoing payload.
+ * - cart_updated: read top-level product fields directly from `properties` into a
+ *   1-element products[]. No per-product metadata — unmapped event-level keys flow
+ *   through the event-level metadata pass.
+ * - other product-bearing events: map each item in `properties.products` and route
+ *   per-product unmapped keys to `products[i].metadata`.
+ */
+const buildProductsArray = (properties, brazeEvent) => {
+  const isCartUpdated = brazeEvent === BRAZE_ECOMMERCE_EVENTS.CART_UPDATED;
+
+  if (isCartUpdated && !Array.isArray(properties.products)) {
+    return [constructPayload(properties, ECOMMERCE_PRODUCT_MAPPING) || {}];
+  }
+
+  const rawProducts = Array.isArray(properties.products) ? properties.products : [];
+  const consumedKeys = consumedKeysFromMapping(ECOMMERCE_PRODUCT_MAPPING);
+  return rawProducts.map(raw => {
+    const item = raw && typeof raw === 'object' ? raw : {};
+    const product = constructPayload(item, ECOMMERCE_PRODUCT_MAPPING) || {};
+    const productMetadata = pickUnmappedKeys(item, consumedKeys);
+    if (Object.keys(productMetadata).length > 0) {
+      product.metadata = productMetadata;
+    }
+    return product;
+  });
+};
+
+/**
+ * Collect the Braze-required fields missing from the constructed payload — event-level
+ * and per-product. An empty `products[]` on a product-bearing event is reported as a
+ * missing `products` field. Returns a flat list of human-readable field labels.
+ */
+const collectMissingRequiredFields = (eventMapping, hasProducts, payload) => {
+  const missing = [];
+
+  eventMapping.forEach(entry => {
+    if (entry.req && !isResolvedValue(payload[entry.destKey])) {
+      missing.push(entry.destKey);
+    }
+  });
+
+  if (hasProducts) {
+    const products = Array.isArray(payload.products) ? payload.products : [];
+    if (products.length === 0) {
+      missing.push('products');
+    } else {
+      const missingProductFields = new Set();
+      products.forEach(product => {
+        ECOMMERCE_PRODUCT_MAPPING.forEach(entry => {
+          if (entry.req && !isResolvedValue(product[entry.destKey])) {
+            missingProductFields.add(`products.${entry.destKey}`);
+          }
+        });
+      });
+      missingProductFields.forEach(field => missing.push(field));
+    }
+  }
+
+  return missing;
+};
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Braze recommended event for a given RS event name.
+ * Returns `undefined` for unmapped events — caller falls back to the legacy path.
+ * Matching is case-insensitive on the trimmed event name.
+ */
+export const getEcommerceMapping = eventName => {
+  if (typeof eventName !== 'string') {
+    return undefined;
+  }
+  return EVENT_NAME_TO_BRAZE[eventName.trim().toLowerCase()];
+};
+
+/**
+ * Derive the Braze `source` field. On the web SDK this resolves to `'web'`, unless the
+ * event carries an explicit, valid `properties.source` (`web`/`ios`/`android`), which
+ * takes precedence. Always returns one of Braze's enum values; never undefined.
+ */
+export const deriveSource = message => {
+  const properties = message.properties || {};
+  const explicit = String(properties.source || '').toLowerCase();
+  if (BRAZE_SOURCE_VALUES.indexOf(explicit) !== -1) {
+    return explicit;
+  }
+  return 'web';
+};
+
+/**
+ * Build the `properties` object for a Braze recommended ecommerce event.
+ *
+ * Algorithm:
+ * 1. Run `constructPayload` against the message event-level mapping (never throws —
+ *    send-anyway is enforced via the validation warning instead).
+ * 2. For events with a `products[]`, build the array (single-product wrap for
+ *    `cart_updated`, iterate `properties.products` otherwise).
+ * 3. Set `source` via `deriveSource` and `action` when present.
+ * 4. Route unmapped event-level keys to `properties.metadata`, and unmapped per-product
+ *    keys to `products[].metadata`.
+ * 5. Emit a single `logger.warn` listing any missing Braze-required fields.
+ *
+ * Never throws on data shape; the warning + the (still-sent) payload is the contract.
+ */
+export const buildEcommerceEventProperties = (message, brazeEvent, action, logger) => {
+  const properties = message.properties || {};
+  const eventMapping = PER_EVENT_MAPPING[brazeEvent];
+  const hasProducts = brazeEvent !== BRAZE_ECOMMERCE_EVENTS.PRODUCT_VIEWED;
+
+  // Step 1: event-level field mapping.
+  const payload = constructPayload(message, eventMapping) || {};
+
+  // Step 2: products[] (skipped for product_viewed — flat, single-product event).
+  if (hasProducts) {
+    payload.products = buildProductsArray(properties, brazeEvent);
+  }
+
+  // Step 3: source + action.
+  payload.source = deriveSource(message);
+  if (action) {
+    payload.action = action;
+  }
+
+  // Step 4: route unmapped event-level keys to metadata.
+  const consumedEventKeys = consumedTopLevelKeysForEvent(brazeEvent, eventMapping, hasProducts);
+  const eventMetadata = pickUnmappedKeys(properties, consumedEventKeys);
+  if (Object.keys(eventMetadata).length > 0) {
+    payload.metadata = eventMetadata;
+  }
+
+  // Step 5: single warning for any missing Braze-required field.
+  const missingFields = collectMissingRequiredFields(eventMapping, hasProducts, payload);
+  if (missingFields.length > 0 && logger) {
+    logger.warn(
+      `${brazeEvent}: missing recommended Braze-required field(s): ${missingFields.join(', ')}. Event sent anyway.`,
+    );
+  }
+
+  return removeUndefinedAndNullAndEmptyValues(payload);
+};

--- a/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
@@ -141,17 +141,19 @@ const isResolvedValue = value => {
 };
 
 /**
- * Return the subset of `source` whose keys are not in `consumed`.
- * Used to derive the `metadata` pass-through.
+ * Return the subset of `source` whose keys are not in `consumed`, with undefined/null/empty
+ * values scrubbed out. Used to derive the `metadata` pass-through — the top-level
+ * `removeUndefinedAndNullAndEmptyValues` is shallow, so this is the only place nested
+ * metadata gets cleaned.
  */
 const pickUnmappedKeys = (source, consumed) => {
   const result = {};
   Object.keys(source).forEach(key => {
-    if (!consumed.has(key) && source[key] !== undefined) {
+    if (!consumed.has(key)) {
       result[key] = source[key];
     }
   });
-  return result;
+  return removeUndefinedAndNullAndEmptyValues(result);
 };
 
 /**
@@ -222,20 +224,27 @@ const buildProductsArray = (properties, brazeEvent) => {
   const isCartUpdated = brazeEvent === BRAZE_ECOMMERCE_EVENTS.CART_UPDATED;
 
   if (isCartUpdated && !Array.isArray(properties.products)) {
-    return [constructPayload(properties, ECOMMERCE_PRODUCT_MAPPING) || {}];
+    const product = removeUndefinedAndNullAndEmptyValues(
+      constructPayload(properties, ECOMMERCE_PRODUCT_MAPPING) || {},
+    );
+    return Object.keys(product).length > 0 ? [product] : [];
   }
 
   const rawProducts = Array.isArray(properties.products) ? properties.products : [];
   const consumedKeys = consumedKeysFromMapping(ECOMMERCE_PRODUCT_MAPPING);
-  return rawProducts.map(raw => {
-    const item = raw && typeof raw === 'object' ? raw : {};
-    const product = constructPayload(item, ECOMMERCE_PRODUCT_MAPPING) || {};
-    const productMetadata = pickUnmappedKeys(item, consumedKeys);
-    if (Object.keys(productMetadata).length > 0) {
-      product.metadata = productMetadata;
-    }
-    return product;
-  });
+  return rawProducts
+    .map(raw => {
+      const item = raw && typeof raw === 'object' ? raw : {};
+      const product = removeUndefinedAndNullAndEmptyValues(
+        constructPayload(item, ECOMMERCE_PRODUCT_MAPPING) || {},
+      );
+      const productMetadata = pickUnmappedKeys(item, consumedKeys);
+      if (Object.keys(productMetadata).length > 0) {
+        product.metadata = productMetadata;
+      }
+      return product;
+    })
+    .filter(product => Object.keys(product).length > 0);
 };
 
 /**

--- a/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
@@ -168,12 +168,13 @@ const INTEGER_STRING_REGEX = /^[+-]?\d+$/;
 /**
  * Coerce a resolved primitive to the type Braze expects, when the conversion is safe and
  * lossless; otherwise return it unchanged (the residual mismatch is surfaced by the
- * type-mismatch warning). Mirrors the cloud/Kotlin coercion table:
+ * type-mismatch warning). Mirrors the cloud coercion table:
  *   - numeric string  -> float    (`"29.99"` -> `29.99`)
  *   - integer string  -> integer  (`"2"` -> `2`; `"2.5"`/`"2.0"` left as-is)
- *   - number/boolean  -> string   (`12345` -> `"12345"`, `true` -> `"true"`)
+ *   - number          -> string   (`12345` -> `"12345"`)
  * Integer numbers are left as-is for float fields (Braze accepts an int where a float is
- * expected, and JSON cannot express `2.0`). Arrays/objects are never coerced.
+ * expected, and JSON cannot express `2.0`). Booleans are NOT coerced to string, and
+ * arrays/objects are never coerced.
  */
 const coerceValue = (value, type) => {
   if (value === null || typeof value === 'object') {
@@ -181,7 +182,7 @@ const coerceValue = (value, type) => {
   }
   switch (type) {
     case FIELD_TYPE.STRING:
-      return typeof value === 'string' ? value : String(value);
+      return typeof value === 'number' ? String(value) : value;
     case FIELD_TYPE.FLOAT:
       return typeof value === 'string' && FLOAT_STRING_REGEX.test(value.trim())
         ? Number(value.trim())

--- a/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
@@ -32,15 +32,33 @@ const EVENT_NAME_TO_BRAZE = {
   'order cancelled': { brazeEvent: BRAZE_ECOMMERCE_EVENTS.ORDER_CANCELLED },
 };
 
+// The type Braze expects for a recommended-event field. Resolved values are coerced to
+// this type where the conversion is safe and lossless; an un-coercible value is sent
+// verbatim and surfaced via the type-mismatch warning.
+const FIELD_TYPE = {
+  STRING: 'string',
+  INTEGER: 'integer',
+  FLOAT: 'float',
+  STRING_ARRAY: 'stringArray',
+  ARRAY: 'array',
+};
+
 // ---------------------------------------------------------------------------
 // Per-event field mappings (mirror of the cloud `Braze*Config.json` files).
-// Each entry is built via `m(destKey, sourceKeys, required)`:
+// Each entry is built via `m(destKey, sourceKeys, required, type)`:
 //   - `destKey`/`sourceKeys` are the `constructPayload` contract.
 //   - `req` flags Braze-required fields (consumed by collectMissingRequiredFields).
+//   - `type` is the Braze-expected type (default String); drives coercion + the
+//     type-mismatch warning.
 // `sourceKeys` arrays are ordered fallback chains (first resolved value wins).
 // ---------------------------------------------------------------------------
 
-const m = (destKey, sourceKeys, req = false) => ({ destKey, sourceKeys, req });
+const m = (destKey, sourceKeys, req = false, type = FIELD_TYPE.STRING) => ({
+  destKey,
+  sourceKeys,
+  req,
+  type,
+});
 
 // Shared fallback chains reused across checkout/order events.
 const TOTAL_VALUE_SOURCES = ['properties.total', 'properties.revenue', 'properties.value'];
@@ -50,62 +68,62 @@ const PRODUCT_VIEWED_MAPPING = [
   m('product_id', ['properties.product_id', 'properties.sku'], true),
   m('product_name', 'properties.name', true),
   m('variant_id', ['properties.variant', 'properties.sku', 'properties.product_id'], true),
-  m('price', 'properties.price', true),
+  m('price', 'properties.price', true, FIELD_TYPE.FLOAT),
   m('currency', 'properties.currency', true),
   m('image_url', 'properties.image_url'),
   m('product_url', 'properties.url'),
-  m('type', 'properties.type'),
+  m('type', 'properties.type', false, FIELD_TYPE.STRING_ARRAY),
 ];
 
 const CART_UPDATED_MAPPING = [
   m('cart_id', 'properties.cart_id', true),
-  m('total_value', ['properties.total', 'properties.value']),
-  m('subtotal_value', 'properties.subtotal_value'),
-  m('tax', 'properties.tax'),
-  m('shipping', 'properties.shipping'),
+  m('total_value', ['properties.total', 'properties.value'], false, FIELD_TYPE.FLOAT),
+  m('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
+  m('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
+  m('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
   m('currency', 'properties.currency', true),
 ];
 
 const CHECKOUT_STARTED_MAPPING = [
   m('checkout_id', ['properties.checkout_id', 'properties.order_id'], true),
   m('cart_id', 'properties.cart_id'),
-  m('total_value', TOTAL_VALUE_SOURCES, true),
-  m('subtotal_value', 'properties.subtotal_value'),
-  m('tax', 'properties.tax'),
-  m('shipping', 'properties.shipping'),
+  m('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
+  m('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
+  m('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
+  m('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
   m('currency', 'properties.currency', true),
 ];
 
 const ORDER_PLACED_MAPPING = [
   m('order_id', 'properties.order_id', true),
-  m('total_value', TOTAL_VALUE_SOURCES, true),
+  m('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
   m('currency', 'properties.currency', true),
   m('cart_id', 'properties.cart_id'),
-  m('tax', 'properties.tax'),
-  m('shipping', 'properties.shipping'),
-  m('total_discounts', TOTAL_DISCOUNTS_SOURCES),
-  m('subtotal_value', 'properties.subtotal_value'),
-  m('discounts', 'properties.discounts'),
+  m('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
+  m('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
+  m('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
+  m('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
+  m('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
 ];
 
 const ORDER_REFUNDED_MAPPING = [
   m('order_id', 'properties.order_id', true),
-  m('total_value', TOTAL_VALUE_SOURCES, true),
+  m('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
   m('currency', 'properties.currency', true),
-  m('total_discounts', TOTAL_DISCOUNTS_SOURCES),
-  m('discounts', 'properties.discounts'),
+  m('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
+  m('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
 ];
 
 const ORDER_CANCELLED_MAPPING = [
   m('order_id', 'properties.order_id', true),
-  m('total_value', TOTAL_VALUE_SOURCES, true),
+  m('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
   m('currency', 'properties.currency', true),
   m('cancel_reason', ['properties.cancel_reason', 'properties.reason'], true),
-  m('tax', 'properties.tax'),
-  m('shipping', 'properties.shipping'),
-  m('total_discounts', TOTAL_DISCOUNTS_SOURCES),
-  m('subtotal_value', 'properties.subtotal_value'),
-  m('discounts', 'properties.discounts'),
+  m('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
+  m('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
+  m('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
+  m('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
+  m('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
 ];
 
 // Shared per-product mapping (bare keys — read from each `products[i]` /
@@ -114,8 +132,8 @@ const ECOMMERCE_PRODUCT_MAPPING = [
   m('product_id', ['product_id', 'sku'], true),
   m('product_name', 'name', true),
   m('variant_id', ['variant', 'sku', 'product_id'], true),
-  m('quantity', 'quantity', true),
-  m('price', 'price', true),
+  m('quantity', 'quantity', true, FIELD_TYPE.INTEGER),
+  m('price', 'price', true, FIELD_TYPE.FLOAT),
   m('image_url', 'image_url'),
   m('product_url', 'url'),
 ];
@@ -141,6 +159,79 @@ const PER_EVENT_MAPPING = {
  * `0`/`false`/numbers stay valid.
  */
 const isResolvedValue = isDefinedAndNotNullAndNotEmpty;
+
+// A safe, lossless numeric-string conversion accepts only plain decimal literals (no
+// scientific notation, Infinity, or NaN). Integer additionally forbids a fractional part.
+const FLOAT_STRING_REGEX = /^[+-]?(\d+\.?\d*|\.\d+)$/;
+const INTEGER_STRING_REGEX = /^[+-]?\d+$/;
+
+/**
+ * Coerce a resolved primitive to the type Braze expects, when the conversion is safe and
+ * lossless; otherwise return it unchanged (the residual mismatch is surfaced by the
+ * type-mismatch warning). Mirrors the cloud/Kotlin coercion table:
+ *   - numeric string  -> float    (`"29.99"` -> `29.99`)
+ *   - integer string  -> integer  (`"2"` -> `2`; `"2.5"`/`"2.0"` left as-is)
+ *   - number/boolean  -> string   (`12345` -> `"12345"`, `true` -> `"true"`)
+ * Integer numbers are left as-is for float fields (Braze accepts an int where a float is
+ * expected, and JSON cannot express `2.0`). Arrays/objects are never coerced.
+ */
+const coerceValue = (value, type) => {
+  if (value === null || typeof value === 'object') {
+    return value;
+  }
+  switch (type) {
+    case FIELD_TYPE.STRING:
+      return typeof value === 'string' ? value : String(value);
+    case FIELD_TYPE.FLOAT:
+      return typeof value === 'string' && FLOAT_STRING_REGEX.test(value.trim())
+        ? Number(value.trim())
+        : value;
+    case FIELD_TYPE.INTEGER:
+      // Only a pure integer literal is a safe, lossless conversion ("2", not "2.5"/"2.0").
+      return typeof value === 'string' && INTEGER_STRING_REGEX.test(value.trim())
+        ? Number(value.trim())
+        : value;
+    default:
+      // stringArray / array — never coerced.
+      return value;
+  }
+};
+
+/**
+ * Whether `value` already matches the type Braze expects. A numeric written as a string
+ * (e.g. `"29.99"`) does NOT match a numeric type, so an un-coercible value still warns.
+ * `0`/`false` are valid for their respective types.
+ */
+const matchesType = (value, type) => {
+  switch (type) {
+    case FIELD_TYPE.STRING:
+      return typeof value === 'string';
+    case FIELD_TYPE.INTEGER:
+      // `value % 1 === 0` is true only for whole numbers; NaN/Infinity yield NaN and fail.
+      return typeof value === 'number' && value % 1 === 0;
+    case FIELD_TYPE.FLOAT:
+      return typeof value === 'number' && !Number.isNaN(value);
+    case FIELD_TYPE.STRING_ARRAY:
+      return Array.isArray(value) && value.every(item => typeof item === 'string');
+    case FIELD_TYPE.ARRAY:
+      return Array.isArray(value);
+    default:
+      return true;
+  }
+};
+
+/**
+ * Coerce every mapped field present in `obj` to its Braze-expected type, in place.
+ * Returns `obj` for chaining.
+ */
+const coerceMappedFields = (obj, mapping) => {
+  mapping.forEach(entry => {
+    if (entry.destKey in obj) {
+      obj[entry.destKey] = coerceValue(obj[entry.destKey], entry.type);
+    }
+  });
+  return obj;
+};
 
 /**
  * Return the subset of `source` whose keys are not in `consumed`, with undefined/null/empty
@@ -224,7 +315,10 @@ const buildProductsArray = (properties, brazeEvent) => {
 
   if (isCartUpdated && !Array.isArray(properties.products)) {
     const product = removeUndefinedAndNullAndEmptyValues(
-      constructPayload(properties, ECOMMERCE_PRODUCT_MAPPING) || {},
+      coerceMappedFields(
+        constructPayload(properties, ECOMMERCE_PRODUCT_MAPPING) || {},
+        ECOMMERCE_PRODUCT_MAPPING,
+      ),
     );
     return Object.keys(product).length > 0 ? [product] : [];
   }
@@ -235,7 +329,10 @@ const buildProductsArray = (properties, brazeEvent) => {
     .map(raw => {
       const item = raw && typeof raw === 'object' ? raw : {};
       const product = removeUndefinedAndNullAndEmptyValues(
-        constructPayload(item, ECOMMERCE_PRODUCT_MAPPING) || {},
+        coerceMappedFields(
+          constructPayload(item, ECOMMERCE_PRODUCT_MAPPING) || {},
+          ECOMMERCE_PRODUCT_MAPPING,
+        ),
       );
       const productMetadata = pickUnmappedKeys(item, consumedKeys);
       if (Object.keys(productMetadata).length > 0) {
@@ -278,6 +375,43 @@ const collectMissingRequiredFields = (eventMapping, hasProducts, payload) => {
   }
 
   return missing;
+};
+
+/**
+ * Whether a resolved value is present but doesn't match its Braze-expected type. Only
+ * resolved values are flagged — an empty/missing value is scrubbed before send and is the
+ * missing-required warning's job, so it must not double-warn here.
+ */
+const isTypeMismatch = (value, type) => isResolvedValue(value) && !matchesType(value, type);
+
+/**
+ * Collect the mapped fields whose (already-coerced) value is present but still doesn't
+ * match Braze's expected type — event-level and per-product. Returns labels of the form
+ * `destKey (expected <type>)` / `products.destKey (expected <type>)`.
+ */
+const collectTypeMismatchedFields = (eventMapping, hasProducts, payload) => {
+  const mismatched = [];
+
+  eventMapping.forEach(entry => {
+    if (isTypeMismatch(payload[entry.destKey], entry.type)) {
+      mismatched.push(`${entry.destKey} (expected ${entry.type})`);
+    }
+  });
+
+  if (hasProducts) {
+    const products = Array.isArray(payload.products) ? payload.products : [];
+    const mismatchedProductFields = new Set();
+    products.forEach(product => {
+      ECOMMERCE_PRODUCT_MAPPING.forEach(entry => {
+        if (isTypeMismatch(product[entry.destKey], entry.type)) {
+          mismatchedProductFields.add(`products.${entry.destKey} (expected ${entry.type})`);
+        }
+      });
+    });
+    mismatchedProductFields.forEach(field => mismatched.push(field));
+  }
+
+  return mismatched;
 };
 
 // ---------------------------------------------------------------------------
@@ -327,16 +461,19 @@ export const deriveSource = message => {
  * 4. Route unmapped event-level keys to `properties.metadata` (excluding `action`, which is
  *    set explicitly), and unmapped per-product keys to `products[].metadata`.
  * 5. Emit a single `logger.warn` listing any missing Braze-required fields.
+ * 6. Emit a single `logger.warn` listing any field whose value type doesn't match Braze's
+ *    schema after safe coercion (Braze rejects type-mismatched events; the value is sent
+ *    as-is so it's not silently dropped).
  *
- * Never throws on data shape; the warning + the (still-sent) payload is the contract.
+ * Never throws on data shape; the warnings + the (still-sent) payload are the contract.
  */
 export const buildEcommerceEventProperties = (message, brazeEvent, action, logger) => {
   const properties = message.properties || {};
   const eventMapping = PER_EVENT_MAPPING[brazeEvent] || [];
   const hasProducts = brazeEvent !== BRAZE_ECOMMERCE_EVENTS.PRODUCT_VIEWED;
 
-  // Step 1: event-level field mapping.
-  const payload = constructPayload(message, eventMapping) || {};
+  // Step 1: event-level field mapping, with each mapped value coerced to its Braze type.
+  const payload = coerceMappedFields(constructPayload(message, eventMapping) || {}, eventMapping);
 
   // Step 2: products[] (skipped for product_viewed — flat, single-product event).
   if (hasProducts) {
@@ -370,6 +507,14 @@ export const buildEcommerceEventProperties = (message, brazeEvent, action, logge
   if (missingFields.length > 0 && logger) {
     logger.warn(
       `${brazeEvent}: missing recommended Braze-required field(s): ${missingFields.join(', ')}. Event sent anyway.`,
+    );
+  }
+
+  // Step 6: single warning for any field whose type still doesn't match Braze's schema.
+  const mismatchedFields = collectTypeMismatchedFields(eventMapping, hasProducts, payload);
+  if (mismatchedFields.length > 0 && logger) {
+    logger.warn(
+      `${brazeEvent}: type-mismatched field(s) (sent as-is): ${mismatchedFields.join(', ')}.`,
     );
   }
 

--- a/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
@@ -17,7 +17,10 @@ export const BRAZE_ECOMMERCE_EVENTS = {
   ORDER_CANCELLED: 'ecommerce.order_cancelled',
 };
 
-const BRAZE_SOURCE_VALUES = ['web', 'ios', 'android'];
+// Braze requires a `source` on every recommended event. This is the web device-mode
+// integration, so it always reports `web` — the mobile SDKs report `ios`/`android`.
+// A caller-supplied `properties.source` is ignored (and not passed through to metadata).
+const BRAZE_WEB_SOURCE = 'web';
 
 // Case-insensitive RS event name -> Braze recommended event mapping.
 // Keys are lowercased RS event names. `Cart Viewed` and `Cart Updated` are
@@ -45,7 +48,7 @@ const FIELD_TYPE = {
 
 // ---------------------------------------------------------------------------
 // Per-event field mappings (mirror of the cloud `Braze*Config.json` files).
-// Each entry is built via `m(destKey, sourceKeys, required, type)`:
+// Each entry is built via `mapField(destKey, sourceKeys, required, type)`:
 //   - `destKey`/`sourceKeys` are the `constructPayload` contract.
 //   - `req` flags Braze-required fields (consumed by collectMissingRequiredFields).
 //   - `type` is the Braze-expected type (default String); drives coercion + the
@@ -53,7 +56,7 @@ const FIELD_TYPE = {
 // `sourceKeys` arrays are ordered fallback chains (first resolved value wins).
 // ---------------------------------------------------------------------------
 
-const m = (destKey, sourceKeys, req = false, type = FIELD_TYPE.STRING) => ({
+const mapField = (destKey, sourceKeys, req = false, type = FIELD_TYPE.STRING) => ({
   destKey,
   sourceKeys,
   req,
@@ -65,77 +68,77 @@ const TOTAL_VALUE_SOURCES = ['properties.total', 'properties.revenue', 'properti
 const TOTAL_DISCOUNTS_SOURCES = ['properties.discount', 'properties.total_discounts'];
 
 const PRODUCT_VIEWED_MAPPING = [
-  m('product_id', ['properties.product_id', 'properties.sku'], true),
-  m('product_name', 'properties.name', true),
-  m('variant_id', ['properties.variant', 'properties.sku', 'properties.product_id'], true),
-  m('price', 'properties.price', true, FIELD_TYPE.FLOAT),
-  m('currency', 'properties.currency', true),
-  m('image_url', 'properties.image_url'),
-  m('product_url', 'properties.url'),
-  m('type', 'properties.type', false, FIELD_TYPE.STRING_ARRAY),
+  mapField('product_id', ['properties.product_id', 'properties.sku'], true),
+  mapField('product_name', 'properties.name', true),
+  mapField('variant_id', ['properties.variant', 'properties.sku', 'properties.product_id'], true),
+  mapField('price', 'properties.price', true, FIELD_TYPE.FLOAT),
+  mapField('currency', 'properties.currency', true),
+  mapField('image_url', 'properties.image_url'),
+  mapField('product_url', 'properties.url'),
+  mapField('type', 'properties.type', false, FIELD_TYPE.STRING_ARRAY),
 ];
 
 const CART_UPDATED_MAPPING = [
-  m('cart_id', 'properties.cart_id', true),
-  m('total_value', ['properties.total', 'properties.value'], false, FIELD_TYPE.FLOAT),
-  m('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
-  m('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
-  m('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
-  m('currency', 'properties.currency', true),
+  mapField('cart_id', 'properties.cart_id', true),
+  mapField('total_value', ['properties.total', 'properties.value'], false, FIELD_TYPE.FLOAT),
+  mapField('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
+  mapField('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
+  mapField('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
+  mapField('currency', 'properties.currency', true),
 ];
 
 const CHECKOUT_STARTED_MAPPING = [
-  m('checkout_id', ['properties.checkout_id', 'properties.order_id'], true),
-  m('cart_id', 'properties.cart_id'),
-  m('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
-  m('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
-  m('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
-  m('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
-  m('currency', 'properties.currency', true),
+  mapField('checkout_id', ['properties.checkout_id', 'properties.order_id'], true),
+  mapField('cart_id', 'properties.cart_id'),
+  mapField('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
+  mapField('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
+  mapField('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
+  mapField('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
+  mapField('currency', 'properties.currency', true),
 ];
 
 const ORDER_PLACED_MAPPING = [
-  m('order_id', 'properties.order_id', true),
-  m('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
-  m('currency', 'properties.currency', true),
-  m('cart_id', 'properties.cart_id'),
-  m('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
-  m('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
-  m('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
-  m('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
-  m('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
+  mapField('order_id', 'properties.order_id', true),
+  mapField('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
+  mapField('currency', 'properties.currency', true),
+  mapField('cart_id', 'properties.cart_id'),
+  mapField('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
+  mapField('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
+  mapField('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
+  mapField('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
+  mapField('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
 ];
 
 const ORDER_REFUNDED_MAPPING = [
-  m('order_id', 'properties.order_id', true),
-  m('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
-  m('currency', 'properties.currency', true),
-  m('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
-  m('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
+  mapField('order_id', 'properties.order_id', true),
+  mapField('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
+  mapField('currency', 'properties.currency', true),
+  mapField('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
+  mapField('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
 ];
 
 const ORDER_CANCELLED_MAPPING = [
-  m('order_id', 'properties.order_id', true),
-  m('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
-  m('currency', 'properties.currency', true),
-  m('cancel_reason', ['properties.cancel_reason', 'properties.reason'], true),
-  m('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
-  m('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
-  m('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
-  m('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
-  m('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
+  mapField('order_id', 'properties.order_id', true),
+  mapField('total_value', TOTAL_VALUE_SOURCES, true, FIELD_TYPE.FLOAT),
+  mapField('currency', 'properties.currency', true),
+  mapField('cancel_reason', ['properties.cancel_reason', 'properties.reason'], true),
+  mapField('tax', 'properties.tax', false, FIELD_TYPE.FLOAT),
+  mapField('shipping', 'properties.shipping', false, FIELD_TYPE.FLOAT),
+  mapField('total_discounts', TOTAL_DISCOUNTS_SOURCES, false, FIELD_TYPE.FLOAT),
+  mapField('subtotal_value', 'properties.subtotal_value', false, FIELD_TYPE.FLOAT),
+  mapField('discounts', 'properties.discounts', false, FIELD_TYPE.ARRAY),
 ];
 
 // Shared per-product mapping (bare keys — read from each `products[i]` /
 // `properties` directly, no `properties.` prefix).
 const ECOMMERCE_PRODUCT_MAPPING = [
-  m('product_id', ['product_id', 'sku'], true),
-  m('product_name', 'name', true),
-  m('variant_id', ['variant', 'sku', 'product_id'], true),
-  m('quantity', 'quantity', true, FIELD_TYPE.INTEGER),
-  m('price', 'price', true, FIELD_TYPE.FLOAT),
-  m('image_url', 'image_url'),
-  m('product_url', 'url'),
+  mapField('product_id', ['product_id', 'sku'], true),
+  mapField('product_name', 'name', true),
+  mapField('variant_id', ['variant', 'sku', 'product_id'], true),
+  mapField('quantity', 'quantity', true, FIELD_TYPE.INTEGER),
+  mapField('price', 'price', true, FIELD_TYPE.FLOAT),
+  mapField('image_url', 'image_url'),
+  mapField('product_url', 'url'),
 ];
 
 const PER_EVENT_MAPPING = {
@@ -451,24 +454,6 @@ export const getEcommerceMapping = eventName => {
 };
 
 /**
- * Derive the Braze `source` field. On the web SDK this resolves to `'web'`, unless the
- * event carries an explicit, valid `properties.source` (`web`/`ios`/`android`), which
- * takes precedence. The explicit value is trimmed and lowercased before matching, so
- * surrounding whitespace doesn't defeat it. Always returns one of Braze's enum values;
- * never undefined.
- */
-export const deriveSource = message => {
-  const properties = message.properties || {};
-  const explicit = String(properties.source || '')
-    .trim()
-    .toLowerCase();
-  if (BRAZE_SOURCE_VALUES.indexOf(explicit) !== -1) {
-    return explicit;
-  }
-  return 'web';
-};
-
-/**
  * Build the `properties` object for a Braze recommended ecommerce event.
  *
  * Algorithm:
@@ -477,7 +462,7 @@ export const deriveSource = message => {
  * 2. For events with a `products[]`, build the array (single-product wrap for
  *    `cart_updated` without an explicit `products[]`, iterate `properties.products`
  *    otherwise).
- * 3. Set `source` via `deriveSource` and `action` when present.
+ * 3. Set `source` (always `web` on this SDK) and `action` when present.
  * 4. Route unmapped event-level keys to `properties.metadata` (excluding `action`, which is
  *    set explicitly), and unmapped per-product keys to `products[].metadata`.
  * 5. Emit a single `logger.warn` listing any missing Braze-required fields.
@@ -501,7 +486,7 @@ export const buildEcommerceEventProperties = (message, brazeEvent, action, logge
   }
 
   // Step 3: source + action.
-  payload.source = deriveSource(message);
+  payload.source = BRAZE_WEB_SOURCE;
   if (action) {
     payload.action = action;
   }

--- a/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
@@ -1,5 +1,8 @@
 import { constructPayload } from '../../utils/utils';
-import { removeUndefinedAndNullAndEmptyValues } from '../../utils/commonUtils';
+import {
+  isDefinedAndNotNullAndNotEmpty,
+  removeUndefinedAndNullAndEmptyValues,
+} from '../../utils/commonUtils';
 
 /**
  * Braze recommended ecommerce event names.
@@ -131,14 +134,13 @@ const PER_EVENT_MAPPING = {
 // ---------------------------------------------------------------------------
 
 /**
- * Mirror `constructPayload`'s truthiness rule: `0` and `false` are valid values; only
- * undefined/null/empty-string count as missing.
+ * A field counts as "resolved" iff it survives the outgoing payload scrub
+ * (`removeUndefinedAndNullAndEmptyValues`). Reuse that exact predicate so the
+ * missing-required-field warning can never drift from what's actually sent — e.g. a
+ * required field of `{}`/`[]`/`''` is both stripped from the payload AND warned, while
+ * `0`/`false`/numbers stay valid.
  */
-const isResolvedValue = value => {
-  if (value === 0 || value === false) return true;
-  if (value === undefined || value === null) return false;
-  return !(typeof value === 'string' && value.length === 0);
-};
+const isResolvedValue = isDefinedAndNotNullAndNotEmpty;
 
 /**
  * Return the subset of `source` whose keys are not in `consumed`, with undefined/null/empty
@@ -201,10 +203,7 @@ const consumedTopLevelKeysForEvent = (brazeEvent, eventMapping, hasProducts, pro
   // explicit `products[]` is provided; in that case mark those keys as consumed so they
   // don't duplicate into event-level metadata. When `products[]` is present, the top-level
   // fields are untouched and must flow through to metadata.
-  if (
-    brazeEvent === BRAZE_ECOMMERCE_EVENTS.CART_UPDATED &&
-    !Array.isArray(properties.products)
-  ) {
+  if (brazeEvent === BRAZE_ECOMMERCE_EVENTS.CART_UPDATED && !Array.isArray(properties.products)) {
     consumedKeysFromMapping(ECOMMERCE_PRODUCT_MAPPING).forEach(key => consumed.add(key));
   }
 
@@ -300,11 +299,15 @@ export const getEcommerceMapping = eventName => {
 /**
  * Derive the Braze `source` field. On the web SDK this resolves to `'web'`, unless the
  * event carries an explicit, valid `properties.source` (`web`/`ios`/`android`), which
- * takes precedence. Always returns one of Braze's enum values; never undefined.
+ * takes precedence. The explicit value is trimmed and lowercased before matching, so
+ * surrounding whitespace doesn't defeat it. Always returns one of Braze's enum values;
+ * never undefined.
  */
 export const deriveSource = message => {
   const properties = message.properties || {};
-  const explicit = String(properties.source || '').toLowerCase();
+  const explicit = String(properties.source || '')
+    .trim()
+    .toLowerCase();
   if (BRAZE_SOURCE_VALUES.indexOf(explicit) !== -1) {
     return explicit;
   }

--- a/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
@@ -166,6 +166,29 @@ const FLOAT_STRING_REGEX = /^[+-]?(\d+\.?\d*|\.\d+)$/;
 const INTEGER_STRING_REGEX = /^[+-]?\d+$/;
 
 /**
+ * Whether `value` is a real, finite number. `Infinity`/`-Infinity` are excluded because they
+ * are not JSON-serializable (they become `null`), so they must never be treated as a valid
+ * numeric value nor be produced by a coercion. (`Number.isFinite` is unavailable on the
+ * legacy build targets, hence the explicit check.)
+ */
+const isFiniteNumber = value =>
+  typeof value === 'number' && !Number.isNaN(value) && value !== Infinity && value !== -Infinity;
+
+/**
+ * Parse a numeric string to a number, but only commit the conversion when it is lossless —
+ * an overflowing literal (e.g. a 400-digit number) would land on `Infinity`, so it is left
+ * verbatim for the type-mismatch warning instead of being destroyed.
+ */
+const coerceNumericString = (value, regex) => {
+  const trimmed = value.trim();
+  if (!regex.test(trimmed)) {
+    return value;
+  }
+  const num = Number(trimmed);
+  return isFiniteNumber(num) ? num : value;
+};
+
+/**
  * Coerce a resolved primitive to the type Braze expects, when the conversion is safe and
  * lossless; otherwise return it unchanged (the residual mismatch is surfaced by the
  * type-mismatch warning). Mirrors the cloud coercion table:
@@ -184,14 +207,10 @@ const coerceValue = (value, type) => {
     case FIELD_TYPE.STRING:
       return typeof value === 'number' ? String(value) : value;
     case FIELD_TYPE.FLOAT:
-      return typeof value === 'string' && FLOAT_STRING_REGEX.test(value.trim())
-        ? Number(value.trim())
-        : value;
+      return typeof value === 'string' ? coerceNumericString(value, FLOAT_STRING_REGEX) : value;
     case FIELD_TYPE.INTEGER:
       // Only a pure integer literal is a safe, lossless conversion ("2", not "2.5"/"2.0").
-      return typeof value === 'string' && INTEGER_STRING_REGEX.test(value.trim())
-        ? Number(value.trim())
-        : value;
+      return typeof value === 'string' ? coerceNumericString(value, INTEGER_STRING_REGEX) : value;
     default:
       // stringArray / array — never coerced.
       return value;
@@ -201,17 +220,17 @@ const coerceValue = (value, type) => {
 /**
  * Whether `value` already matches the type Braze expects. A numeric written as a string
  * (e.g. `"29.99"`) does NOT match a numeric type, so an un-coercible value still warns.
- * `0`/`false` are valid for their respective types.
+ * `0`/`false` are valid for their respective types; `NaN`/`Infinity` are not.
  */
 const matchesType = (value, type) => {
   switch (type) {
     case FIELD_TYPE.STRING:
       return typeof value === 'string';
     case FIELD_TYPE.INTEGER:
-      // `value % 1 === 0` is true only for whole numbers; NaN/Infinity yield NaN and fail.
-      return typeof value === 'number' && value % 1 === 0;
+      // `value % 1 === 0` is true only for whole numbers.
+      return isFiniteNumber(value) && value % 1 === 0;
     case FIELD_TYPE.FLOAT:
-      return typeof value === 'number' && !Number.isNaN(value);
+      return isFiniteNumber(value);
     case FIELD_TYPE.STRING_ARRAY:
       return Array.isArray(value) && value.every(item => typeof item === 'string');
     case FIELD_TYPE.ARRAY:

--- a/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
+++ b/packages/analytics-js-integrations/src/integrations/Braze/ecommerceUtil.js
@@ -39,8 +39,9 @@ const EVENT_NAME_TO_BRAZE = {
 
 const m = (destKey, sourceKeys, req = false) => ({ destKey, sourceKeys, req });
 
-// Shared fallback chain reused across checkout/order events.
+// Shared fallback chains reused across checkout/order events.
 const TOTAL_VALUE_SOURCES = ['properties.total', 'properties.revenue', 'properties.value'];
+const TOTAL_DISCOUNTS_SOURCES = ['properties.discount', 'properties.total_discounts'];
 
 const PRODUCT_VIEWED_MAPPING = [
   m('product_id', ['properties.product_id', 'properties.sku'], true),
@@ -79,7 +80,7 @@ const ORDER_PLACED_MAPPING = [
   m('cart_id', 'properties.cart_id'),
   m('tax', 'properties.tax'),
   m('shipping', 'properties.shipping'),
-  m('total_discounts', 'properties.discount'),
+  m('total_discounts', TOTAL_DISCOUNTS_SOURCES),
   m('subtotal_value', 'properties.subtotal_value'),
   m('discounts', 'properties.discounts'),
 ];
@@ -88,7 +89,7 @@ const ORDER_REFUNDED_MAPPING = [
   m('order_id', 'properties.order_id', true),
   m('total_value', TOTAL_VALUE_SOURCES, true),
   m('currency', 'properties.currency', true),
-  m('total_discounts', 'properties.total_discounts'),
+  m('total_discounts', TOTAL_DISCOUNTS_SOURCES),
   m('discounts', 'properties.discounts'),
 ];
 
@@ -99,7 +100,7 @@ const ORDER_CANCELLED_MAPPING = [
   m('cancel_reason', ['properties.cancel_reason', 'properties.reason'], true),
   m('tax', 'properties.tax'),
   m('shipping', 'properties.shipping'),
-  m('total_discounts', 'properties.discount'),
+  m('total_discounts', TOTAL_DISCOUNTS_SOURCES),
   m('subtotal_value', 'properties.subtotal_value'),
   m('discounts', 'properties.discounts'),
 ];
@@ -174,9 +175,10 @@ const consumedKeysFromMapping = mapping => {
  * Compute the set of message-property keys "consumed" by the event-level mapping (so
  * they aren't duplicated into `metadata`). Includes the `properties.`-prefixed source
  * keys, the `source` key (always derived), the `products` key for product-bearing
- * events, and (for cart_updated) the top-level product field keys folded into products[0].
+ * events, and (for cart_updated without an explicit `products[]`) the top-level product
+ * field keys folded into products[0].
  */
-const consumedTopLevelKeysForEvent = (brazeEvent, eventMapping, hasProducts) => {
+const consumedTopLevelKeysForEvent = (brazeEvent, eventMapping, hasProducts, properties) => {
   const consumed = new Set();
   consumed.add('source');
 
@@ -193,9 +195,14 @@ const consumedTopLevelKeysForEvent = (brazeEvent, eventMapping, hasProducts) => 
     consumed.add('products');
   }
 
-  // cart_updated uses top-level product fields as the single wrapped product;
-  // mark those keys as consumed so they don't duplicate into event-level metadata.
-  if (brazeEvent === BRAZE_ECOMMERCE_EVENTS.CART_UPDATED && hasProducts) {
+  // cart_updated wraps top-level product fields into a single product ONLY when no
+  // explicit `products[]` is provided; in that case mark those keys as consumed so they
+  // don't duplicate into event-level metadata. When `products[]` is present, the top-level
+  // fields are untouched and must flow through to metadata.
+  if (
+    brazeEvent === BRAZE_ECOMMERCE_EVENTS.CART_UPDATED &&
+    !Array.isArray(properties.products)
+  ) {
     consumedKeysFromMapping(ECOMMERCE_PRODUCT_MAPPING).forEach(key => consumed.add(key));
   }
 
@@ -204,11 +211,12 @@ const consumedTopLevelKeysForEvent = (brazeEvent, eventMapping, hasProducts) => 
 
 /**
  * Build the `products[]` array for the outgoing payload.
- * - cart_updated: read top-level product fields directly from `properties` into a
- *   1-element products[]. No per-product metadata — unmapped event-level keys flow
- *   through the event-level metadata pass.
- * - other product-bearing events: map each item in `properties.products` and route
- *   per-product unmapped keys to `products[i].metadata`.
+ * - cart_updated WITHOUT an explicit `products[]`: read top-level product fields directly
+ *   from `properties` into a 1-element products[]. No per-product metadata — unmapped
+ *   event-level keys flow through the event-level metadata pass.
+ * - all other cases (cart_updated WITH `products[]`, and other product-bearing events):
+ *   map each item in `properties.products` and route per-product unmapped keys to
+ *   `products[i].metadata`.
  */
 const buildProductsArray = (properties, brazeEvent) => {
   const isCartUpdated = brazeEvent === BRAZE_ECOMMERCE_EVENTS.CART_UPDATED;
@@ -301,17 +309,18 @@ export const deriveSource = message => {
  * 1. Run `constructPayload` against the message event-level mapping (never throws —
  *    send-anyway is enforced via the validation warning instead).
  * 2. For events with a `products[]`, build the array (single-product wrap for
- *    `cart_updated`, iterate `properties.products` otherwise).
+ *    `cart_updated` without an explicit `products[]`, iterate `properties.products`
+ *    otherwise).
  * 3. Set `source` via `deriveSource` and `action` when present.
- * 4. Route unmapped event-level keys to `properties.metadata`, and unmapped per-product
- *    keys to `products[].metadata`.
+ * 4. Route unmapped event-level keys to `properties.metadata` (excluding `action`, which is
+ *    set explicitly), and unmapped per-product keys to `products[].metadata`.
  * 5. Emit a single `logger.warn` listing any missing Braze-required fields.
  *
  * Never throws on data shape; the warning + the (still-sent) payload is the contract.
  */
 export const buildEcommerceEventProperties = (message, brazeEvent, action, logger) => {
   const properties = message.properties || {};
-  const eventMapping = PER_EVENT_MAPPING[brazeEvent];
+  const eventMapping = PER_EVENT_MAPPING[brazeEvent] || [];
   const hasProducts = brazeEvent !== BRAZE_ECOMMERCE_EVENTS.PRODUCT_VIEWED;
 
   // Step 1: event-level field mapping.
@@ -328,8 +337,17 @@ export const buildEcommerceEventProperties = (message, brazeEvent, action, logge
     payload.action = action;
   }
 
-  // Step 4: route unmapped event-level keys to metadata.
-  const consumedEventKeys = consumedTopLevelKeysForEvent(brazeEvent, eventMapping, hasProducts);
+  // Step 4: route unmapped event-level keys to metadata. Exclude `action` when it's set
+  // explicitly (Step 3) so a caller-provided `properties.action` can't conflict with it.
+  const consumedEventKeys = consumedTopLevelKeysForEvent(
+    brazeEvent,
+    eventMapping,
+    hasProducts,
+    properties,
+  );
+  if (action) {
+    consumedEventKeys.add('action');
+  }
   const eventMetadata = pickUnmappedKeys(properties, consumedEventKeys);
   if (Object.keys(eventMetadata).length > 0) {
     payload.metadata = eventMetadata;


### PR DESCRIPTION
## PR Description

Adds support for Braze's [recommended ecommerce events](https://www.braze.com/docs/user_guide/data/activation/events/recommended_events) in the **web device mode** integration, mirroring the cloud-mode mapping. Gated behind a new opt-in config flag `useEcommerceRecommendedEvents` (default off); when off, the existing legacy custom-event / `logPurchase` path is unchanged.

When enabled, mapped RudderStack ecommerce events are emitted via `globalThis.braze.logCustomEvent(name, properties)` (including `Order Completed`, which maps to `ecommerce.order_placed` rather than `logPurchase`).

**Event mapping (RS → Braze):**

| RudderStack event | Braze event | Notes |
|---|---|---|
| Product Viewed | `ecommerce.product_viewed` | flat, no `products[]` |
| Product Added | `ecommerce.cart_updated` | `action: 'add'`, single-product wrap |
| Product Removed | `ecommerce.cart_updated` | `action: 'remove'` |
| Checkout Started | `ecommerce.checkout_started` | |
| Order Completed | `ecommerce.order_placed` | |
| Order Refunded | `ecommerce.order_refunded` | |
| Order Cancelled | `ecommerce.order_cancelled` | |

`Cart Viewed` / `Cart Updated` are intentionally unmapped and fall through to the legacy path.

**Changes:**
- `ecommerceUtil.js` (new) — event-name resolution, per-event + per-product field mappings, `products[]` construction, unmapped-key → `metadata` pass-through, and `source` derivation (`'web'`, with valid `properties.source` taking precedence).
- `browser.js` — reads the `useEcommerceRecommendedEvents` flag and routes mapped events through the new builder.
- Validation posture matches cloud's "send-anyway": on missing Braze-required fields, emit a single `logger.warn` and still call `logCustomEvent`.
- Empty `products[]` and other empty/null fields are stripped from the payload before sending (the missing-field warning still fires).

## Linear task

[INT-4303](https://linear.app/rudderstack/issue/INT-4303/braze-update-with-recommended-events-in-web-device-mode)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Braze recommended ecommerce events. When enabled, ecommerce events are routed to Braze’s dedicated ecommerce endpoints with correctly normalized sources, mapped fields, and products payload shaping.
* **Bug Fixes**
  * Improved cart, checkout, and order handling, including correct precedence for “order completed,” consistent action derivation, and scrubbing of null/empty product and metadata values.
  * Missing or empty required ecommerce data now triggers warnings while still sending the event; unmapped events use the legacy tracking path.
* **Tests**
  * Added comprehensive Jest coverage for event mapping, payload transformations, and edge cases.
* **Chores**
  * Updated the legacy CDN bundle size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->