### PR TITLE
fix(monorepo): pin form-data to 4.0.6 to fix CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14578,16 +14578,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -15365,9 +15365,9 @@
       "license": "ISC"
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -224,7 +224,8 @@
     },
     "tmp": "0.2.5",
     "tar": "7.5.9",
-    "conventional-changelog-conventionalcommits": "7.0.2"
+    "conventional-changelog-conventionalcommits": "7.0.2",
+    "form-data": "4.0.6"
   },
   "lint-staged": {
     "*.{json,js,md,ts}": "prettier --write"


### PR DESCRIPTION
## PR Description

Pins `form-data` to `4.0.6` via an npm `overrides` entry in the root `package.json`, resolving the high-severity CRLF injection vulnerability ([GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx)) affecting `form-data` `4.0.0 - 4.0.5`.

The vulnerable `form-data` version was reachable on a production dependency path (via `@vespaiach/axios-fetch-adapter` → `axios`), so the root `npm audit --audit-level=high --omit=dev` gate (the "Security checks" CI job) was failing on PRs and blocking otherwise-unrelated changes from getting a green build.

**Why an override (and not a parent upgrade):** the only parent version that pulls `form-data@4.0.6` natively is a major `nx` upgrade (`22.x → 23.x`), which is out of scope for on-call maintenance. A targeted override is the minimal, low-risk fix and matches the repo's existing pattern for pinned transitive deps (`tmp`, `tar`).

**Changes:**
- `package.json` — add `"form-data": "4.0.6"` to the existing `overrides` block.
- `package-lock.json` — `form-data` `4.0.5 → 4.0.6` (and its transitive `hasown` `2.0.3 → 2.0.4`).

## Linear task (optional)

[SDK-5124](https://linear.app/rudderstack/issue/SDK-5124/fix-form-data-high-severity-vulnerability-failing-security-checks-in)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

_N/A — dependency-only change, no runtime/source code touched._

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

Verified locally (lockfile round-trip, simulating CI):
- `npm ci` + `npm audit --audit-level=high --omit=dev` → **found 0 vulnerabilities**
- `npm run check:security` (exact CI script) → **found 0 vulnerabilities**
- `npm ls form-data --all` → all copies `overridden` / `deduped`, no `invalid` or nested copies
- Affected test suites pass
