### PR TITLE
feat: sdk-5055 seed load-time custom context

### DIFF
--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -179,6 +179,16 @@ describe('Core - Rudder Analytics Facade', () => {
     loadSpy.mockRestore();
   });
 
+  it('loads a new analytics instance without optional load options', () => {
+    rudderAnalytics.analyticsInstances = {};
+    rudderAnalytics.defaultAnalyticsKey = '';
+
+    rudderAnalytics.load('writeKey', 'data-plane-url');
+    const analyticsInstance = rudderAnalytics.getAnalyticsInstance('writeKey') as Analytics;
+
+    expect(analyticsInstance.load).toHaveBeenCalledWith('writeKey', 'data-plane-url', undefined);
+  });
+
   it('extracts raw custom context without mutating the caller load options', () => {
     const capturedAt = new Date('2026-07-21T00:00:00.000Z');
     const loadOptions = {

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -189,7 +189,7 @@ describe('Core - Rudder Analytics Facade', () => {
     expect(analyticsInstance.load).toHaveBeenCalledWith('writeKey', 'data-plane-url', undefined);
   });
 
-  it('extracts raw custom context without mutating the caller load options', () => {
+  it('passes custom context through load options to the analytics instance', () => {
     const capturedAt = new Date('2026-07-21T00:00:00.000Z');
     const loadOptions = {
       ...mockLoadOptions,
@@ -198,27 +198,12 @@ describe('Core - Rudder Analytics Facade', () => {
         account: { plan: undefined },
       },
     };
-    const originalContext = loadOptions.context;
-
     rudderAnalytics.analyticsInstances = {};
     rudderAnalytics.defaultAnalyticsKey = '';
     rudderAnalytics.load('writeKey', 'data-plane-url', loadOptions);
     const analyticsInstance = rudderAnalytics.getAnalyticsInstance('writeKey') as Analytics;
 
-    expect(analyticsInstance.load).toHaveBeenCalledWith(
-      'writeKey',
-      'data-plane-url',
-      mockLoadOptions,
-      originalContext,
-    );
-    expect(loadOptions).toEqual({
-      ...mockLoadOptions,
-      context: {
-        capturedAt,
-        account: { plan: undefined },
-      },
-    });
-    expect(loadOptions.context).toBe(originalContext);
+    expect(analyticsInstance.load).toHaveBeenCalledWith('writeKey', 'data-plane-url', loadOptions);
   });
 
   it('should dispatch an error event if an exception is thrown during the load', () => {

--- a/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
+++ b/packages/analytics-js/__tests__/app/RudderAnalytics.test.ts
@@ -179,6 +179,38 @@ describe('Core - Rudder Analytics Facade', () => {
     loadSpy.mockRestore();
   });
 
+  it('extracts raw custom context without mutating the caller load options', () => {
+    const capturedAt = new Date('2026-07-21T00:00:00.000Z');
+    const loadOptions = {
+      ...mockLoadOptions,
+      context: {
+        capturedAt,
+        account: { plan: undefined },
+      },
+    };
+    const originalContext = loadOptions.context;
+
+    rudderAnalytics.analyticsInstances = {};
+    rudderAnalytics.defaultAnalyticsKey = '';
+    rudderAnalytics.load('writeKey', 'data-plane-url', loadOptions);
+    const analyticsInstance = rudderAnalytics.getAnalyticsInstance('writeKey') as Analytics;
+
+    expect(analyticsInstance.load).toHaveBeenCalledWith(
+      'writeKey',
+      'data-plane-url',
+      mockLoadOptions,
+      originalContext,
+    );
+    expect(loadOptions).toEqual({
+      ...mockLoadOptions,
+      context: {
+        capturedAt,
+        account: { plan: undefined },
+      },
+    });
+    expect(loadOptions.context).toBe(originalContext);
+  });
+
   it('should dispatch an error event if an exception is thrown during the load', () => {
     const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
 

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -280,17 +280,17 @@ describe('Core - Analytics', () => {
     it('seeds valid custom context before starting the lifecycle', () => {
       const startLifecycleSpy = jest.spyOn(analytics, 'startLifecycle').mockImplementation();
       const capturedAt = new Date('2026-07-21T00:00:00.000Z');
+      const context = {
+        region: 'EU',
+        account: { plan: undefined, seats: 5 },
+        capturedAt,
+      };
+      const loadOptions = {
+        logLevel: 'ERROR' as const,
+        context,
+      };
 
-      analytics.load(
-        dummyWriteKey,
-        sampleDataPlaneUrl,
-        { logLevel: 'ERROR' },
-        {
-          region: 'EU',
-          account: { plan: undefined, seats: 5 },
-          capturedAt,
-        },
-      );
+      analytics.load(dummyWriteKey, sampleDataPlaneUrl, loadOptions);
       capturedAt.setUTCFullYear(2030);
 
       expect(analytics.customContextStore.get()).toEqual({
@@ -298,6 +298,8 @@ describe('Core - Analytics', () => {
         account: { seats: 5 },
         capturedAt: new Date('2026-07-21T00:00:00.000Z'),
       });
+      expect(loadOptions.context).toBe(context);
+      expect(state.loadOptions.value).not.toHaveProperty('context');
       expect(startLifecycleSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -305,12 +307,10 @@ describe('Core - Analytics', () => {
       jest.spyOn(analytics, 'startLifecycle').mockImplementation();
 
       analytics.setCustomContext({ account: { plan: 'pro' } });
-      analytics.load(
-        dummyWriteKey,
-        sampleDataPlaneUrl,
-        { logLevel: 'ERROR' },
-        { region: 'EU', account: { source: 'load' } },
-      );
+      analytics.load(dummyWriteKey, sampleDataPlaneUrl, {
+        logLevel: 'ERROR',
+        context: { region: 'EU', account: { source: 'load' } },
+      });
 
       expect(analytics.getCustomContext()).toEqual({
         region: 'EU',
@@ -330,12 +330,10 @@ describe('Core - Analytics', () => {
       const startLifecycleSpy = jest.spyOn(analytics, 'startLifecycle').mockImplementation();
       const loggerWarnSpy = jest.spyOn(analytics.logger, 'warn');
 
-      analytics.load(
-        dummyWriteKey,
-        sampleDataPlaneUrl,
-        { logLevel: 'ERROR' },
-        { valid: 'value', invalid: new Map([['key', 'value']]) },
-      );
+      analytics.load(dummyWriteKey, sampleDataPlaneUrl, {
+        logLevel: 'ERROR',
+        context: { valid: 'value', invalid: new Map([['key', 'value']]) } as any,
+      });
 
       expect(analytics.customContextStore.get()).toEqual({});
       expect(startLifecycleSpy).toHaveBeenCalledTimes(1);
@@ -360,7 +358,10 @@ describe('Core - Analytics', () => {
       const startLifecycleSpy = jest.spyOn(analytics, 'startLifecycle');
       const errorSpy = jest.spyOn(analytics.logger, 'error');
 
-      analytics.load('', sampleDataPlaneUrl, { logLevel: 'ERROR' }, { region: 'EU' });
+      analytics.load('', sampleDataPlaneUrl, {
+        logLevel: 'ERROR',
+        context: { region: 'EU' },
+      });
 
       expect(state.lifecycle.status.value).toBeUndefined();
       expect(analytics.customContextStore.get()).toEqual({});

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -338,7 +338,7 @@ describe('Core - Analytics', () => {
       expect(analytics.customContextStore.get()).toEqual({});
       expect(startLifecycleSpy).toHaveBeenCalledTimes(1);
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'CustomContext:: The custom context update is invalid. Use a plain object containing only supported context values.',
+        'CustomContext:: Invalid custom context. Use a plain object without prototype pollution keys.',
       );
     });
 

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -301,6 +301,31 @@ describe('Core - Analytics', () => {
       expect(startLifecycleSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('seeds load-time context before replaying buffered context updates', () => {
+      jest.spyOn(analytics, 'startLifecycle').mockImplementation();
+
+      analytics.setCustomContext({ account: { plan: 'pro' } });
+      analytics.load(
+        dummyWriteKey,
+        sampleDataPlaneUrl,
+        { logLevel: 'ERROR' },
+        { region: 'EU', account: { source: 'load' } },
+      );
+
+      expect(analytics.getCustomContext()).toEqual({
+        region: 'EU',
+        account: { source: 'load' },
+      });
+
+      state.lifecycle.loaded.value = true;
+      analytics.processBufferedEvents();
+
+      expect(analytics.getCustomContext()).toEqual({
+        region: 'EU',
+        account: { source: 'load', plan: 'pro' },
+      });
+    });
+
     it('continues loading with an empty store when initial custom context is invalid', () => {
       const startLifecycleSpy = jest.spyOn(analytics, 'startLifecycle').mockImplementation();
       const loggerWarnSpy = jest.spyOn(analytics.logger, 'warn');

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -332,7 +332,7 @@ describe('Core - Analytics', () => {
 
       analytics.load(dummyWriteKey, sampleDataPlaneUrl, {
         logLevel: 'ERROR',
-        context: { valid: 'value', invalid: new Map([['key', 'value']]) } as any,
+        context: new Map([['key', 'value']]) as any,
       });
 
       expect(analytics.customContextStore.get()).toEqual({});

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -277,6 +277,48 @@ describe('Core - Analytics', () => {
       expect(setExposedGlobal).toHaveBeenCalledWith('state', state, dummyWriteKey);
     });
 
+    it('seeds valid custom context before starting the lifecycle', () => {
+      const startLifecycleSpy = jest.spyOn(analytics, 'startLifecycle').mockImplementation();
+      const capturedAt = new Date('2026-07-21T00:00:00.000Z');
+
+      analytics.load(
+        dummyWriteKey,
+        sampleDataPlaneUrl,
+        { logLevel: 'ERROR' },
+        {
+          region: 'EU',
+          account: { plan: undefined, seats: 5 },
+          capturedAt,
+        },
+      );
+      capturedAt.setUTCFullYear(2030);
+
+      expect(analytics.customContextStore.get()).toEqual({
+        region: 'EU',
+        account: { seats: 5 },
+        capturedAt: new Date('2026-07-21T00:00:00.000Z'),
+      });
+      expect(startLifecycleSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues loading with an empty store when initial custom context is invalid', () => {
+      const startLifecycleSpy = jest.spyOn(analytics, 'startLifecycle').mockImplementation();
+      const loggerWarnSpy = jest.spyOn(analytics.logger, 'warn');
+
+      analytics.load(
+        dummyWriteKey,
+        sampleDataPlaneUrl,
+        { logLevel: 'ERROR' },
+        { valid: 'value', invalid: new Map([['key', 'value']]) },
+      );
+
+      expect(analytics.customContextStore.get()).toEqual({});
+      expect(startLifecycleSpy).toHaveBeenCalledTimes(1);
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        'CustomContext:: The custom context update is invalid. Use a plain object containing only supported context values.',
+      );
+    });
+
     it('should set the log level if it is not configured', () => {
       state.loadOptions.value.logLevel = undefined;
       const setMinLogLevelSpy = jest.spyOn(analytics.logger, 'setMinLogLevel');
@@ -293,9 +335,10 @@ describe('Core - Analytics', () => {
       const startLifecycleSpy = jest.spyOn(analytics, 'startLifecycle');
       const errorSpy = jest.spyOn(analytics.logger, 'error');
 
-      analytics.load('', sampleDataPlaneUrl, { logLevel: 'ERROR' });
+      analytics.load('', sampleDataPlaneUrl, { logLevel: 'ERROR' }, { region: 'EU' });
 
       expect(state.lifecycle.status.value).toBeUndefined();
+      expect(analytics.customContextStore.get()).toEqual({});
       expect(startLifecycleSpy).not.toHaveBeenCalled();
 
       expect(errorSpy).toHaveBeenCalledTimes(1);

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -225,23 +225,7 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
 
       setExposedGlobal(GLOBAL_PRELOAD_BUFFER, clone(preloadedEventsArray));
 
-      const loadOptionsCopy = loadOptions ? { ...loadOptions } : undefined;
-      const hasCustomContext = Object.prototype.hasOwnProperty.call(
-        loadOptionsCopy ?? {},
-        'context',
-      );
-      const customContext = loadOptionsCopy?.context;
-      if (loadOptionsCopy) {
-        delete loadOptionsCopy.context;
-      }
-
-      const analyticsInstance = this.getAnalyticsInstance(writeKey);
-      const sanitizedLoadOptions = getSanitizedValue(loadOptionsCopy);
-      if (hasCustomContext) {
-        analyticsInstance?.load(writeKey, dataPlaneUrl, sanitizedLoadOptions, customContext);
-      } else {
-        analyticsInstance?.load(writeKey, dataPlaneUrl, sanitizedLoadOptions);
-      }
+      this.getAnalyticsInstance(writeKey)?.load(writeKey, dataPlaneUrl, loadOptions);
     } catch (error: any) {
       dispatchErrorEvent(error);
     }

--- a/packages/analytics-js/src/app/RudderAnalytics.ts
+++ b/packages/analytics-js/src/app/RudderAnalytics.ts
@@ -225,11 +225,23 @@ class RudderAnalytics implements IRudderAnalytics<IAnalytics> {
 
       setExposedGlobal(GLOBAL_PRELOAD_BUFFER, clone(preloadedEventsArray));
 
-      this.getAnalyticsInstance(writeKey)?.load(
-        writeKey,
-        dataPlaneUrl,
-        getSanitizedValue(loadOptions),
+      const loadOptionsCopy = loadOptions ? { ...loadOptions } : undefined;
+      const hasCustomContext = Object.prototype.hasOwnProperty.call(
+        loadOptionsCopy ?? {},
+        'context',
       );
+      const customContext = loadOptionsCopy?.context;
+      if (loadOptionsCopy) {
+        delete loadOptionsCopy.context;
+      }
+
+      const analyticsInstance = this.getAnalyticsInstance(writeKey);
+      const sanitizedLoadOptions = getSanitizedValue(loadOptionsCopy);
+      if (hasCustomContext) {
+        analyticsInstance?.load(writeKey, dataPlaneUrl, sanitizedLoadOptions, customContext);
+      } else {
+        analyticsInstance?.load(writeKey, dataPlaneUrl, sanitizedLoadOptions);
+      }
     } catch (error: any) {
       dispatchErrorEvent(error);
     }

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -118,7 +118,12 @@ class Analytics implements IAnalytics {
   /**
    * Start application lifecycle if not already started
    */
-  load(writeKey: string, dataPlaneUrl: string, loadOptions: Partial<LoadOptions> = {}) {
+  load(
+    writeKey: string,
+    dataPlaneUrl: string,
+    loadOptions: Partial<LoadOptions> = {},
+    customContext?: unknown,
+  ) {
     if (state.lifecycle.status.value) {
       return;
     }
@@ -131,6 +136,10 @@ class Analytics implements IAnalytics {
     if (!isDataPlaneUrlValid(dataPlaneUrl)) {
       this.logger.error(DATA_PLANE_URL_VALIDATION_ERROR(ANALYTICS_CORE, dataPlaneUrl));
       return;
+    }
+
+    if (customContext !== undefined) {
+      this.customContextStore.set(customContext);
     }
 
     // Set initial state values

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -2,6 +2,7 @@
 import { ExternalSrcLoader } from '@rudderstack/analytics-js-common/services/ExternalSrcLoader';
 import { batch, effect } from '@preact/signals-core';
 import { isFunction, isNull } from '@rudderstack/analytics-js-common/utilities/checks';
+import { getSanitizedValue } from '@rudderstack/analytics-js-common/utilities/json';
 import type { IHttpClient } from '@rudderstack/analytics-js-common/types/HttpClient';
 import { clone } from 'ramda';
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
@@ -118,12 +119,7 @@ class Analytics implements IAnalytics {
   /**
    * Start application lifecycle if not already started
    */
-  load(
-    writeKey: string,
-    dataPlaneUrl: string,
-    loadOptions: Partial<LoadOptions> = {},
-    customContext?: unknown,
-  ) {
+  load(writeKey: string, dataPlaneUrl: string, loadOptions: Partial<LoadOptions> = {}) {
     if (state.lifecycle.status.value) {
       return;
     }
@@ -138,6 +134,11 @@ class Analytics implements IAnalytics {
       return;
     }
 
+    const loadOptionsCopy = { ...loadOptions };
+    const customContext = loadOptionsCopy.context;
+    delete loadOptionsCopy.context;
+    const sanitizedLoadOptions = getSanitizedValue(loadOptionsCopy);
+
     if (customContext !== undefined) {
       this.customContextStore.set(customContext);
     }
@@ -146,7 +147,7 @@ class Analytics implements IAnalytics {
     batch(() => {
       state.lifecycle.writeKey.value = clone(writeKey);
       state.lifecycle.dataPlaneUrl.value = clone(dataPlaneUrl);
-      state.loadOptions.value = normalizeLoadOptions(state.loadOptions.value, loadOptions);
+      state.loadOptions.value = normalizeLoadOptions(state.loadOptions.value, sanitizedLoadOptions);
       state.lifecycle.status.value = 'mounted';
     });
 

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -134,10 +134,8 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const loadOptionsCopy = { ...loadOptions };
-    const customContext = loadOptionsCopy.context;
-    delete loadOptionsCopy.context;
-    const sanitizedLoadOptions = getSanitizedValue(loadOptionsCopy);
+    const { context: customContext, ...loadOptionsWithoutContext } = loadOptions;
+    const sanitizedLoadOptions = getSanitizedValue(loadOptionsWithoutContext);
 
     if (customContext !== undefined) {
       this.customContextStore.set(customContext);

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -56,6 +56,7 @@ export interface IAnalytics {
     writeKey: string,
     dataPlaneUrl?: string | Partial<LoadOptions>,
     loadOptions?: Partial<LoadOptions>,
+    customContext?: unknown,
   ): void;
 
   /**

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -56,7 +56,6 @@ export interface IAnalytics {
     writeKey: string,
     dataPlaneUrl?: string | Partial<LoadOptions>,
     loadOptions?: Partial<LoadOptions>,
-    customContext?: unknown,
   ): void;
 
   /**


### PR DESCRIPTION
## Summary

- extract `LoadOptions.context` without mutating caller-owned load options
- preserve raw context values until custom-context validation runs
- seed accepted context before the SDK lifecycle begins
- continue loading with an empty store when initial context is invalid
- rebase load seeding onto the shared application-state ownership model approved in the architecture review

## Validation

- 303 focused load, lifecycle, state, privacy, and integration tests passed on the rebased stack
- analytics-js and analytics-js-common lint passed with zero errors
- Prettier and `git diff --check` passed

Linear: [SDK-5055](https://linear.app/rudderstack/issue/SDK-5055/add-load-time-custom-context-support-to-js-sdk-load-options)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom context data provided during analytics loading.
  * Invalid context values are safely ignored, while valid data is sanitized and preserved.
  * Custom context is now correctly available throughout initialization and buffered event replay.
  * Load options are forwarded consistently without altering the original options object.

* **Tests**
  * Added coverage for load options, custom context handling, sanitization, lifecycle ordering, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->