### PR TITLE
fix(fb-pixel): guard global fbq bootstrap so multiple pixel destinations don't conflict

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/browser.test.js
@@ -87,10 +87,21 @@ describe('FacebookPixel init tests', () => {
 
 describe('FacebookPixel multiple destinations bootstrap guard', () => {
   const mockAnalytics = {};
+  let previousFbq;
+  let previousFbqShim;
 
   beforeEach(() => {
+    // Capture and clear the globals so this suite exercises a fresh bootstrap,
+    // then restore them in afterEach so sibling suites are not affected.
+    previousFbq = window.fbq;
+    previousFbqShim = window._fbq;
     delete window.fbq;
     delete window._fbq;
+  });
+
+  afterEach(() => {
+    window.fbq = previousFbq;
+    window._fbq = previousFbqShim;
   });
 
   test('does not re-bootstrap the global fbq shim when a second destination initializes', () => {
@@ -119,6 +130,26 @@ describe('FacebookPixel multiple destinations bootstrap guard', () => {
     expect(window.fbq.queue).toContainEqual(
       expect.objectContaining({ 0: 'init', 1: '222222222' }),
     );
+  });
+
+  test('applies pushState flags on every init even when fbq is pre-existing', () => {
+    // Simulate the host page (or an earlier destination) having already bootstrapped
+    // Meta Pixel with automatic pageview tracking enabled.
+    window.fbq = jest.fn();
+    window.fbq.queue = [];
+    window.fbq.version = 'pre-existing';
+    window.fbq.disablePushState = false;
+    window.fbq.allowDuplicatePageViews = false;
+
+    const pixel = new FacebookPixel({ pixelId: '333333333' }, mockAnalytics, destinationInfo);
+    pixel.init();
+
+    // The one-time shim state is left untouched (no version conflict)...
+    expect(window.fbq.version).toBe('pre-existing');
+    // ...but the pageview flags are (re)applied on this init so we never fall back
+    // to Meta's automatic pageview/pushState tracking.
+    expect(window.fbq.disablePushState).toBe(true);
+    expect(window.fbq.allowDuplicatePageViews).toBe(true);
   });
 });
 

--- a/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/browser.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/browser.test.js
@@ -85,6 +85,43 @@ describe('FacebookPixel init tests', () => {
   });
 });
 
+describe('FacebookPixel multiple destinations bootstrap guard', () => {
+  const mockAnalytics = {};
+
+  beforeEach(() => {
+    delete window.fbq;
+    delete window._fbq;
+  });
+
+  test('does not re-bootstrap the global fbq shim when a second destination initializes', () => {
+    // First destination bootstraps the global fbq shim.
+    const firstPixel = new FacebookPixel({ pixelId: '111111111' }, mockAnalytics, destinationInfo);
+    firstPixel.init();
+
+    const shimAfterFirstInit = window.fbq;
+    expect(typeof shimAfterFirstInit).toBe('function');
+    expect(window.fbq.version).toBe('2.0');
+
+    // Simulate the loaded SDK taking over: mark the shim and enqueue an event.
+    window.fbq.version = 'preserved-by-loaded-sdk';
+    window.fbq.queue.push('event-from-first-destination');
+
+    // Second destination initializes. Its init() must NOT reset the global shim.
+    const secondPixel = new FacebookPixel({ pixelId: '222222222' }, mockAnalytics, destinationInfo);
+    secondPixel.init();
+
+    // The guard preserves the already established shim: version and queue are untouched.
+    expect(window.fbq).toBe(shimAfterFirstInit);
+    expect(window.fbq.version).toBe('preserved-by-loaded-sdk');
+    expect(window.fbq.queue).toContain('event-from-first-destination');
+
+    // The second pixel still registers itself via its own init call.
+    expect(window.fbq.queue).toContainEqual(
+      expect.objectContaining({ 0: 'init', 1: '222222222' }),
+    );
+  });
+});
+
 describe('FacebookPixel page', () => {
   let facebookPixel;
   const mockAnalytics = {

--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
@@ -53,21 +53,28 @@ class FacebookPixel {
   }
 
   init() {
-    window._fbq = function () {
-      if (window.fbq.callMethod) {
-        window.fbq.callMethod.apply(window.fbq, arguments);
-      } else {
-        window.fbq.queue.push(arguments);
-      }
-    };
+    // Bootstrap the global fbq shim only once per page. When multiple Meta Pixel
+    // destinations are configured, each one calls init(), and re-running this block
+    // mutates the already loaded fbevents.js SDK (resetting fbq.version, fbq.queue, etc.),
+    // which makes Meta log "Multiple pixels with conflicting versions were detected"
+    // and prevents the second pixel from initializing. Guard it like Meta's own snippet.
+    if (!window.fbq) {
+      window._fbq = function () {
+        if (window.fbq.callMethod) {
+          window.fbq.callMethod.apply(window.fbq, arguments);
+        } else {
+          window.fbq.queue.push(arguments);
+        }
+      };
 
-    window.fbq = window.fbq || window._fbq;
-    window.fbq.push = window.fbq;
-    window.fbq.loaded = true;
-    window.fbq.disablePushState = true; // disables automatic pageview tracking
-    window.fbq.allowDuplicatePageViews = true; // enables fb
-    window.fbq.version = '2.0';
-    window.fbq.queue = [];
+      window.fbq = window.fbq || window._fbq;
+      window.fbq.push = window.fbq;
+      window.fbq.loaded = true;
+      window.fbq.disablePushState = true; // disables automatic pageview tracking
+      window.fbq.allowDuplicatePageViews = true; // enables fb
+      window.fbq.version = '2.0';
+      window.fbq.queue = [];
+    }
     window.fbq('set', 'autoConfig', this.autoConfig, this.pixelId); // toggle autoConfig : sends button click and page metadata
     if (this.advancedMapping) {
       if (this.useUpdatedMapping) {

--- a/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
+++ b/packages/analytics-js-integrations/src/integrations/FacebookPixel/browser.js
@@ -70,11 +70,14 @@ class FacebookPixel {
       window.fbq = window.fbq || window._fbq;
       window.fbq.push = window.fbq;
       window.fbq.loaded = true;
-      window.fbq.disablePushState = true; // disables automatic pageview tracking
-      window.fbq.allowDuplicatePageViews = true; // enables fb
       window.fbq.version = '2.0';
       window.fbq.queue = [];
     }
+    // Apply these flags on every init() (even when fbq was bootstrapped by the host page
+    // or an earlier destination), so we never fall back to Meta's automatic pageview
+    // tracking. They don't cause the version conflict, so they stay outside the guard.
+    window.fbq.disablePushState = true; // disables automatic pageview tracking
+    window.fbq.allowDuplicatePageViews = true; // enables fb
     window.fbq('set', 'autoConfig', this.autoConfig, this.pixelId); // toggle autoConfig : sends button click and page metadata
     if (this.advancedMapping) {
       if (this.useUpdatedMapping) {


### PR DESCRIPTION
Fixes #2587

### Symptom
When two Meta Pixel destinations are configured in device mode (different Pixel IDs), the browser console logs:

> [Meta Pixel] - Multiple pixels with conflicting versions were detected on this page.

Only the first pixel ends up initialized (confirmed with the Meta Pixel Helper extension); the second one does not fire.

### Root cause
`FacebookPixel.init()` runs the global `fbq` bootstrap unconditionally. The `fbevents.js` script is loaded only once, but each destination's `init()` re-runs the shim setup and overwrites the already-loaded SDK: it reassigns `window._fbq`, resets `window.fbq.push/loaded/version` and, critically, `window.fbq.queue = []`. Meta's real SDK sees its own `fbq` mutated back to the `2.0` bootstrap state and reports a version conflict, which breaks the second pixel.

### Fix
I wrapped only the one-time shim bootstrap in an `if (!window.fbq) { ... }` guard, mirroring Meta's official snippet (`if (f.fbq) return;`). The per-destination calls stay outside the guard, so every destination still registers itself: `fbq('set', 'autoConfig', ...)`, the advanced-mapping block, `fbq('init', pixelId, ...)` and the `ScriptLoader(...)` call all run for each instance. The result is a single global shim with both pixels initialized and no conflict warning.

### Tests
Added a unit test in `packages/analytics-js-integrations/__tests__/integrations/FacebookPixel/browser.test.js` that initializes one destination, marks the shim (`window.fbq.version` + a queued event), initializes a second destination, and asserts the global shim and its queue are preserved while the second pixel still registers its own `init`. The full FacebookPixel suite passes (9/9), and I verified the new test fails against the old unguarded code, so it guards against regressions.

I'm happy to sign the CLA and to make any changes the team would like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the Meta Pixel browser shim from being re-initialized when multiple pixel destinations initialize on the same page.
  * Preserved existing Pixel queue and browser state during subsequent initializations while registering each pixel.
  * Refreshed pushState and pageview-related settings on every initialization.

* **Tests**
  * Added coverage for multi-destination and repeated initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->