### PR TITLE
feat: sdk-5056 enrich events with custom context

### DIFF
--- a/packages/analytics-js-common/src/types/Event.ts
+++ b/packages/analytics-js-common/src/types/Event.ts
@@ -1,12 +1,34 @@
-import type { RudderEventType, Traits } from './EventApi';
+import type { ApiCallback, ResetOptions, RudderEventType, Traits } from './EventApi';
 import type { Nullable } from './Nullable';
-import type { ConsentManagement } from './Consent';
+import type { ConsentManagement, ConsentOptions } from './Consent';
 import type { AppInfo, LibraryInfo, OSInfo, ScreenInfo, UTMParameters } from './EventContext';
 import type { IntegrationOpts } from './Integration';
 import type { ApiObject } from './ApiObject';
+import type { CustomContext, InputCustomContext } from './CustomContext';
+import type { RSACustomIntegration } from './IRudderAnalytics';
+import type {
+  AliasCallOptions,
+  GroupCallOptions,
+  IdentifyCallOptions,
+  PageCallOptions,
+  TrackCallOptions,
+} from '../utilities/eventMethodOverloads';
 
-// TODO: fix type
-export type BufferedEvent = any[];
+export type BufferedEvent =
+  | ['setCustomContext', InputCustomContext]
+  | ['clearCustomContext']
+  | ['ready', ApiCallback]
+  | ['page', PageCallOptions, CustomContext?]
+  | ['track', TrackCallOptions, CustomContext?]
+  | ['identify', IdentifyCallOptions, CustomContext?]
+  | ['alias', AliasCallOptions, CustomContext?]
+  | ['group', GroupCallOptions, CustomContext?]
+  | ['reset', ResetOptions | boolean | undefined]
+  | ['setAnonymousId', string | undefined, string | undefined]
+  | ['startSession', number | undefined]
+  | ['endSession']
+  | ['consent', ConsentOptions | undefined]
+  | ['addCustomIntegration', string, RSACustomIntegration];
 
 export type PageLifecycle = {
   pageViewId: string; // UUID

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -739,9 +739,7 @@ describe('Core - Analytics', () => {
   describe('page', () => {
     it('should buffer events until loaded', () => {
       analytics.page({ name: 'name' });
-      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['page', { name: 'name' }, {}],
-      ]);
+      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([['page', { name: 'name' }]]);
     });
     it('should sent events if loaded', () => {
       analytics.prepareInternalServices();
@@ -766,7 +764,7 @@ describe('Core - Analytics', () => {
     it('should buffer events until loaded', () => {
       analytics.track({ name: 'name' });
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['track', { name: 'name' }, {}],
+        ['track', { name: 'name' }],
       ]);
     });
     it('should sent events if loaded', () => {
@@ -787,25 +785,31 @@ describe('Core - Analytics', () => {
       );
     });
 
-    it('replays a buffered event with its invocation-time context snapshot', () => {
+    it('captures context when a buffered event reaches its ordered replay position', () => {
       analytics.prepareInternalServices();
       const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
-      analytics.customContextStore.set({ version: 'before' });
 
-      analytics.track({ name: 'buffered-event' });
-      analytics.customContextStore.set({ version: 'after' });
+      analytics.track({ name: 'before-update' });
+      analytics.setCustomContext({ version: 'updated' });
+      analytics.track({ name: 'after-update' });
+      analytics.clearCustomContext();
+      analytics.track({ name: 'after-clear' });
 
+      analytics.customContextStore.set({ version: 'load-time' });
       state.lifecycle.loaded.value = true;
       analytics.processBufferedEvents();
 
-      expect(addEventSpy).toHaveBeenCalledWith(
-        {
-          type: 'track',
-          name: 'buffered-event',
-        },
-        { version: 'before' },
+      expect(addEventSpy).toHaveBeenNthCalledWith(
+        1,
+        { type: 'track', name: 'before-update' },
+        { version: 'load-time' },
       );
-      expect(analytics.customContextStore.get()).toEqual({ version: 'after' });
+      expect(addEventSpy).toHaveBeenNthCalledWith(
+        2,
+        { type: 'track', name: 'after-update' },
+        { version: 'updated' },
+      );
+      expect(addEventSpy).toHaveBeenNthCalledWith(3, { type: 'track', name: 'after-clear' }, {});
     });
   });
 
@@ -813,7 +817,7 @@ describe('Core - Analytics', () => {
     it('should buffer events until loaded', () => {
       analytics.identify({ userId: 'userId' });
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['identify', { userId: 'userId' }, {}],
+        ['identify', { userId: 'userId' }],
       ]);
     });
     it('should sent events if loaded', () => {
@@ -870,7 +874,7 @@ describe('Core - Analytics', () => {
     it('should buffer events until loaded', () => {
       analytics.alias({ to: 'to' });
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['alias', { to: 'to' }, {}],
+        ['alias', { to: 'to' }],
       ]);
     });
     it('should sent events if loaded', () => {
@@ -943,7 +947,7 @@ describe('Core - Analytics', () => {
       expect(setGroupIdIdSpy).toHaveBeenCalledTimes(0);
       expect(setGroupTraitsSpy).toHaveBeenCalledTimes(0);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['group', { groupId: 'groupId' }, {}],
+        ['group', { groupId: 'groupId' }],
       ]);
     });
     it('should sent events if loaded', () => {

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -1315,12 +1315,12 @@ describe('Core - Analytics', () => {
 
       it('should add to existing buffered events when SDK is not loaded', () => {
         const destinationId = 'custom-dest-123';
-        state.eventBuffer.toBeProcessedArray.value = [['track', 'some_event']];
+        state.eventBuffer.toBeProcessedArray.value = [['track', { name: 'some_event' }]];
 
         analytics.addCustomIntegration(destinationId, mockCustomIntegration);
 
         expect(state.eventBuffer.toBeProcessedArray.value).toEqual([
-          ['track', 'some_event'],
+          ['track', { name: 'some_event' }],
           ['addCustomIntegration', destinationId, mockCustomIntegration],
         ]);
       });

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -828,6 +828,40 @@ describe('Core - Analytics', () => {
         { version: 'captured' },
       );
     });
+
+    it('filters reserved keys from a context snapshot supplied by an internal buffering stage', () => {
+      analytics.prepareInternalServices();
+      const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
+      state.eventBuffer.toBeProcessedArray.value = [
+        [
+          'track',
+          { name: 'internally-buffered' },
+          { agentId: 'agent-1', library: { name: 'override' } },
+        ],
+      ];
+
+      state.lifecycle.loaded.value = true;
+      analytics.processBufferedEvents();
+
+      expect(addEventSpy).toHaveBeenCalledWith(
+        { type: 'track', name: 'internally-buffered' },
+        { agentId: 'agent-1' },
+      );
+    });
+
+    it('rejects an unsafe context snapshot supplied by an internal buffering stage', () => {
+      analytics.prepareInternalServices();
+      const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
+      const unsafeContext = JSON.parse('{"nested":{"__proto__":{"polluted":true}}}');
+      state.eventBuffer.toBeProcessedArray.value = [
+        ['track', { name: 'internally-buffered' }, unsafeContext],
+      ];
+
+      state.lifecycle.loaded.value = true;
+      analytics.processBufferedEvents();
+
+      expect(addEventSpy).toHaveBeenCalledWith({ type: 'track', name: 'internally-buffered' }, {});
+    });
   });
 
   describe('identify', () => {

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -811,6 +811,23 @@ describe('Core - Analytics', () => {
       );
       expect(addEventSpy).toHaveBeenNthCalledWith(3, { type: 'track', name: 'after-clear' }, {});
     });
+
+    it('retains a context snapshot supplied by a later internal buffering stage', () => {
+      analytics.prepareInternalServices();
+      const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
+      state.eventBuffer.toBeProcessedArray.value = [
+        ['track', { name: 'internally-buffered' }, { version: 'captured' }],
+      ];
+      analytics.customContextStore.set({ version: 'current' });
+
+      state.lifecycle.loaded.value = true;
+      analytics.processBufferedEvents();
+
+      expect(addEventSpy).toHaveBeenCalledWith(
+        { type: 'track', name: 'internally-buffered' },
+        { version: 'captured' },
+      );
+    });
   });
 
   describe('identify', () => {

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -740,7 +740,7 @@ describe('Core - Analytics', () => {
     it('should buffer events until loaded', () => {
       analytics.page({ name: 'name' });
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['page', { name: 'name' }],
+        ['page', { name: 'name' }, {}],
       ]);
     });
     it('should sent events if loaded', () => {
@@ -752,10 +752,13 @@ describe('Core - Analytics', () => {
       analytics.page({ name: 'name' });
       expect(leaveBreadcrumbSpy).toHaveBeenCalledTimes(1);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([]);
-      expect(addEventSpy).toHaveBeenCalledWith({
-        type: 'page',
-        name: 'name',
-      });
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'page',
+          name: 'name',
+        },
+        {},
+      );
     });
   });
 
@@ -763,7 +766,7 @@ describe('Core - Analytics', () => {
     it('should buffer events until loaded', () => {
       analytics.track({ name: 'name' });
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['track', { name: 'name' }],
+        ['track', { name: 'name' }, {}],
       ]);
     });
     it('should sent events if loaded', () => {
@@ -775,10 +778,34 @@ describe('Core - Analytics', () => {
       analytics.track({ name: 'name' });
       expect(leaveBreadcrumbSpy).toHaveBeenCalledTimes(1);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([]);
-      expect(addEventSpy).toHaveBeenCalledWith({
-        type: 'track',
-        name: 'name',
-      });
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'track',
+          name: 'name',
+        },
+        {},
+      );
+    });
+
+    it('replays a buffered event with its invocation-time context snapshot', () => {
+      analytics.prepareInternalServices();
+      const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
+      analytics.customContextStore.set({ version: 'before' });
+
+      analytics.track({ name: 'buffered-event' });
+      analytics.customContextStore.set({ version: 'after' });
+
+      state.lifecycle.loaded.value = true;
+      analytics.processBufferedEvents();
+
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'track',
+          name: 'buffered-event',
+        },
+        { version: 'before' },
+      );
+      expect(analytics.customContextStore.get()).toEqual({ version: 'after' });
     });
   });
 
@@ -786,7 +813,7 @@ describe('Core - Analytics', () => {
     it('should buffer events until loaded', () => {
       analytics.identify({ userId: 'userId' });
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['identify', { userId: 'userId' }],
+        ['identify', { userId: 'userId' }, {}],
       ]);
     });
     it('should sent events if loaded', () => {
@@ -805,10 +832,13 @@ describe('Core - Analytics', () => {
       expect(setUserIdSpy).toHaveBeenCalledTimes(1);
       expect(setUserTraitsSpy).toHaveBeenCalledTimes(1);
       expect(resetSpy).toHaveBeenCalledTimes(0);
-      expect(addEventSpy).toHaveBeenCalledWith({
-        type: 'identify',
-        userId: 'userId',
-      });
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'identify',
+          userId: 'userId',
+        },
+        {},
+      );
     });
     it('should sent events if loaded and reset session if userID changed', () => {
       analytics.prepareInternalServices();
@@ -826,17 +856,22 @@ describe('Core - Analytics', () => {
       expect(setUserIdSpy).toHaveBeenCalledTimes(1);
       expect(setUserTraitsSpy).toHaveBeenCalledTimes(1);
       expect(resetSpy).toHaveBeenCalledTimes(1);
-      expect(addEventSpy).toHaveBeenCalledWith({
-        type: 'identify',
-        userId: 'userId',
-      });
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'identify',
+          userId: 'userId',
+        },
+        {},
+      );
     });
   });
 
   describe('alias', () => {
     it('should buffer events until loaded', () => {
       analytics.alias({ to: 'to' });
-      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([['alias', { to: 'to' }]]);
+      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
+        ['alias', { to: 'to' }, {}],
+      ]);
     });
     it('should sent events if loaded', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
@@ -849,11 +884,14 @@ describe('Core - Analytics', () => {
       analytics.alias({ to: 'to', from: 'x' });
       expect(leaveBreadcrumbSpy).toHaveBeenCalledTimes(1);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([]);
-      expect(addEventSpy).toHaveBeenCalledWith({
-        type: 'alias',
-        to: 'to',
-        from: 'x',
-      });
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'alias',
+          to: 'to',
+          from: 'x',
+        },
+        {},
+      );
     });
 
     it('should use the user ID if from is not provided', () => {
@@ -865,11 +903,14 @@ describe('Core - Analytics', () => {
 
       analytics.alias({ to: 'to' });
 
-      expect(addEventSpy).toHaveBeenCalledWith({
-        type: 'alias',
-        to: 'to',
-        from: 'userId',
-      });
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'alias',
+          to: 'to',
+          from: 'userId',
+        },
+        {},
+      );
     });
 
     it('should use the anonymous ID if user ID is not set', () => {
@@ -881,11 +922,14 @@ describe('Core - Analytics', () => {
 
       analytics.alias({ to: 'to' });
 
-      expect(addEventSpy).toHaveBeenCalledWith({
-        type: 'alias',
-        to: 'to',
-        from: 'test_uuid',
-      });
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'alias',
+          to: 'to',
+          from: 'test_uuid',
+        },
+        {},
+      );
     });
   });
 
@@ -899,7 +943,7 @@ describe('Core - Analytics', () => {
       expect(setGroupIdIdSpy).toHaveBeenCalledTimes(0);
       expect(setGroupTraitsSpy).toHaveBeenCalledTimes(0);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['group', { groupId: 'groupId' }],
+        ['group', { groupId: 'groupId' }, {}],
       ]);
     });
     it('should sent events if loaded', () => {
@@ -915,10 +959,13 @@ describe('Core - Analytics', () => {
       expect(setGroupIdIdSpy).toHaveBeenCalledTimes(1);
       expect(setGroupTraitsSpy).toHaveBeenCalledTimes(1);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([]);
-      expect(addEventSpy).toHaveBeenCalledWith({
-        type: 'group',
-        groupId: 'groupId',
-      });
+      expect(addEventSpy).toHaveBeenCalledWith(
+        {
+          type: 'group',
+          groupId: 'groupId',
+        },
+        {},
+      );
     });
   });
 

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -2,6 +2,7 @@ import type { IPluginsManager } from '@rudderstack/analytics-js-common/types/Plu
 import type { IStoreManager } from '@rudderstack/analytics-js-common/types/Store';
 import { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
 import type { RSACustomIntegration } from '@rudderstack/analytics-js-common/types/IRudderAnalytics';
+import type { BufferedEvent } from '@rudderstack/analytics-js-common/types/Event';
 import { batch } from '@preact/signals-core';
 import type { IUserSessionManager } from '../../../src/components/userSessionManager/types';
 import type { IEventManager } from '../../../src/components/eventManager/types';
@@ -160,6 +161,114 @@ describe('Core - Analytics', () => {
         clearSpy.mock.invocationCallOrder[0]!,
       );
       expect(analytics.getCustomContext()).toEqual({});
+    });
+  });
+
+  describe('processBufferedEvent', () => {
+    it('dispatches every supported buffered event with the correct arguments', () => {
+      const callback = jest.fn();
+      const preservedContext = { region: 'EU' };
+      const customIntegration: RSACustomIntegration = {
+        init: jest.fn(),
+        isReady: jest.fn(() => true),
+        track: jest.fn(),
+        page: jest.fn(),
+        identify: jest.fn(),
+        group: jest.fn(),
+        alias: jest.fn(),
+      };
+      const spies = {
+        setCustomContext: jest.spyOn(analytics, 'setCustomContext').mockImplementation(),
+        clearCustomContext: jest.spyOn(analytics, 'clearCustomContext').mockImplementation(),
+        ready: jest.spyOn(analytics, 'ready').mockImplementation(),
+        page: jest.spyOn(analytics, 'page').mockImplementation(),
+        track: jest.spyOn(analytics, 'track').mockImplementation(),
+        identify: jest.spyOn(analytics, 'identify').mockImplementation(),
+        alias: jest.spyOn(analytics, 'alias').mockImplementation(),
+        group: jest.spyOn(analytics, 'group').mockImplementation(),
+        reset: jest.spyOn(analytics, 'reset').mockImplementation(),
+        setAnonymousId: jest.spyOn(analytics, 'setAnonymousId').mockImplementation(),
+        startSession: jest.spyOn(analytics, 'startSession').mockImplementation(),
+        endSession: jest.spyOn(analytics, 'endSession').mockImplementation(),
+        consent: jest.spyOn(analytics, 'consent').mockImplementation(),
+        addCustomIntegration: jest.spyOn(analytics, 'addCustomIntegration').mockImplementation(),
+      };
+      const cases: Array<{
+        event: BufferedEvent;
+        spy: jest.SpyInstance;
+        expectedArguments: unknown[];
+      }> = [
+        {
+          event: ['setCustomContext', { agentId: 'agent-1' }],
+          spy: spies.setCustomContext,
+          expectedArguments: [{ agentId: 'agent-1' }],
+        },
+        { event: ['clearCustomContext'], spy: spies.clearCustomContext, expectedArguments: [] },
+        { event: ['ready', callback], spy: spies.ready, expectedArguments: [callback, true] },
+        {
+          event: ['page', { name: 'Docs' }, preservedContext],
+          spy: spies.page,
+          expectedArguments: [{ name: 'Docs' }, true, preservedContext],
+        },
+        {
+          event: ['track', { name: 'Viewed Docs' }, preservedContext],
+          spy: spies.track,
+          expectedArguments: [{ name: 'Viewed Docs' }, true, preservedContext],
+        },
+        {
+          event: ['identify', { userId: 'user-1' }, preservedContext],
+          spy: spies.identify,
+          expectedArguments: [{ userId: 'user-1' }, true, preservedContext],
+        },
+        {
+          event: ['alias', { to: 'user-1' }, preservedContext],
+          spy: spies.alias,
+          expectedArguments: [{ to: 'user-1' }, true, preservedContext],
+        },
+        {
+          event: ['group', { groupId: 'group-1' }, preservedContext],
+          spy: spies.group,
+          expectedArguments: [{ groupId: 'group-1' }, true, preservedContext],
+        },
+        { event: ['reset', true], spy: spies.reset, expectedArguments: [true, true] },
+        {
+          event: ['setAnonymousId', 'anonymous-1', 'linker-1'],
+          spy: spies.setAnonymousId,
+          expectedArguments: ['anonymous-1', 'linker-1', true],
+        },
+        {
+          event: ['startSession', 123],
+          spy: spies.startSession,
+          expectedArguments: [123, true],
+        },
+        { event: ['endSession'], spy: spies.endSession, expectedArguments: [true] },
+        {
+          event: ['consent', { sendPageEvent: true }],
+          spy: spies.consent,
+          expectedArguments: [{ sendPageEvent: true }, true],
+        },
+        {
+          event: ['addCustomIntegration', 'destination-1', customIntegration],
+          spy: spies.addCustomIntegration,
+          expectedArguments: ['destination-1', customIntegration, true],
+        },
+      ];
+
+      cases.forEach(({ event, spy, expectedArguments }) => {
+        analytics.processBufferedEvent(event);
+
+        expect(spy).toHaveBeenCalledWith(...expectedArguments);
+      });
+
+      Object.values(spies).forEach(spy => {
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('ignores an unsupported buffered event', () => {
+      const unsupportedEvent = ['unsupported'] as unknown as BufferedEvent;
+
+      expect(analytics.processBufferedEvent(unsupportedEvent)).toBe(unsupportedEvent);
     });
   });
 

--- a/packages/analytics-js/__tests__/components/eventManager/EventManager.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/EventManager.test.ts
@@ -9,6 +9,8 @@ import { StoreManager } from '../../../src/services/StoreManager/StoreManager';
 import { PluginsManager } from '../../../src/components/pluginsManager/PluginsManager';
 import { defaultLogger } from '../../../src/services/Logger';
 import { defaultHttpClient } from '../../../src/services/HttpClient';
+import type { APIEvent } from '@rudderstack/analytics-js-common/types/EventApi';
+import type { RudderEvent } from '@rudderstack/analytics-js-common/types/Event';
 
 describe('EventManager', () => {
   class MockErrorHandler implements IErrorHandler {
@@ -61,5 +63,20 @@ describe('EventManager', () => {
 
       eventRepositoryResumeSpy.mockRestore();
     });
+  });
+
+  it('forwards the invocation-time context snapshot to event construction', () => {
+    const apiEvent = { type: 'track', name: 'Test event' } as APIEvent;
+    const customContext = { region: 'EU' };
+    const rudderEvent = { type: 'track' } as RudderEvent;
+    const refreshSessionSpy = jest.spyOn(userSessionManager, 'refreshSession').mockImplementation();
+    const createSpy = jest.spyOn(eventManager.eventFactory, 'create').mockReturnValue(rudderEvent);
+    const enqueueSpy = jest.spyOn(eventRepository, 'enqueue').mockImplementation();
+
+    eventManager.addEvent(apiEvent, customContext);
+
+    expect(refreshSessionSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledWith(apiEvent, customContext);
+    expect(enqueueSpy).toHaveBeenCalledWith(rudderEvent, undefined);
   });
 });

--- a/packages/analytics-js/__tests__/components/eventManager/RudderEventFactory.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/RudderEventFactory.test.ts
@@ -246,6 +246,30 @@ describe('RudderEventFactory', () => {
     });
   });
 
+  it.each([
+    ['page', { type: 'page', name: 'Custom context page' }],
+    ['track', { type: 'track', name: 'Custom context track' }],
+    ['identify', { type: 'identify', userId: 'custom-context-user' }],
+    ['group', { type: 'group', groupId: 'custom-context-group' }],
+    ['alias', { type: 'alias', to: 'custom-context-alias' }],
+  ] as Array<[string, APIEvent]>)('applies custom context to %s events', (_, apiEvent) => {
+    const event = rudderEventFactory.create(apiEvent, { surface: apiEvent.type });
+
+    expect(event.context).toMatchObject({ surface: apiEvent.type });
+  });
+
+  it('defaults custom context for direct event generators', () => {
+    const events = [
+      rudderEventFactory.generatePageEvent(),
+      rudderEventFactory.generateTrackEvent('Direct track'),
+      rudderEventFactory.generateIdentifyEvent(),
+      rudderEventFactory.generateGroupEvent(),
+      rudderEventFactory.generateAliasEvent('direct-alias'),
+    ];
+
+    events.forEach(event => expect(event.context).toBeDefined());
+  });
+
   it('should generate a track event if track event data is provided even without event name', () => {
     const apiEvent = {
       type: 'track',

--- a/packages/analytics-js/__tests__/components/eventManager/RudderEventFactory.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/RudderEventFactory.test.ts
@@ -214,6 +214,38 @@ describe('RudderEventFactory', () => {
     });
   });
 
+  it('merges custom context after SDK context and before per-event options', () => {
+    const capturedAt = new Date('2026-07-21T00:00:00.000Z');
+    const customContext = {
+      region: 'global',
+      nested: { global: true },
+      capturedAt,
+    };
+    const apiEvent = {
+      type: 'track',
+      name: 'Context precedence',
+      options: {
+        context: {
+          region: 'event',
+          nested: { event: true },
+        },
+      },
+    } as APIEvent;
+
+    const trackEvent = rudderEventFactory.create(apiEvent, customContext);
+
+    expect(trackEvent.context).toMatchObject({
+      region: 'event',
+      nested: { global: true, event: true },
+      capturedAt: new Date('2026-07-21T00:00:00.000Z'),
+    });
+    expect(customContext).toEqual({
+      region: 'global',
+      nested: { global: true },
+      capturedAt,
+    });
+  });
+
   it('should generate a track event if track event data is provided even without event name', () => {
     const apiEvent = {
       type: 'track',

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -617,7 +617,7 @@ describe('Event Manager - Utilities', () => {
         },
       };
 
-      const mergedContext = getMergedContext(defaultContext, apiOptions);
+      const mergedContext = getMergedContext(defaultContext, apiOptions, mockLogger);
 
       expect(mergedContext).toEqual({
         library: {
@@ -667,7 +667,7 @@ describe('Event Manager - Utilities', () => {
         },
       };
 
-      const mergedContext = getMergedContext(defaultContext, apiOptions);
+      const mergedContext = getMergedContext(defaultContext, apiOptions, mockLogger);
 
       expect(mergedContext).toEqual({
         library: {

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -759,23 +759,23 @@ describe('Event Manager - Utilities', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(5);
       expect(mockLogger.warn).toHaveBeenNthCalledWith(
         1,
-        'CustomContext:: The "library" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+        'CustomContext:: The top-level custom context property "library" is reserved and was ignored.',
       );
       expect(mockLogger.warn).toHaveBeenNthCalledWith(
         2,
-        'CustomContext:: The "consentManagement" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+        'CustomContext:: The top-level custom context property "consentManagement" is reserved and was ignored.',
       );
       expect(mockLogger.warn).toHaveBeenNthCalledWith(
         3,
-        'CustomContext:: The "userAgent" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+        'CustomContext:: The top-level custom context property "userAgent" is reserved and was ignored.',
       );
       expect(mockLogger.warn).toHaveBeenNthCalledWith(
         4,
-        'CustomContext:: The "screen" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+        'CustomContext:: The top-level custom context property "screen" is reserved and was ignored.',
       );
       expect(mockLogger.warn).toHaveBeenNthCalledWith(
         5,
-        'CustomContext:: The "ua-ch" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+        'CustomContext:: The top-level custom context property "ua-ch" is reserved and was ignored.',
       );
     });
 

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -699,7 +699,7 @@ describe('Event Manager - Utilities', () => {
       });
     });
 
-    it('should skip merging into context if options contain either top-level or context reserved elements', () => {
+    it('should warn and skip reserved context elements from both supported options shapes', () => {
       // Set specific contextual data in options to override
       // Include top-level elements and reserved elements in options and options context object
       // which should be skipped
@@ -707,6 +707,9 @@ describe('Event Manager - Utilities', () => {
         newContextKey1: 'newContextValue1',
         anonymousId: 'test_anon_id',
         originalTimestamp: '2020-01-01T00:00:00.000Z',
+        library: {
+          name: 'wrapper-free override',
+        },
         context: {
           campaign: {
             name: 'test1',
@@ -721,15 +724,11 @@ describe('Event Manager - Utilities', () => {
             width: 100,
             height: 200,
           },
-          library: {
-            name: 'test1',
-            isNew: true,
-          },
           'ua-ch': {},
         },
       };
 
-      const mergedContext = getMergedContext(defaultContext, apiOptions);
+      const mergedContext = getMergedContext(defaultContext, apiOptions, mockLogger);
 
       expect(mergedContext).toEqual({
         library: {
@@ -757,6 +756,27 @@ describe('Event Manager - Utilities', () => {
         },
         userAgent: 'defaultUA',
       });
+      expect(mockLogger.warn).toHaveBeenCalledTimes(5);
+      expect(mockLogger.warn).toHaveBeenNthCalledWith(
+        1,
+        'CustomContext:: The "library" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+      );
+      expect(mockLogger.warn).toHaveBeenNthCalledWith(
+        2,
+        'CustomContext:: The "consentManagement" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+      );
+      expect(mockLogger.warn).toHaveBeenNthCalledWith(
+        3,
+        'CustomContext:: The "userAgent" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+      );
+      expect(mockLogger.warn).toHaveBeenNthCalledWith(
+        4,
+        'CustomContext:: The "screen" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+      );
+      expect(mockLogger.warn).toHaveBeenNthCalledWith(
+        5,
+        'CustomContext:: The "ua-ch" property defined under "custom context" is a reserved keyword. Please choose a different property name to avoid conflicts with reserved keywords (library,consentManagement,userAgent,ua-ch,screen).',
+      );
     });
 
     it('should log warning if the context inside the options is not a valid object', () => {

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -790,10 +790,13 @@ describe('Event Manager - Utilities', () => {
         } as ApiOptions,
       ],
     ])('should warn and skip prototype-pollution input from %s', (_, apiOptions) => {
+      const expectedContext = JSON.parse(JSON.stringify(defaultContext)) as RudderContext;
+      const expectedPrototype = Object.getPrototypeOf(defaultContext);
       const mergedContext = getMergedContext(defaultContext, apiOptions, mockLogger);
 
-      expect(mergedContext).toEqual(defaultContext);
-      expect(Object.getPrototypeOf(mergedContext)).toBe(Object.getPrototypeOf(defaultContext));
+      expect(mergedContext).toEqual(expectedContext);
+      expect(Object.getPrototypeOf(mergedContext)).toBe(expectedPrototype);
+      expect(Object.prototype).not.toHaveProperty('polluted');
       expect(mockLogger.warn).toHaveBeenCalledWith(INVALID_CUSTOM_CONTEXT_WARNING(EVENT_MANAGER));
     });
 

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -11,6 +11,7 @@ import type {
 } from '@rudderstack/analytics-js-common/types/EventContext';
 import type { SessionInfo } from '@rudderstack/analytics-js-common/types/Session';
 import type { RudderContext, RudderEvent } from '@rudderstack/analytics-js-common/types/Event';
+import { EVENT_MANAGER } from '@rudderstack/analytics-js-common/constants/loggerContexts';
 import { resetState, state } from '../../../src/state';
 import {
   checkForReservedElements,
@@ -27,6 +28,7 @@ import { PluginsManager } from '../../../src/components/pluginsManager';
 import { defaultErrorHandler } from '../../../src/services/ErrorHandler';
 import { defaultPluginEngine } from '../../../src/services/PluginEngine';
 import { defaultLogger } from '../../../src/services/Logger';
+import { INVALID_CUSTOM_CONTEXT_WARNING } from '../../../src/constants/logMessages';
 
 jest.mock('@rudderstack/analytics-js-common/utilities/timestamp', () => ({
   getCurrentTimeFormatted: jest.fn().mockReturnValue('2020-01-01T00:00:00.000Z'),
@@ -792,9 +794,7 @@ describe('Event Manager - Utilities', () => {
 
       expect(mergedContext).toEqual(defaultContext);
       expect(Object.getPrototypeOf(mergedContext)).toBe(Object.getPrototypeOf(defaultContext));
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'EventManager:: The custom context update is invalid. Use a plain object containing only supported context values.',
-      );
+      expect(mockLogger.warn).toHaveBeenCalledWith(INVALID_CUSTOM_CONTEXT_WARNING(EVENT_MANAGER));
     });
 
     it('should log warning if the context inside the options is not a valid object', () => {

--- a/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
+++ b/packages/analytics-js/__tests__/components/eventManager/utilities.test.ts
@@ -779,6 +779,24 @@ describe('Event Manager - Utilities', () => {
       );
     });
 
+    it.each([
+      ['a top-level wrapper-free key', JSON.parse('{"__proto__":{"polluted":true}}') as ApiOptions],
+      [
+        'a nested options.context key',
+        {
+          context: JSON.parse('{"account":{"constructor":{"polluted":true}}}'),
+        } as ApiOptions,
+      ],
+    ])('should warn and skip prototype-pollution input from %s', (_, apiOptions) => {
+      const mergedContext = getMergedContext(defaultContext, apiOptions, mockLogger);
+
+      expect(mergedContext).toEqual(defaultContext);
+      expect(Object.getPrototypeOf(mergedContext)).toBe(Object.getPrototypeOf(defaultContext));
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'EventManager:: The custom context update is invalid. Use a plain object containing only supported context values.',
+      );
+    });
+
     it('should log warning if the context inside the options is not a valid object', () => {
       // Set specific contextual data in options to override
       // Set the 'context' object to be a string

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -75,7 +75,6 @@ import { getConsentManagementData, getValidPostConsentOptions } from '../utiliti
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
-import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import { CustomContextStore } from '../customContext';
 
 const CUSTOM_CONTEXT_EVENT_METHODS = ['page', 'track', 'identify', 'alias', 'group'];

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -75,9 +75,8 @@ import { getConsentManagementData, getValidPostConsentOptions } from '../utiliti
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
+import type { BufferedEvent } from '@rudderstack/analytics-js-common/types/Event';
 import { CustomContextStore } from '../customContext';
-
-const CUSTOM_CONTEXT_EVENT_METHODS = ['page', 'track', 'identify', 'alias', 'group'];
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events
@@ -421,18 +420,61 @@ class Analytics implements IAnalytics {
       state.eventBuffer.toBeProcessedArray.value = bufferedEvents;
 
       if (bufferedEvent) {
-        const methodName = bufferedEvent[0];
-        if (isFunction((this as any)[methodName])) {
-          if (CUSTOM_CONTEXT_EVENT_METHODS.includes(methodName) && bufferedEvent.length > 2) {
-            (this as any)[methodName](bufferedEvent[1], true, bufferedEvent[2]);
-          } else {
-            // Send additional arg 'true' to indicate that this is a buffered invocation
-            (this as any)[methodName](...bufferedEvent.slice(1), true);
-          }
-        }
+        this.processBufferedEvent(bufferedEvent);
       }
 
       bufferedEvents = state.eventBuffer.toBeProcessedArray.value;
+    }
+  }
+
+  processBufferedEvent(bufferedEvent: BufferedEvent) {
+    switch (bufferedEvent[0]) {
+      case 'setCustomContext':
+        this.setCustomContext(bufferedEvent[1]);
+        break;
+      case 'clearCustomContext':
+        this.clearCustomContext();
+        break;
+      case 'ready':
+        this.ready(bufferedEvent[1], true);
+        break;
+      case 'page':
+        this.page(bufferedEvent[1], true, bufferedEvent[2]);
+        break;
+      case 'track':
+        this.track(bufferedEvent[1], true, bufferedEvent[2]);
+        break;
+      case 'identify':
+        this.identify(bufferedEvent[1], true, bufferedEvent[2]);
+        break;
+      case 'alias':
+        this.alias(bufferedEvent[1], true, bufferedEvent[2]);
+        break;
+      case 'group':
+        this.group(bufferedEvent[1], true, bufferedEvent[2]);
+        break;
+      case 'reset':
+        this.reset(bufferedEvent[1], true);
+        break;
+      case 'setAnonymousId':
+        this.setAnonymousId(bufferedEvent[1], bufferedEvent[2], true);
+        break;
+      case 'startSession':
+        this.startSession(bufferedEvent[1], true);
+        break;
+      case 'endSession':
+        this.endSession(true);
+        break;
+      case 'consent':
+        this.consent(bufferedEvent[1], true);
+        break;
+      case 'addCustomIntegration':
+        this.addCustomIntegration(bufferedEvent[1], bufferedEvent[2], true);
+        break;
+      default: {
+        const unsupportedEvent: never = bufferedEvent;
+        return unsupportedEvent;
+      }
     }
   }
 

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -75,7 +75,10 @@ import { getConsentManagementData, getValidPostConsentOptions } from '../utiliti
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import { CustomContextStore } from '../customContext';
+
+const CUSTOM_CONTEXT_EVENT_METHODS = ['page', 'track', 'identify', 'alias', 'group'];
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events
@@ -421,8 +424,12 @@ class Analytics implements IAnalytics {
       if (bufferedEvent) {
         const methodName = bufferedEvent[0];
         if (isFunction((this as any)[methodName])) {
-          // Send additional arg 'true' to indicate that this is a buffered invocation
-          (this as any)[methodName](...bufferedEvent.slice(1), true);
+          if (CUSTOM_CONTEXT_EVENT_METHODS.includes(methodName)) {
+            (this as any)[methodName](bufferedEvent[1], true, bufferedEvent[2]);
+          } else {
+            // Send additional arg 'true' to indicate that this is a buffered invocation
+            (this as any)[methodName](...bufferedEvent.slice(1), true);
+          }
         }
       }
 
@@ -536,13 +543,18 @@ class Analytics implements IAnalytics {
     }
   }
 
-  page(payload: PageCallOptions, isBufferedInvocation = false) {
+  page(
+    payload: PageCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'page';
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload],
+        [type, payload, invocationContext],
       ];
       return;
     }
@@ -550,14 +562,17 @@ class Analytics implements IAnalytics {
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
 
-    this.eventManager?.addEvent({
-      type: 'page',
-      category: payload.category,
-      name: payload.name,
-      properties: payload.properties,
-      options: payload.options,
-      callback: payload.callback,
-    });
+    this.eventManager?.addEvent(
+      {
+        type: 'page',
+        category: payload.category,
+        name: payload.name,
+        properties: payload.properties,
+        options: payload.options,
+        callback: payload.callback,
+      },
+      invocationContext,
+    );
 
     // TODO: Maybe we should alter the behavior to send the ad-block page event even if the SDK is still loaded. It'll be pushed into the to be processed queue.
 
@@ -582,13 +597,18 @@ class Analytics implements IAnalytics {
     }
   }
 
-  track(payload: TrackCallOptions, isBufferedInvocation = false) {
+  track(
+    payload: TrackCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'track';
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload],
+        [type, payload, invocationContext],
       ];
       return;
     }
@@ -596,22 +616,30 @@ class Analytics implements IAnalytics {
     this.errorHandler.leaveBreadcrumb(`New ${type} event - ${payload.name}`);
     state.metrics.triggered.value += 1;
 
-    this.eventManager?.addEvent({
-      type,
-      name: payload.name || undefined,
-      properties: payload.properties,
-      options: payload.options,
-      callback: payload.callback,
-    });
+    this.eventManager?.addEvent(
+      {
+        type,
+        name: payload.name || undefined,
+        properties: payload.properties,
+        options: payload.options,
+        callback: payload.callback,
+      },
+      invocationContext,
+    );
   }
 
-  identify(payload: IdentifyCallOptions, isBufferedInvocation = false) {
+  identify(
+    payload: IdentifyCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'identify';
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload],
+        [type, payload, invocationContext],
       ];
       return;
     }
@@ -633,22 +661,30 @@ class Analytics implements IAnalytics {
     }
     this.userSessionManager?.setUserTraits(payload.traits);
 
-    this.eventManager?.addEvent({
-      type,
-      userId: payload.userId,
-      traits: payload.traits,
-      options: payload.options,
-      callback: payload.callback,
-    });
+    this.eventManager?.addEvent(
+      {
+        type,
+        userId: payload.userId,
+        traits: payload.traits,
+        options: payload.options,
+        callback: payload.callback,
+      },
+      invocationContext,
+    );
   }
 
-  alias(payload: AliasCallOptions, isBufferedInvocation = false) {
+  alias(
+    payload: AliasCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'alias';
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload],
+        [type, payload, invocationContext],
       ];
       return;
     }
@@ -659,22 +695,30 @@ class Analytics implements IAnalytics {
     const previousId =
       payload.from ?? (this.getUserId() || this.userSessionManager?.getAnonymousId());
 
-    this.eventManager?.addEvent({
-      type,
-      to: payload.to,
-      from: previousId,
-      options: payload.options,
-      callback: payload.callback,
-    });
+    this.eventManager?.addEvent(
+      {
+        type,
+        to: payload.to,
+        from: previousId,
+        options: payload.options,
+        callback: payload.callback,
+      },
+      invocationContext,
+    );
   }
 
-  group(payload: GroupCallOptions, isBufferedInvocation = false) {
+  group(
+    payload: GroupCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'group';
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload],
+        [type, payload, invocationContext],
       ];
       return;
     }
@@ -689,13 +733,16 @@ class Analytics implements IAnalytics {
 
     this.userSessionManager?.setGroupTraits(payload.traits);
 
-    this.eventManager?.addEvent({
-      type,
-      groupId: payload.groupId,
-      traits: payload.traits,
-      options: payload.options,
-      callback: payload.callback,
-    });
+    this.eventManager?.addEvent(
+      {
+        type,
+        groupId: payload.groupId,
+        traits: payload.traits,
+        options: payload.options,
+        callback: payload.callback,
+      },
+      invocationContext,
+    );
   }
 
   reset(options?: ResetOptions | boolean, isBufferedInvocation = false) {

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -76,7 +76,7 @@ import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilit
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
 import type { BufferedEvent } from '@rudderstack/analytics-js-common/types/Event';
-import { CustomContextStore } from '../customContext';
+import { CustomContextStore, prepareCustomContextUpdate } from '../customContext';
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events
@@ -478,6 +478,15 @@ class Analytics implements IAnalytics {
     }
   }
 
+  private getInvocationContext(preservedCustomContext?: CustomContext): CustomContext {
+    if (preservedCustomContext === undefined) {
+      return this.customContextStore.get();
+    }
+
+    const preparedContext = prepareCustomContextUpdate(preservedCustomContext, this.logger);
+    return (preparedContext as CustomContext | undefined) ?? {};
+  }
+
   /**
    * Load device mode destinations
    */
@@ -599,7 +608,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
+    const invocationContext = this.getInvocationContext(preservedCustomContext);
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -654,7 +663,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
+    const invocationContext = this.getInvocationContext(preservedCustomContext);
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event - ${payload.name}`);
     state.metrics.triggered.value += 1;
@@ -686,7 +695,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
+    const invocationContext = this.getInvocationContext(preservedCustomContext);
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -732,7 +741,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
+    const invocationContext = this.getInvocationContext(preservedCustomContext);
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -767,7 +776,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
+    const invocationContext = this.getInvocationContext(preservedCustomContext);
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -75,10 +75,7 @@ import { getConsentManagementData, getValidPostConsentOptions } from '../utiliti
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
-import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import { CustomContextStore } from '../customContext';
-
-const CUSTOM_CONTEXT_EVENT_METHODS = ['page', 'track', 'identify', 'alias', 'group'];
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events
@@ -424,12 +421,8 @@ class Analytics implements IAnalytics {
       if (bufferedEvent) {
         const methodName = bufferedEvent[0];
         if (isFunction((this as any)[methodName])) {
-          if (CUSTOM_CONTEXT_EVENT_METHODS.includes(methodName)) {
-            (this as any)[methodName](bufferedEvent[1], true, bufferedEvent[2]);
-          } else {
-            // Send additional arg 'true' to indicate that this is a buffered invocation
-            (this as any)[methodName](...bufferedEvent.slice(1), true);
-          }
+          // Send additional arg 'true' to indicate that this is a buffered invocation
+          (this as any)[methodName](...bufferedEvent.slice(1), true);
         }
       }
 
@@ -543,21 +536,18 @@ class Analytics implements IAnalytics {
     }
   }
 
-  page(
-    payload: PageCallOptions,
-    isBufferedInvocation = false,
-    preservedCustomContext?: CustomContext,
-  ) {
+  page(payload: PageCallOptions, isBufferedInvocation = false) {
     const type = 'page';
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload, invocationContext],
+        [type, payload],
       ];
       return;
     }
+
+    const invocationContext = this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -597,21 +587,18 @@ class Analytics implements IAnalytics {
     }
   }
 
-  track(
-    payload: TrackCallOptions,
-    isBufferedInvocation = false,
-    preservedCustomContext?: CustomContext,
-  ) {
+  track(payload: TrackCallOptions, isBufferedInvocation = false) {
     const type = 'track';
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload, invocationContext],
+        [type, payload],
       ];
       return;
     }
+
+    const invocationContext = this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event - ${payload.name}`);
     state.metrics.triggered.value += 1;
@@ -628,21 +615,18 @@ class Analytics implements IAnalytics {
     );
   }
 
-  identify(
-    payload: IdentifyCallOptions,
-    isBufferedInvocation = false,
-    preservedCustomContext?: CustomContext,
-  ) {
+  identify(payload: IdentifyCallOptions, isBufferedInvocation = false) {
     const type = 'identify';
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload, invocationContext],
+        [type, payload],
       ];
       return;
     }
+
+    const invocationContext = this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -673,21 +657,18 @@ class Analytics implements IAnalytics {
     );
   }
 
-  alias(
-    payload: AliasCallOptions,
-    isBufferedInvocation = false,
-    preservedCustomContext?: CustomContext,
-  ) {
+  alias(payload: AliasCallOptions, isBufferedInvocation = false) {
     const type = 'alias';
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload, invocationContext],
+        [type, payload],
       ];
       return;
     }
+
+    const invocationContext = this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -707,21 +688,18 @@ class Analytics implements IAnalytics {
     );
   }
 
-  group(
-    payload: GroupCallOptions,
-    isBufferedInvocation = false,
-    preservedCustomContext?: CustomContext,
-  ) {
+  group(payload: GroupCallOptions, isBufferedInvocation = false) {
     const type = 'group';
-    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     if (!state.lifecycle.loaded.value) {
       state.eventBuffer.toBeProcessedArray.value = [
         ...state.eventBuffer.toBeProcessedArray.value,
-        [type, payload, invocationContext],
+        [type, payload],
       ];
       return;
     }
+
+    const invocationContext = this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -75,7 +75,10 @@ import { getConsentManagementData, getValidPostConsentOptions } from '../utiliti
 import { dispatchSDKEvent, isDataPlaneUrlValid, isWriteKeyValid } from './utilities';
 import { safelyInvokeCallback } from '../utilities/callbacks';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import { CustomContextStore } from '../customContext';
+
+const CUSTOM_CONTEXT_EVENT_METHODS = ['page', 'track', 'identify', 'alias', 'group'];
 
 /*
  * Analytics class with lifecycle based on state ad user triggered events
@@ -421,8 +424,12 @@ class Analytics implements IAnalytics {
       if (bufferedEvent) {
         const methodName = bufferedEvent[0];
         if (isFunction((this as any)[methodName])) {
-          // Send additional arg 'true' to indicate that this is a buffered invocation
-          (this as any)[methodName](...bufferedEvent.slice(1), true);
+          if (CUSTOM_CONTEXT_EVENT_METHODS.includes(methodName) && bufferedEvent.length > 2) {
+            (this as any)[methodName](bufferedEvent[1], true, bufferedEvent[2]);
+          } else {
+            // Send additional arg 'true' to indicate that this is a buffered invocation
+            (this as any)[methodName](...bufferedEvent.slice(1), true);
+          }
         }
       }
 
@@ -536,7 +543,11 @@ class Analytics implements IAnalytics {
     }
   }
 
-  page(payload: PageCallOptions, isBufferedInvocation = false) {
+  page(
+    payload: PageCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'page';
 
     if (!state.lifecycle.loaded.value) {
@@ -547,7 +558,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = this.customContextStore.get();
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -587,7 +598,11 @@ class Analytics implements IAnalytics {
     }
   }
 
-  track(payload: TrackCallOptions, isBufferedInvocation = false) {
+  track(
+    payload: TrackCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'track';
 
     if (!state.lifecycle.loaded.value) {
@@ -598,7 +613,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = this.customContextStore.get();
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event - ${payload.name}`);
     state.metrics.triggered.value += 1;
@@ -615,7 +630,11 @@ class Analytics implements IAnalytics {
     );
   }
 
-  identify(payload: IdentifyCallOptions, isBufferedInvocation = false) {
+  identify(
+    payload: IdentifyCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'identify';
 
     if (!state.lifecycle.loaded.value) {
@@ -626,7 +645,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = this.customContextStore.get();
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -657,7 +676,11 @@ class Analytics implements IAnalytics {
     );
   }
 
-  alias(payload: AliasCallOptions, isBufferedInvocation = false) {
+  alias(
+    payload: AliasCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'alias';
 
     if (!state.lifecycle.loaded.value) {
@@ -668,7 +691,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = this.customContextStore.get();
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;
@@ -688,7 +711,11 @@ class Analytics implements IAnalytics {
     );
   }
 
-  group(payload: GroupCallOptions, isBufferedInvocation = false) {
+  group(
+    payload: GroupCallOptions,
+    isBufferedInvocation = false,
+    preservedCustomContext?: CustomContext,
+  ) {
     const type = 'group';
 
     if (!state.lifecycle.loaded.value) {
@@ -699,7 +726,7 @@ class Analytics implements IAnalytics {
       return;
     }
 
-    const invocationContext = this.customContextStore.get();
+    const invocationContext = preservedCustomContext ?? this.customContextStore.get();
 
     this.errorHandler.leaveBreadcrumb(`New ${type} event`);
     state.metrics.triggered.value += 1;

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -32,7 +32,6 @@ import type { ICapabilitiesManager } from '../capabilitiesManager/types';
 import type { PreloadedEventCall } from '../preloadBuffer/types';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
 import type { CustomContextStore } from '../customContext';
-import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 
 export interface IAnalytics {
   preloadBuffer: BufferQueue<PreloadedEventCall>;

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -32,7 +32,6 @@ import type { ICapabilitiesManager } from '../capabilitiesManager/types';
 import type { PreloadedEventCall } from '../preloadBuffer/types';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
 import type { CustomContextStore } from '../customContext';
-import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 
 export interface IAnalytics {
   preloadBuffer: BufferQueue<PreloadedEventCall>;
@@ -137,47 +136,27 @@ export interface IAnalytics {
   /**
    * To record a page view event
    */
-  page(
-    pageOptions: PageCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  page(pageOptions: PageCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user track event
    */
-  track(
-    trackCallOptions: TrackCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  track(trackCallOptions: TrackCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user identification event
    */
-  identify(
-    identifyCallOptions: IdentifyCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  identify(identifyCallOptions: IdentifyCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user alias event
    */
-  alias(
-    aliasCallOptions: AliasCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  alias(aliasCallOptions: AliasCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user group event
    */
-  group(
-    groupCallOptions: GroupCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  group(groupCallOptions: GroupCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To get anonymousId set in the SDK

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -32,6 +32,7 @@ import type { ICapabilitiesManager } from '../capabilitiesManager/types';
 import type { PreloadedEventCall } from '../preloadBuffer/types';
 import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
 import type { CustomContextStore } from '../customContext';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 
 export interface IAnalytics {
   preloadBuffer: BufferQueue<PreloadedEventCall>;
@@ -136,27 +137,47 @@ export interface IAnalytics {
   /**
    * To record a page view event
    */
-  page(pageOptions: PageCallOptions, isBufferedInvocation?: boolean): void;
+  page(
+    pageOptions: PageCallOptions,
+    isBufferedInvocation?: boolean,
+    preservedCustomContext?: CustomContext,
+  ): void;
 
   /**
    * To record a user track event
    */
-  track(trackCallOptions: TrackCallOptions, isBufferedInvocation?: boolean): void;
+  track(
+    trackCallOptions: TrackCallOptions,
+    isBufferedInvocation?: boolean,
+    preservedCustomContext?: CustomContext,
+  ): void;
 
   /**
    * To record a user identification event
    */
-  identify(identifyCallOptions: IdentifyCallOptions, isBufferedInvocation?: boolean): void;
+  identify(
+    identifyCallOptions: IdentifyCallOptions,
+    isBufferedInvocation?: boolean,
+    preservedCustomContext?: CustomContext,
+  ): void;
 
   /**
    * To record a user alias event
    */
-  alias(aliasCallOptions: AliasCallOptions, isBufferedInvocation?: boolean): void;
+  alias(
+    aliasCallOptions: AliasCallOptions,
+    isBufferedInvocation?: boolean,
+    preservedCustomContext?: CustomContext,
+  ): void;
 
   /**
    * To record a user group event
    */
-  group(groupCallOptions: GroupCallOptions, isBufferedInvocation?: boolean): void;
+  group(
+    groupCallOptions: GroupCallOptions,
+    isBufferedInvocation?: boolean,
+    preservedCustomContext?: CustomContext,
+  ): void;
 
   /**
    * To get anonymousId set in the SDK

--- a/packages/analytics-js/src/components/core/IAnalytics.ts
+++ b/packages/analytics-js/src/components/core/IAnalytics.ts
@@ -136,47 +136,27 @@ export interface IAnalytics {
   /**
    * To record a page view event
    */
-  page(
-    pageOptions: PageCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  page(pageOptions: PageCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user track event
    */
-  track(
-    trackCallOptions: TrackCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  track(trackCallOptions: TrackCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user identification event
    */
-  identify(
-    identifyCallOptions: IdentifyCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  identify(identifyCallOptions: IdentifyCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user alias event
    */
-  alias(
-    aliasCallOptions: AliasCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  alias(aliasCallOptions: AliasCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To record a user group event
    */
-  group(
-    groupCallOptions: GroupCallOptions,
-    isBufferedInvocation?: boolean,
-    preservedCustomContext?: CustomContext,
-  ): void;
+  group(groupCallOptions: GroupCallOptions, isBufferedInvocation?: boolean): void;
 
   /**
    * To get anonymousId set in the SDK

--- a/packages/analytics-js/src/components/customContext/index.ts
+++ b/packages/analytics-js/src/components/customContext/index.ts
@@ -1,3 +1,7 @@
 export { CustomContextStore } from './CustomContextStore';
-export { filterReservedCustomContextKeys, prepareCustomContextUpdate } from './utilities';
+export {
+  containsPrototypePollutionKey,
+  filterReservedCustomContextKeys,
+  prepareCustomContextUpdate,
+} from './utilities';
 export type { CustomContext, CustomContextSnapshot, CustomContextValue } from './types';

--- a/packages/analytics-js/src/components/customContext/utilities.ts
+++ b/packages/analytics-js/src/components/customContext/utilities.ts
@@ -107,4 +107,8 @@ const prepareCustomContextUpdate = (
   }
 };
 
-export { filterReservedCustomContextKeys, prepareCustomContextUpdate };
+export {
+  containsPrototypePollutionKey,
+  filterReservedCustomContextKeys,
+  prepareCustomContextUpdate,
+};

--- a/packages/analytics-js/src/components/eventManager/EventManager.ts
+++ b/packages/analytics-js/src/components/eventManager/EventManager.ts
@@ -1,6 +1,7 @@
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { IErrorHandler } from '@rudderstack/analytics-js-common/types/ErrorHandler';
 import type { APIEvent } from '@rudderstack/analytics-js-common/types/EventApi';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import type { IEventManager } from './types';
 import { RudderEventFactory } from './RudderEventFactory';
 import type { IEventRepository } from '../eventRepository/types';
@@ -51,9 +52,9 @@ class EventManager implements IEventManager {
    * Consumes a new incoming event
    * @param event Incoming event data
    */
-  addEvent(event: APIEvent) {
+  addEvent(event: APIEvent, customContext: CustomContext) {
     this.userSessionManager.refreshSession();
-    const rudderEvent = this.eventFactory.create(event);
+    const rudderEvent = this.eventFactory.create(event, customContext);
     this.eventRepository.enqueue(rudderEvent, event.callback);
   }
 }

--- a/packages/analytics-js/src/components/eventManager/RudderEventFactory.ts
+++ b/packages/analytics-js/src/components/eventManager/RudderEventFactory.ts
@@ -3,6 +3,7 @@ import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 import type { ApiObject } from '@rudderstack/analytics-js-common/types/ApiObject';
 import type { APIEvent, ApiOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 import type { RudderContext, RudderEvent } from '@rudderstack/analytics-js-common/types/Event';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import { getEnrichedEvent, getUpdatedPageProperties } from './utilities';
 
 class RudderEventFactory {
@@ -24,6 +25,7 @@ class RudderEventFactory {
     name?: string,
     properties?: Nullable<ApiObject>,
     options?: Nullable<ApiOptions>,
+    customContext: CustomContext = {},
   ): RudderEvent {
     let props = properties ?? {};
     props = getUpdatedPageProperties(props, options);
@@ -35,7 +37,7 @@ class RudderEventFactory {
       type: 'page',
     };
 
-    return getEnrichedEvent(pageEvent, options, props, this.logger);
+    return getEnrichedEvent(pageEvent, options, props, this.logger, customContext);
   }
 
   /**
@@ -48,6 +50,7 @@ class RudderEventFactory {
     event: string,
     properties?: Nullable<ApiObject>,
     options?: Nullable<ApiOptions>,
+    customContext: CustomContext = {},
   ): RudderEvent {
     const trackEvent: Partial<RudderEvent> = {
       properties,
@@ -55,7 +58,7 @@ class RudderEventFactory {
       type: 'track',
     };
 
-    return getEnrichedEvent(trackEvent, options, undefined, this.logger);
+    return getEnrichedEvent(trackEvent, options, undefined, this.logger, customContext);
   }
 
   /**
@@ -68,6 +71,7 @@ class RudderEventFactory {
     userId?: Nullable<string>,
     traits?: Nullable<ApiObject>,
     options?: Nullable<ApiOptions>,
+    customContext: CustomContext = {},
   ): RudderEvent {
     const identifyEvent: Partial<RudderEvent> = {
       userId,
@@ -77,7 +81,7 @@ class RudderEventFactory {
       } as RudderContext,
     };
 
-    return getEnrichedEvent(identifyEvent, options, undefined, this.logger);
+    return getEnrichedEvent(identifyEvent, options, undefined, this.logger, customContext);
   }
 
   /**
@@ -86,13 +90,24 @@ class RudderEventFactory {
    * @param from Old user ID
    * @param options API options
    */
-  generateAliasEvent(to: string, from?: string, options?: Nullable<ApiOptions>): RudderEvent {
+  generateAliasEvent(
+    to: string,
+    from?: string,
+    options?: Nullable<ApiOptions>,
+    customContext: CustomContext = {},
+  ): RudderEvent {
     const aliasEvent: Partial<RudderEvent> = {
       previousId: from,
       type: 'alias',
     };
 
-    const enrichedEvent = getEnrichedEvent(aliasEvent, options, undefined, this.logger);
+    const enrichedEvent = getEnrichedEvent(
+      aliasEvent,
+      options,
+      undefined,
+      this.logger,
+      customContext,
+    );
     // override the User ID from the API inputs
     enrichedEvent.userId = to ?? enrichedEvent.userId;
     return enrichedEvent;
@@ -108,6 +123,7 @@ class RudderEventFactory {
     groupId?: Nullable<string>,
     traits?: Nullable<ApiObject>,
     options?: Nullable<ApiOptions>,
+    customContext: CustomContext = {},
   ): RudderEvent {
     const groupEvent: Partial<RudderEvent> = {
       type: 'group',
@@ -121,7 +137,7 @@ class RudderEventFactory {
       groupEvent.traits = traits;
     }
 
-    return getEnrichedEvent(groupEvent, options, undefined, this.logger);
+    return getEnrichedEvent(groupEvent, options, undefined, this.logger, customContext);
   }
 
   /**
@@ -129,7 +145,7 @@ class RudderEventFactory {
    * @param event API event parameters object
    * @returns A RudderEvent object
    */
-  create(event: APIEvent): RudderEvent {
+  create(event: APIEvent, customContext: CustomContext = {}): RudderEvent {
     let eventObj: RudderEvent | undefined;
     switch (event.type) {
       case 'page':
@@ -138,20 +154,41 @@ class RudderEventFactory {
           event.name,
           event.properties,
           event.options,
+          customContext,
         );
         break;
       case 'track':
-        eventObj = this.generateTrackEvent(event.name as string, event.properties, event.options);
+        eventObj = this.generateTrackEvent(
+          event.name as string,
+          event.properties,
+          event.options,
+          customContext,
+        );
         break;
       case 'identify':
-        eventObj = this.generateIdentifyEvent(event.userId, event.traits, event.options);
+        eventObj = this.generateIdentifyEvent(
+          event.userId,
+          event.traits,
+          event.options,
+          customContext,
+        );
         break;
       case 'alias':
-        eventObj = this.generateAliasEvent(event.to as string, event.from, event.options);
+        eventObj = this.generateAliasEvent(
+          event.to as string,
+          event.from,
+          event.options,
+          customContext,
+        );
         break;
       case 'group':
       default:
-        eventObj = this.generateGroupEvent(event.groupId, event.traits, event.options);
+        eventObj = this.generateGroupEvent(
+          event.groupId,
+          event.traits,
+          event.options,
+          customContext,
+        );
         break;
     }
     return eventObj;

--- a/packages/analytics-js/src/components/eventManager/RudderEventFactory.ts
+++ b/packages/analytics-js/src/components/eventManager/RudderEventFactory.ts
@@ -147,48 +147,24 @@ class RudderEventFactory {
    */
   create(event: APIEvent, customContext: CustomContext = {}): RudderEvent {
     let eventObj: RudderEvent | undefined;
+    const ctx = customContext;
+    const { name, properties, options } = event;
     switch (event.type) {
       case 'page':
-        eventObj = this.generatePageEvent(
-          event.category,
-          event.name,
-          event.properties,
-          event.options,
-          customContext,
-        );
+        eventObj = this.generatePageEvent(event.category, name, properties, options, ctx);
         break;
       case 'track':
-        eventObj = this.generateTrackEvent(
-          event.name as string,
-          event.properties,
-          event.options,
-          customContext,
-        );
+        eventObj = this.generateTrackEvent(name as string, properties, options, ctx);
         break;
       case 'identify':
-        eventObj = this.generateIdentifyEvent(
-          event.userId,
-          event.traits,
-          event.options,
-          customContext,
-        );
+        eventObj = this.generateIdentifyEvent(event.userId, event.traits, event.options, ctx);
         break;
       case 'alias':
-        eventObj = this.generateAliasEvent(
-          event.to as string,
-          event.from,
-          event.options,
-          customContext,
-        );
+        eventObj = this.generateAliasEvent(event.to as string, event.from, event.options, ctx);
         break;
       case 'group':
       default:
-        eventObj = this.generateGroupEvent(
-          event.groupId,
-          event.traits,
-          event.options,
-          customContext,
-        );
+        eventObj = this.generateGroupEvent(event.groupId, event.traits, event.options, ctx);
         break;
     }
     return eventObj;

--- a/packages/analytics-js/src/components/eventManager/RudderEventFactory.ts
+++ b/packages/analytics-js/src/components/eventManager/RudderEventFactory.ts
@@ -147,24 +147,23 @@ class RudderEventFactory {
    */
   create(event: APIEvent, customContext: CustomContext = {}): RudderEvent {
     let eventObj: RudderEvent | undefined;
-    const ctx = customContext;
-    const { name, properties, options } = event;
-    switch (event.type) {
+    const { type, name, properties, options, category, userId, traits, to, from, groupId } = event;
+    switch (type) {
       case 'page':
-        eventObj = this.generatePageEvent(event.category, name, properties, options, ctx);
+        eventObj = this.generatePageEvent(category, name, properties, options, customContext);
         break;
       case 'track':
-        eventObj = this.generateTrackEvent(name as string, properties, options, ctx);
+        eventObj = this.generateTrackEvent(name as string, properties, options, customContext);
         break;
       case 'identify':
-        eventObj = this.generateIdentifyEvent(event.userId, event.traits, event.options, ctx);
+        eventObj = this.generateIdentifyEvent(userId, traits, options, customContext);
         break;
       case 'alias':
-        eventObj = this.generateAliasEvent(event.to as string, event.from, event.options, ctx);
+        eventObj = this.generateAliasEvent(to as string, from, options, customContext);
         break;
       case 'group':
       default:
-        eventObj = this.generateGroupEvent(event.groupId, event.traits, event.options, ctx);
+        eventObj = this.generateGroupEvent(groupId, traits, options, customContext);
         break;
     }
     return eventObj;

--- a/packages/analytics-js/src/components/eventManager/types.ts
+++ b/packages/analytics-js/src/components/eventManager/types.ts
@@ -1,7 +1,8 @@
 import type { APIEvent } from '@rudderstack/analytics-js-common/types/EventApi';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 
 export interface IEventManager {
   init(): void;
-  addEvent(event: APIEvent): void;
+  addEvent(event: APIEvent, customContext: CustomContext): void;
   resume(): void;
 }

--- a/packages/analytics-js/src/components/eventManager/utilities.ts
+++ b/packages/analytics-js/src/components/eventManager/utilities.ts
@@ -5,6 +5,7 @@ import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 import type { ApiOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 import type { RudderContext, RudderEvent } from '@rudderstack/analytics-js-common/types/Event';
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import type { CustomContext } from '@rudderstack/analytics-js-common/types/CustomContext';
 import type { IntegrationOpts } from '@rudderstack/analytics-js-common/types/Integration';
 import {
   isNonEmptyObject,
@@ -237,6 +238,7 @@ const getEnrichedEvent = (
   options: Nullable<ApiOptions> | undefined,
   pageProps: ApiObject | undefined,
   logger: ILogger,
+  customContext: CustomContext = {},
 ): RudderEvent => {
   const commonEventData = {
     channel: CHANNEL,
@@ -314,7 +316,10 @@ const getEnrichedEvent = (
     }
   }
 
-  const processedEvent = mergeDeepRight(rudderEvent, commonEventData) as RudderEvent;
+  const sdkBuiltEvent = mergeDeepRight(rudderEvent, commonEventData) as RudderEvent;
+  const processedEvent = mergeDeepRight(sdkBuiltEvent, {
+    context: customContext,
+  }) as RudderEvent;
   // Set the default values for the event properties
   // matching with v1.1 payload
   if (processedEvent.event === undefined) {

--- a/packages/analytics-js/src/components/eventManager/utilities.ts
+++ b/packages/analytics-js/src/components/eventManager/utilities.ts
@@ -23,12 +23,8 @@ import {
   INVALID_CONTEXT_OBJECT_WARNING,
   RESERVED_KEYWORD_WARNING,
 } from '../../constants/logMessages';
-import {
-  CHANNEL,
-  CONTEXT_RESERVED_ELEMENTS,
-  RESERVED_ELEMENTS,
-  TOP_LEVEL_ELEMENTS,
-} from './constants';
+import { CHANNEL, RESERVED_ELEMENTS, TOP_LEVEL_ELEMENTS } from './constants';
+import { filterReservedCustomContextKeys } from '../customContext';
 import { getDefaultPageProperties } from '../utilities/page';
 import { extractUTMParameters } from '../utilities/url';
 import { generateAnonymousId, isStorageTypeValidForStoringData } from '../userSessionManager/utils';
@@ -164,21 +160,17 @@ const getMergedContext = (
 ): RudderContext => {
   let context = rudderContext;
   Object.keys(options).forEach(key => {
-    if (!TOP_LEVEL_ELEMENTS.includes(key) && !CONTEXT_RESERVED_ELEMENTS.includes(key)) {
+    if (!TOP_LEVEL_ELEMENTS.includes(key)) {
       if (key !== 'context') {
-        context = mergeDeepRight(context, {
-          [key]: options[key],
-        });
+        context = mergeDeepRight(
+          context,
+          filterReservedCustomContextKeys({ [key]: options[key] }, logger),
+        );
       } else if (!isUndefined(options[key]) && isObjectLiteralAndNotNull(options[key])) {
-        const tempContext: Record<string, any> = {};
-        Object.keys(options[key] as Record<string, any>).forEach(e => {
-          if (!CONTEXT_RESERVED_ELEMENTS.includes(e)) {
-            tempContext[e] = (options[key] as Record<string, any>)[e];
-          }
-        });
-        context = mergeDeepRight(context, {
-          ...tempContext,
-        });
+        context = mergeDeepRight(
+          context,
+          filterReservedCustomContextKeys(options[key] as Record<string, unknown>, logger),
+        );
       } else {
         logger.warn(INVALID_CONTEXT_OBJECT_WARNING(EVENT_MANAGER));
       }

--- a/packages/analytics-js/src/components/eventManager/utilities.ts
+++ b/packages/analytics-js/src/components/eventManager/utilities.ts
@@ -20,11 +20,12 @@ import { DEFAULT_INTEGRATIONS_CONFIG } from '@rudderstack/analytics-js-common/co
 import type { StorageType } from '@rudderstack/analytics-js-common/types/Storage';
 import { state } from '../../state';
 import {
+  INVALID_CUSTOM_CONTEXT_WARNING,
   INVALID_CONTEXT_OBJECT_WARNING,
   RESERVED_KEYWORD_WARNING,
 } from '../../constants/logMessages';
 import { CHANNEL, RESERVED_ELEMENTS, TOP_LEVEL_ELEMENTS } from './constants';
-import { filterReservedCustomContextKeys } from '../customContext';
+import { containsPrototypePollutionKey, filterReservedCustomContextKeys } from '../customContext';
 import { getDefaultPageProperties } from '../utilities/page';
 import { extractUTMParameters } from '../utilities/url';
 import { generateAnonymousId, isStorageTypeValidForStoringData } from '../userSessionManager/utils';
@@ -159,18 +160,24 @@ const getMergedContext = (
   logger: ILogger,
 ): RudderContext => {
   let context = rudderContext;
+
+  const mergeContext = (candidateContext: Record<string, unknown>): void => {
+    const acceptedContext = filterReservedCustomContextKeys(candidateContext, logger);
+
+    if (containsPrototypePollutionKey(acceptedContext)) {
+      logger.warn(INVALID_CUSTOM_CONTEXT_WARNING(EVENT_MANAGER));
+      return;
+    }
+
+    context = mergeDeepRight(context, acceptedContext);
+  };
+
   Object.keys(options).forEach(key => {
     if (!TOP_LEVEL_ELEMENTS.includes(key)) {
       if (key !== 'context') {
-        context = mergeDeepRight(
-          context,
-          filterReservedCustomContextKeys({ [key]: options[key] }, logger),
-        );
+        mergeContext({ [key]: options[key] });
       } else if (!isUndefined(options[key]) && isObjectLiteralAndNotNull(options[key])) {
-        context = mergeDeepRight(
-          context,
-          filterReservedCustomContextKeys(options[key] as Record<string, unknown>, logger),
-        );
+        mergeContext(options[key] as Record<string, unknown>);
       } else {
         logger.warn(INVALID_CONTEXT_OBJECT_WARNING(EVENT_MANAGER));
       }


### PR DESCRIPTION
## Summary

- capture custom context at event invocation time
- preserve invocation snapshots through buffering and replay
- merge shared application-state context into canonical events with the approved precedence
- cover all supported event factories and automatic event paths without changing existing per-event options behavior
- rebase event enrichment onto the shared application-state ownership model approved in the architecture review

## Validation

- 303 focused event, facade, state, privacy, and integration tests passed on the rebased stack
- analytics-js and analytics-js-common lint passed with zero errors
- Prettier and `git diff --check` passed

Linear: [SDK-5056](https://linear.app/rudderstack/issue/SDK-5056/merge-global-custom-context-into-event-context-with-correct-precedence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom context is consistently attached to page, track, identify, alias, and group events.
  - Buffered events preserve their context during replay.
  - Nested context values are merged, with event-specific values taking precedence.

- **Bug Fixes**
  - Reserved or unsafe context properties are rejected to prevent unintended updates and prototype-pollution risks.
  - Invalid context updates generate warnings and leave existing context unchanged.

- **Tests**
  - Expanded coverage for immediate, buffered, replayed, and context-merging event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->