### PR TITLE
feat: sdk-5054 add state-backed custom context store

### DIFF
--- a/packages/analytics-js-common/src/types/ApplicationState.ts
+++ b/packages/analytics-js-common/src/types/ApplicationState.ts
@@ -22,6 +22,7 @@ import type {
 import type { StorageType, CookieOptions } from './Storage';
 import type { UserSessionKey } from './UserSessionStorage';
 import type { RSAnalytics } from './IRudderAnalytics';
+import type { CustomContext } from './CustomContext';
 
 export type CapabilitiesState = {
   isOnline: Signal<boolean>;
@@ -76,6 +77,8 @@ export type ContextState = {
   'ua-ch': Signal<UADataValues | undefined>;
   timezone: Signal<string | undefined>;
 };
+
+export type CustomContextState = Signal<CustomContext>;
 
 export type EventBufferState = {
   // TODO: make this a BufferQueue?
@@ -205,6 +208,7 @@ export interface ApplicationState {
   capabilities: CapabilitiesState;
   consents: ConsentsState;
   context: ContextState;
+  customContext: CustomContextState;
   eventBuffer: EventBufferState;
   lifecycle: LifecycleState;
   loadOptions: LoadOptionsState;

--- a/packages/analytics-js-common/src/types/CustomContext.ts
+++ b/packages/analytics-js-common/src/types/CustomContext.ts
@@ -1,0 +1,11 @@
+export type CustomContextValue =
+  | string
+  | number
+  | boolean
+  | Date
+  | CustomContext
+  | CustomContextValue[];
+
+export interface CustomContext {
+  [key: string]: CustomContextValue;
+}

--- a/packages/analytics-js-plugins/__mocks__/state.ts
+++ b/packages/analytics-js-plugins/__mocks__/state.ts
@@ -60,6 +60,7 @@ const defaultStateValues: ApplicationState = {
     'ua-ch': signal(undefined),
     timezone: signal(undefined),
   },
+  customContext: signal({}),
   eventBuffer: {
     toBeProcessedArray: signal([]),
     readyCallbacksArray: signal([]),
@@ -203,6 +204,7 @@ const resetState = () => {
   state.capabilities = clone(defaultStateValues.capabilities);
   state.consents = clone(defaultStateValues.consents);
   state.context = clone(defaultStateValues.context);
+  state.customContext = clone(defaultStateValues.customContext);
   state.eventBuffer = clone(defaultStateValues.eventBuffer);
   state.lifecycle = clone(defaultStateValues.lifecycle);
   state.loadOptions = clone(defaultStateValues.loadOptions);

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -48,6 +48,13 @@ describe('Core - Analytics', () => {
       expect(analytics.externalSrcLoader).toBeDefined();
       expect(analytics.capabilitiesManager).toBeDefined();
       expect(analytics.httpClient).toBeDefined();
+      expect(analytics.customContextStore.get()).toEqual({});
+    });
+
+    it('owns a custom context store per Analytics instance', () => {
+      const otherAnalytics = new Analytics();
+
+      expect(otherAnalytics.customContextStore).not.toBe(analytics.customContextStore);
     });
   });
 

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -51,10 +51,12 @@ describe('Core - Analytics', () => {
       expect(analytics.customContextStore.get()).toEqual({});
     });
 
-    it('owns a custom context store per Analytics instance', () => {
+    it('uses the shared custom context state across Analytics components', () => {
       const otherAnalytics = new Analytics();
+      analytics.customContextStore.set({ region: 'EU' });
 
       expect(otherAnalytics.customContextStore).not.toBe(analytics.customContextStore);
+      expect(otherAnalytics.customContextStore.get()).toEqual({ region: 'EU' });
     });
   });
 

--- a/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
+++ b/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
@@ -68,7 +68,7 @@ describe('CustomContextStore', () => {
 
   it('leaves the previous snapshot unchanged when normalization rejects an update', () => {
     setContext({ region: 'EU', account: { plan: 'pro' } });
-    setContext({ region: null, invalid: new Date('2026-07-21T00:00:00.000Z') });
+    setContext({ region: null, invalid: new Map([['key', 'value']]) });
 
     expect(store.get()).toEqual({ region: 'EU', account: { plan: 'pro' } });
   });
@@ -91,6 +91,21 @@ describe('CustomContextStore', () => {
       account: { plan: 'pro' },
       variants: [{ name: 'control' }],
     });
+  });
+
+  it('owns date inputs and returns defensive date snapshots', () => {
+    const inputDate = new Date('2026-07-21T00:00:00.000Z');
+    setContext({ capturedAt: inputDate });
+    inputDate.setUTCFullYear(2030);
+
+    const firstSnapshot = store.get();
+    const firstSnapshotDate = firstSnapshot.capturedAt as Date;
+    firstSnapshotDate.setUTCFullYear(2031);
+
+    const storedDate = store.get().capturedAt as Date;
+    expect(storedDate).toEqual(new Date('2026-07-21T00:00:00.000Z'));
+    expect(storedDate).not.toBe(inputDate);
+    expect(storedDate).not.toBe(firstSnapshotDate);
   });
 
   it('clears the complete snapshot without retaining previous references', () => {

--- a/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
+++ b/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
@@ -1,4 +1,6 @@
+import { signal } from '@preact/signals-core';
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import { CustomContextStore } from '../../../src/components/customContext';
 
 class MockLogger implements ILogger {
@@ -17,10 +19,12 @@ class MockLogger implements ILogger {
 describe('CustomContextStore', () => {
   let logger: MockLogger;
   let store: CustomContextStore;
+  let contextState: ReturnType<typeof signal<CustomContext>>;
 
   beforeEach(() => {
     logger = new MockLogger();
-    store = new CustomContextStore(logger);
+    contextState = signal<CustomContext>({});
+    store = new CustomContextStore(contextState, logger);
   });
 
   const setContext = (context: unknown): void => {
@@ -118,11 +122,12 @@ describe('CustomContextStore', () => {
     expect(store.get()).toEqual({});
   });
 
-  it('keeps separate store instances isolated', () => {
-    const otherStore = new CustomContextStore(new MockLogger());
+  it('uses the provided state slice as the storage boundary', () => {
+    const otherStore = new CustomContextStore(contextState, new MockLogger());
     setContext({ region: 'EU' });
 
+    expect(contextState.value).toEqual({ region: 'EU' });
     expect(store.get()).toEqual({ region: 'EU' });
-    expect(otherStore.get()).toEqual({});
+    expect(otherStore.get()).toEqual({ region: 'EU' });
   });
 });

--- a/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
+++ b/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
@@ -1,0 +1,113 @@
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import { CustomContextStore } from '../../../src/components/customContext';
+
+class MockLogger implements ILogger {
+  warn = jest.fn();
+  log = jest.fn();
+  error = jest.fn();
+  info = jest.fn();
+  debug = jest.fn();
+  minLogLevel = 0;
+  scope = 'test scope';
+  setMinLogLevel = jest.fn();
+  setScope = jest.fn();
+  logProvider = console;
+}
+
+describe('CustomContextStore', () => {
+  let logger: MockLogger;
+  let store: CustomContextStore;
+
+  beforeEach(() => {
+    logger = new MockLogger();
+    store = new CustomContextStore(logger);
+  });
+
+  const setContext = (context: unknown): void => {
+    store.set(context);
+  };
+
+  it('starts empty', () => {
+    expect(store.get()).toEqual({});
+  });
+
+  it('deep merges repeated updates using the existing array-by-index contract', () => {
+    setContext({
+      account: { plan: 'pro', seats: 5 },
+      variants: [{ name: 'control', weight: 50 }, 'legacy', 'retained'],
+    });
+    setContext({
+      account: { plan: 'enterprise' },
+      variants: [{ name: 'treatment' }, 'current'],
+    });
+
+    expect(store.get()).toEqual({
+      account: { plan: 'enterprise', seats: 5 },
+      variants: [{ name: 'treatment', weight: 50 }, 'current', 'retained'],
+    });
+  });
+
+  it('deletes top-level and nested paths while retaining an existing empty parent', () => {
+    setContext({
+      region: 'EU',
+      account: { plan: 'pro', seats: 5 },
+    });
+    setContext({
+      region: null,
+      account: { plan: undefined, seats: null },
+    });
+
+    expect(store.get()).toEqual({ account: {} });
+  });
+
+  it('does not create parents when deleting a missing nested path', () => {
+    setContext({ missing: { nested: null } });
+
+    expect(store.get()).toEqual({});
+  });
+
+  it('leaves the previous snapshot unchanged when normalization rejects an update', () => {
+    setContext({ region: 'EU', account: { plan: 'pro' } });
+    setContext({ region: null, invalid: new Date('2026-07-21T00:00:00.000Z') });
+
+    expect(store.get()).toEqual({ region: 'EU', account: { plan: 'pro' } });
+  });
+
+  it('owns input values and returns deep defensive snapshots', () => {
+    const input = {
+      account: { plan: 'pro' },
+      variants: [{ name: 'control' }],
+    };
+    setContext(input);
+
+    input.account.plan = 'enterprise';
+    input.variants[0]!.name = 'treatment';
+
+    const firstSnapshot = store.get();
+    (firstSnapshot.account as Record<string, unknown>).plan = 'free';
+    (firstSnapshot.variants as Array<Record<string, unknown>>)[0]!.name = 'mutated';
+
+    expect(store.get()).toEqual({
+      account: { plan: 'pro' },
+      variants: [{ name: 'control' }],
+    });
+  });
+
+  it('clears the complete snapshot without retaining previous references', () => {
+    setContext({ account: { plan: 'pro' } });
+    const previousSnapshot = store.get();
+
+    store.clear();
+    (previousSnapshot.account as Record<string, unknown>).plan = 'mutated';
+
+    expect(store.get()).toEqual({});
+  });
+
+  it('keeps separate store instances isolated', () => {
+    const otherStore = new CustomContextStore(new MockLogger());
+    setContext({ region: 'EU' });
+
+    expect(store.get()).toEqual({ region: 'EU' });
+    expect(otherStore.get()).toEqual({});
+  });
+});

--- a/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
+++ b/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
@@ -1,4 +1,5 @@
 import { signal } from '@preact/signals-core';
+import type { CustomContextState } from '@rudderstack/analytics-js-common/types/ApplicationState';
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import { CustomContextStore } from '../../../src/components/customContext';
@@ -19,7 +20,7 @@ class MockLogger implements ILogger {
 describe('CustomContextStore', () => {
   let logger: MockLogger;
   let store: CustomContextStore;
-  let contextState: ReturnType<typeof signal<CustomContext>>;
+  let contextState: CustomContextState;
 
   beforeEach(() => {
     logger = new MockLogger();

--- a/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
+++ b/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
@@ -65,17 +65,28 @@ describe('CustomContextStore', () => {
     expect(store.get()).toEqual({ account: {} });
   });
 
-  it('does not create parents when deleting a missing nested path', () => {
+  it('retains an empty parent when deleting a missing nested path', () => {
     setContext({ missing: { nested: null } });
 
-    expect(store.get()).toEqual({});
+    expect(store.get()).toEqual({ missing: {} });
   });
 
-  it('leaves the previous snapshot unchanged when normalization rejects an update', () => {
+  it('applies deletion markers with user supplied values in one update', () => {
+    const value = new Map([['key', 'value']]);
     setContext({ region: 'EU', account: { plan: 'pro' } });
-    setContext({ region: null, invalid: new Map([['key', 'value']]) });
+    setContext({ region: null, value });
 
-    expect(store.get()).toEqual({ region: 'EU', account: { plan: 'pro' } });
+    expect(store.get()).toEqual({ account: { plan: 'pro' }, value });
+  });
+
+  it('does not apply object property cleanup to array entries', () => {
+    setContext({
+      variants: ['control', null, undefined, { removeMe: null }],
+    });
+
+    expect(store.get()).toStrictEqual({
+      variants: ['control', null, undefined, { removeMe: null }],
+    });
   });
 
   it('owns input values and returns deep defensive snapshots', () => {

--- a/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
+++ b/packages/analytics-js/__tests__/services/ErrorHandler/utils.test.ts
@@ -309,6 +309,16 @@ describe('Error Reporting utilities', () => {
 
       expect(getAppStateForMetadata(input)).toEqual(expected);
     });
+
+    it('excludes custom context from application state metadata', () => {
+      state.customContext.value = {
+        account: {
+          plan: 'enterprise',
+        },
+      };
+
+      expect(getAppStateForMetadata(state)).not.toHaveProperty('customContext');
+    });
   });
 
   describe('getBugsnagErrorEvent', () => {

--- a/packages/analytics-js/__tests__/state/index.test.ts
+++ b/packages/analytics-js/__tests__/state/index.test.ts
@@ -1,0 +1,23 @@
+import { resetState, state } from '../../src/state';
+
+describe('application state', () => {
+  afterEach(() => {
+    resetState();
+  });
+
+  it('initializes custom context as empty', () => {
+    expect(state.customContext.value).toEqual({});
+  });
+
+  it('restores custom context to empty on full state reset', () => {
+    state.customContext.value = {
+      account: {
+        plan: 'enterprise',
+      },
+    };
+
+    resetState();
+
+    expect(state.customContext.value).toEqual({});
+  });
+});

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -70,6 +70,7 @@ import { getConsentManagementData, getValidPostConsentOptions } from '../utiliti
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
+import { CustomContextStore } from '../customContext';
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events
@@ -89,6 +90,7 @@ class Analytics implements IAnalytics {
   eventManager?: IEventManager;
   userSessionManager?: IUserSessionManager;
   clientDataStore?: Store;
+  customContextStore: CustomContextStore;
 
   /**
    * Initialize services and components or use default ones if singletons
@@ -98,6 +100,7 @@ class Analytics implements IAnalytics {
     this.initialized = false;
     this.errorHandler = defaultErrorHandler;
     this.logger = defaultLogger;
+    this.customContextStore = new CustomContextStore(this.logger);
     this.externalSrcLoader = new ExternalSrcLoader(this.logger);
     this.httpClient = defaultHttpClient;
     this.httpClient.init(this.errorHandler);

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -100,7 +100,7 @@ class Analytics implements IAnalytics {
     this.initialized = false;
     this.errorHandler = defaultErrorHandler;
     this.logger = defaultLogger;
-    this.customContextStore = new CustomContextStore(this.logger);
+    this.customContextStore = new CustomContextStore(state.customContext, this.logger);
     this.externalSrcLoader = new ExternalSrcLoader(this.logger);
     this.httpClient = defaultHttpClient;
     this.httpClient.init(this.errorHandler);

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -27,6 +27,7 @@ import type { IEventManager } from '../eventManager/types';
 import type { ICapabilitiesManager } from '../capabilitiesManager/types';
 import type { PreloadedEventCall } from '../preloadBuffer/types';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
+import type { CustomContextStore } from '../customContext';
 
 export interface IAnalytics {
   preloadBuffer: BufferQueue<PreloadedEventCall>;
@@ -42,6 +43,7 @@ export interface IAnalytics {
   userSessionManager?: IUserSessionManager;
   pluginsManager?: IPluginsManager;
   clientDataStore?: Store;
+  customContextStore: CustomContextStore;
 
   /**
    * Start application lifecycle if not already started

--- a/packages/analytics-js/src/components/customContext/CustomContextStore.ts
+++ b/packages/analytics-js/src/components/customContext/CustomContextStore.ts
@@ -1,5 +1,6 @@
 import { clone } from 'ramda';
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import type { CustomContextState } from '@rudderstack/analytics-js-common/types/ApplicationState';
 import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/object';
 import { prepareCustomContextUpdate } from './utilities';
 import type { CustomContext } from './types';
@@ -23,10 +24,11 @@ const deleteValueAtPath = (context: CustomContext, path: string[]): void => {
 };
 
 class CustomContextStore {
-  private context: CustomContext = {};
+  private state: CustomContextState;
   private logger: ILogger;
 
-  constructor(logger: ILogger) {
+  constructor(state: CustomContextState, logger: ILogger) {
+    this.state = state;
     this.logger = logger;
   }
 
@@ -36,17 +38,17 @@ class CustomContextStore {
       return;
     }
 
-    const workingContext = clone(this.context);
+    const workingContext = clone(this.state.value);
     update.deletionPaths.forEach(path => deleteValueAtPath(workingContext, path));
-    this.context = mergeDeepRight(workingContext, update.context);
+    this.state.value = mergeDeepRight(workingContext, update.context);
   }
 
   get(): CustomContext {
-    return clone(this.context);
+    return clone(this.state.value);
   }
 
   clear(): void {
-    this.context = {};
+    this.state.value = {};
   }
 }
 

--- a/packages/analytics-js/src/components/customContext/CustomContextStore.ts
+++ b/packages/analytics-js/src/components/customContext/CustomContextStore.ts
@@ -1,0 +1,53 @@
+import { clone } from 'ramda';
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/object';
+import { prepareCustomContextUpdate } from './utilities';
+import type { CustomContext } from './types';
+
+const deleteValueAtPath = (context: CustomContext, path: string[]): void => {
+  if (path.length === 0) {
+    return;
+  }
+
+  let parent: CustomContext = context;
+
+  for (let index = 0; index < path.length - 1; index += 1) {
+    const value = parent[path[index]!];
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      return;
+    }
+    parent = value as CustomContext;
+  }
+
+  delete parent[path[path.length - 1]!];
+};
+
+class CustomContextStore {
+  private context: CustomContext = {};
+  private logger: ILogger;
+
+  constructor(logger: ILogger) {
+    this.logger = logger;
+  }
+
+  set(context: unknown): void {
+    const update = prepareCustomContextUpdate(context, this.logger);
+    if (!update) {
+      return;
+    }
+
+    const workingContext = clone(this.context);
+    update.deletionPaths.forEach(path => deleteValueAtPath(workingContext, path));
+    this.context = mergeDeepRight(workingContext, update.context);
+  }
+
+  get(): CustomContext {
+    return clone(this.context);
+  }
+
+  clear(): void {
+    this.context = {};
+  }
+}
+
+export { CustomContextStore };

--- a/packages/analytics-js/src/components/customContext/CustomContextStore.ts
+++ b/packages/analytics-js/src/components/customContext/CustomContextStore.ts
@@ -9,8 +9,8 @@ import { prepareCustomContextUpdate } from './utilities';
 import type { CustomContext } from './types';
 
 class CustomContextStore {
-  private state: CustomContextState;
-  private logger: ILogger;
+  private readonly state: CustomContextState;
+  private readonly logger: ILogger;
 
   constructor(state: CustomContextState, logger: ILogger) {
     this.state = state;

--- a/packages/analytics-js/src/components/customContext/CustomContextStore.ts
+++ b/packages/analytics-js/src/components/customContext/CustomContextStore.ts
@@ -1,27 +1,12 @@
 import { clone } from 'ramda';
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { CustomContextState } from '@rudderstack/analytics-js-common/types/ApplicationState';
-import { mergeDeepRight } from '@rudderstack/analytics-js-common/utilities/object';
+import {
+  mergeDeepRight,
+  removeUndefinedAndNullValues,
+} from '@rudderstack/analytics-js-common/utilities/object';
 import { prepareCustomContextUpdate } from './utilities';
 import type { CustomContext } from './types';
-
-const deleteValueAtPath = (context: CustomContext, path: string[]): void => {
-  if (path.length === 0) {
-    return;
-  }
-
-  let parent: CustomContext = context;
-
-  for (let index = 0; index < path.length - 1; index += 1) {
-    const value = parent[path[index]!];
-    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-      return;
-    }
-    parent = value as CustomContext;
-  }
-
-  delete parent[path[path.length - 1]!];
-};
 
 class CustomContextStore {
   private state: CustomContextState;
@@ -38,9 +23,8 @@ class CustomContextStore {
       return;
     }
 
-    const workingContext = clone(this.state.value);
-    update.deletionPaths.forEach(path => deleteValueAtPath(workingContext, path));
-    this.state.value = mergeDeepRight(workingContext, update.context);
+    const mergedContext = mergeDeepRight(clone(this.state.value), update);
+    this.state.value = removeUndefinedAndNullValues(mergedContext);
   }
 
   get(): CustomContext {

--- a/packages/analytics-js/src/components/customContext/index.ts
+++ b/packages/analytics-js/src/components/customContext/index.ts
@@ -1,2 +1,3 @@
+export { CustomContextStore } from './CustomContextStore';
 export { filterReservedCustomContextKeys, prepareCustomContextUpdate } from './utilities';
 export type { CustomContext, CustomContextSnapshot, CustomContextValue } from './types';

--- a/packages/analytics-js/src/components/customContext/types.ts
+++ b/packages/analytics-js/src/components/customContext/types.ts
@@ -1,8 +1,7 @@
-type CustomContextValue = string | number | boolean | Date | CustomContext | CustomContextValue[];
-
-interface CustomContext {
-  [key: string]: CustomContextValue;
-}
+import type {
+  CustomContext,
+  CustomContextValue,
+} from '@rudderstack/analytics-js-common/types/CustomContext';
 
 type UnknownContext = Record<string, unknown>;
 

--- a/packages/analytics-js/src/components/customContext/types.ts
+++ b/packages/analytics-js/src/components/customContext/types.ts
@@ -1,10 +1,9 @@
-import type {
-  CustomContext,
-  CustomContextValue,
-} from '@rudderstack/analytics-js-common/types/CustomContext';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
+
+export type { CustomContextValue } from '@rudderstack/analytics-js-common/types/CustomContext';
 
 type UnknownContext = Record<string, unknown>;
 
 type CustomContextSnapshot = CustomContext;
 
-export type { CustomContext, CustomContextSnapshot, CustomContextValue, UnknownContext };
+export type { CustomContext, CustomContextSnapshot, UnknownContext };

--- a/packages/analytics-js/src/services/ErrorHandler/constants.ts
+++ b/packages/analytics-js/src/services/ErrorHandler/constants.ts
@@ -16,6 +16,7 @@ const APP_STATE_EXCLUDE_KEYS = [
   'config',
   'integration', // integration instance objects
   'eventBuffer', // pre-load event buffer (may contain PII)
+  'customContext', // customer-provided event context
   'traits',
   'authToken',
 ];

--- a/packages/analytics-js/src/state/index.ts
+++ b/packages/analytics-js/src/state/index.ts
@@ -9,6 +9,7 @@ import { lifecycleState } from './slices/lifecycle';
 import { consentsState } from './slices/consents';
 import { metricsState } from './slices/metrics';
 import { contextState } from './slices/context';
+import { customContextState } from './slices/customContext';
 import { nativeDestinationsState } from './slices/nativeDestinations';
 import { eventBufferState } from './slices/eventBuffer';
 import { pluginsState } from './slices/plugins';
@@ -21,6 +22,7 @@ const defaultStateValues: ApplicationState = {
   capabilities: capabilitiesState,
   consents: consentsState,
   context: contextState,
+  customContext: customContextState,
   eventBuffer: eventBufferState,
   lifecycle: lifecycleState,
   loadOptions: loadOptionsState,
@@ -44,6 +46,7 @@ const resetState = () => {
   state.capabilities = clone(defaultStateValues.capabilities);
   state.consents = clone(defaultStateValues.consents);
   state.context = clone(defaultStateValues.context);
+  state.customContext = clone(defaultStateValues.customContext);
   state.eventBuffer = clone(defaultStateValues.eventBuffer);
   state.lifecycle = clone(defaultStateValues.lifecycle);
   state.loadOptions = clone(defaultStateValues.loadOptions);

--- a/packages/analytics-js/src/state/slices/customContext.ts
+++ b/packages/analytics-js/src/state/slices/customContext.ts
@@ -1,0 +1,7 @@
+import { signal } from '@preact/signals-core';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
+import type { CustomContextState } from '@rudderstack/analytics-js-common/types/ApplicationState';
+
+const customContextState: CustomContextState = signal<CustomContext>({});
+
+export { customContextState };


### PR DESCRIPTION
## Summary

- add custom-context storage to shared application state behind the dedicated `CustomContextStore` component
- apply prepared updates atomically using deletion paths and the existing `mergeDeepRight` behavior
- return defensive snapshots, including cloned `Date` values
- exclude customer-provided custom context from error-handler application-state metadata
- keep the component boundary ready for a future move to per-instance state when the SDK fully supports multiple instances

## Validation

- 167 focused state, store, core, and error-handler tests passed
- affected pre-commit tests passed, including 1,239 analytics-js tests
- analytics-js and analytics-js-common lint passed with zero errors
- legacy development bundle, Prettier, and `git diff --check` passed
- the unrelated loading-scripts size build remains locally blocked because its TypeScript build cannot resolve the workspace `@rudderstack/analytics-js` package

Linear: [SDK-5054](https://linear.app/rudderstack/issue/SDK-5054/implement-in-memory-custom-context-store-and-runtime-apis)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom context support for storing application-specific data.
  * Added APIs to set, retrieve, and clear custom context.
  * Supports nested objects, arrays, dates, merging updates, and removing values.
  * Custom context is shared across analytics instances and resets when application state is reset.
* **Privacy**
  * Custom context is excluded from error metadata and application-state metadata.
* **Bug Fixes**
  * Invalid custom context updates are ignored and logged safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->