### PR TITLE
test: sdk-5059 add custom context integration coverage

### DIFF
--- a/packages/analytics-js-common/__tests__/types/CustomContext.test.ts
+++ b/packages/analytics-js-common/__tests__/types/CustomContext.test.ts
@@ -1,11 +1,11 @@
-import type { CustomContext, CustomContextUpdate } from '../../src/types/CustomContext';
+import type { CustomContext, InputCustomContext } from '../../src/types/CustomContext';
 import type { IRudderAnalytics } from '../../src/types/IRudderAnalytics';
 import type { LoadOptions } from '../../src/types/LoadOptions';
 
 describe('CustomContext public types', () => {
   it('supports the approved load, runtime update, and snapshot surfaces', () => {
     const capturedAt = new Date('2026-07-28T00:00:00.000Z');
-    const update: CustomContextUpdate = {
+    const update: InputCustomContext = {
       region: 'EU',
       capturedAt,
       account: {
@@ -33,7 +33,7 @@ describe('CustomContext public types', () => {
   });
 
   it('rejects unsupported public values at compile time', () => {
-    const invalidUpdates: CustomContextUpdate[] = [
+    const invalidUpdates: InputCustomContext[] = [
       // @ts-expect-error Map is not a supported custom context value
       { invalid: new Map([['key', 'value']]) },
       // @ts-expect-error functions are not supported custom context values

--- a/packages/analytics-js-common/__tests__/types/CustomContext.test.ts
+++ b/packages/analytics-js-common/__tests__/types/CustomContext.test.ts
@@ -1,0 +1,45 @@
+import type { CustomContext, CustomContextUpdate } from '../../src/types/CustomContext';
+import type { IRudderAnalytics } from '../../src/types/IRudderAnalytics';
+import type { LoadOptions } from '../../src/types/LoadOptions';
+
+describe('CustomContext public types', () => {
+  it('supports the approved load, runtime update, and snapshot surfaces', () => {
+    const capturedAt = new Date('2026-07-28T00:00:00.000Z');
+    const update: CustomContextUpdate = {
+      region: 'EU',
+      capturedAt,
+      account: {
+        plan: undefined,
+        seats: 5,
+      },
+    };
+    const loadOptions: Partial<LoadOptions> = { context: update };
+    const snapshot: CustomContext = {
+      region: 'EU',
+      capturedAt,
+      account: { seats: 5 },
+    };
+
+    const exercisePublicApi = (analytics: IRudderAnalytics) => {
+      analytics.setCustomContext(update);
+      const current: CustomContext = analytics.getCustomContext();
+      analytics.clearCustomContext();
+      return current;
+    };
+
+    expect(loadOptions.context).toBe(update);
+    expect(snapshot.capturedAt).toBe(capturedAt);
+    expect(exercisePublicApi).toEqual(expect.any(Function));
+  });
+
+  it('rejects unsupported public values at compile time', () => {
+    const invalidUpdates: CustomContextUpdate[] = [
+      // @ts-expect-error Map is not a supported custom context value
+      { invalid: new Map([['key', 'value']]) },
+      // @ts-expect-error functions are not supported custom context values
+      { invalid: () => 'value' },
+    ];
+
+    expect(invalidUpdates).toHaveLength(2);
+  });
+});

--- a/packages/analytics-js/__tests__/browser.test.ts
+++ b/packages/analytics-js/__tests__/browser.test.ts
@@ -62,9 +62,24 @@ describe('Test suite for the SDK', () => {
     'group-trait-key-2': 'group-trait-value-2',
   };
 
-  const loadSDKScript = () => {
-    loadingSnippet(dummyCDNHost, SDK_FILE_NAME, WRITE_KEY, DATA_PLANE_URL);
+  const loadSDKScript = (options = {}) => {
+    loadingSnippet(dummyCDNHost, SDK_FILE_NAME, WRITE_KEY, DATA_PLANE_URL, options);
   };
+
+  const getSentEvents = (): Record<string, any>[] =>
+    xhrMock.send.mock.calls
+      .map(([body]: [unknown]) => {
+        if (typeof body !== 'string') {
+          return undefined;
+        }
+
+        try {
+          return JSON.parse(body);
+        } catch {
+          return undefined;
+        }
+      })
+      .filter((body: Record<string, any> | undefined) => body?.event);
 
   const waitForSDKReady = async () => {
     const readyPromise = new Promise((resolve, reject) => {
@@ -110,6 +125,28 @@ describe('Test suite for the SDK', () => {
 
       // one source configuration request, one page request, and one track request
       expect(xhrMock.send).toHaveBeenCalledTimes(3);
+    });
+
+    it('applies load, set, and clear context in preload invocation order', async () => {
+      loadSDKScript({ context: { version: 'load-time' } });
+
+      window.rudderanalytics?.track('before-runtime-update');
+      window.rudderanalytics?.setCustomContext({ version: 'runtime' });
+      window.rudderanalytics?.track('after-runtime-update');
+      window.rudderanalytics?.clearCustomContext();
+      window.rudderanalytics?.track('after-clear');
+
+      await waitForSDKReady();
+
+      const eventsByName = Object.fromEntries(getSentEvents().map(event => [event.event, event]));
+
+      expect(eventsByName['before-runtime-update']?.context).toMatchObject({
+        version: 'load-time',
+      });
+      expect(eventsByName['after-runtime-update']?.context).toMatchObject({
+        version: 'runtime',
+      });
+      expect(eventsByName['after-clear']?.context).not.toHaveProperty('version');
     });
   });
 

--- a/packages/analytics-js/__tests__/browser.test.ts
+++ b/packages/analytics-js/__tests__/browser.test.ts
@@ -79,7 +79,9 @@ describe('Test suite for the SDK', () => {
           return undefined;
         }
       })
-      .filter((body: Record<string, any> | undefined) => body?.event);
+      .filter((body: Record<string, any> | undefined): body is Record<string, any> =>
+        Boolean(body?.event),
+      );
 
   const waitForSDKReady = async () => {
     const readyPromise = new Promise((resolve, reject) => {

--- a/packages/analytics-js/__tests__/browser.test.ts
+++ b/packages/analytics-js/__tests__/browser.test.ts
@@ -1,6 +1,23 @@
 import { dummyCDNHost, SDK_FILE_NAME } from '../__fixtures__/fixtures';
 import { loadingSnippet } from './nativeSdkLoader';
 import { server } from '../__fixtures__/msw.server';
+import type { RudderEvent } from '@rudderstack/analytics-js-common/types/Event';
+
+type SentTrackEvent = Pick<RudderEvent, 'event' | 'context'>;
+
+const isSentTrackEvent = (value: unknown): value is SentTrackEvent => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  return (
+    'event' in value &&
+    typeof value.event === 'string' &&
+    'context' in value &&
+    typeof value.context === 'object' &&
+    value.context !== null
+  );
+};
 
 describe('Test suite for the SDK', () => {
   beforeAll(() => {
@@ -66,7 +83,7 @@ describe('Test suite for the SDK', () => {
     loadingSnippet(dummyCDNHost, SDK_FILE_NAME, WRITE_KEY, DATA_PLANE_URL, options);
   };
 
-  const getSentEvents = (): Record<string, any>[] =>
+  const getSentEvents = (): SentTrackEvent[] =>
     xhrMock.send.mock.calls
       .map(([body]: [unknown]) => {
         if (typeof body !== 'string') {
@@ -74,14 +91,13 @@ describe('Test suite for the SDK', () => {
         }
 
         try {
-          return JSON.parse(body);
+          const parsedBody: unknown = JSON.parse(body);
+          return isSentTrackEvent(parsedBody) ? parsedBody : undefined;
         } catch {
           return undefined;
         }
       })
-      .filter((body: Record<string, any> | undefined): body is Record<string, any> =>
-        Boolean(body?.event),
-      );
+      .filter((body: SentTrackEvent | undefined): body is SentTrackEvent => body !== undefined);
 
   const waitForSDKReady = async () => {
     const readyPromise = new Promise((resolve, reject) => {

--- a/packages/analytics-js/__tests__/browser.test.ts
+++ b/packages/analytics-js/__tests__/browser.test.ts
@@ -2,6 +2,7 @@ import { dummyCDNHost, SDK_FILE_NAME } from '../__fixtures__/fixtures';
 import { loadingSnippet } from './nativeSdkLoader';
 import { server } from '../__fixtures__/msw.server';
 import type { RudderEvent } from '@rudderstack/analytics-js-common/types/Event';
+import type { LoadOptions } from '@rudderstack/analytics-js-common/types/LoadOptions';
 
 type SentTrackEvent = Pick<RudderEvent, 'event' | 'context'>;
 
@@ -79,7 +80,7 @@ describe('Test suite for the SDK', () => {
     'group-trait-key-2': 'group-trait-value-2',
   };
 
-  const loadSDKScript = (options = {}) => {
+  const loadSDKScript = (options: Partial<LoadOptions> = {}) => {
     loadingSnippet(dummyCDNHost, SDK_FILE_NAME, WRITE_KEY, DATA_PLANE_URL, options);
   };
 

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -893,6 +893,38 @@ describe('Core - Analytics', () => {
         { region: 'EU' },
       );
     });
+
+    it('uses the captured context for an automatic adblock page event during replay', () => {
+      analytics.prepareInternalServices();
+      const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
+      state.lifecycle.loaded.value = true;
+      state.capabilities.isAdBlocked.value = true;
+      state.eventBuffer.toBeProcessedArray.value = [
+        ['page', { name: 'customer-page' }, { region: 'before' }],
+      ];
+      analytics.customContextStore.set({ region: 'after' });
+
+      analytics.processBufferedEvents();
+
+      expect(addEventSpy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          type: 'page',
+          name: 'customer-page',
+        }),
+        { region: 'before' },
+      );
+      expect(addEventSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          type: 'page',
+          category: ADBLOCK_PAGE_CATEGORY,
+          name: ADBLOCK_PAGE_NAME,
+          properties: expect.objectContaining({ path: ADBLOCK_PAGE_PATH }),
+        }),
+        { region: 'before' },
+      );
+    });
   });
 
   describe('track', () => {

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -1232,12 +1232,9 @@ describe('Core - Analytics', () => {
         ['identify', 'preloaded-user', { source: 'query-string' }],
         ['track', 'preloaded-event', { source: 'preload-buffer' }],
       ]);
-      analytics.load(
-        dummyWriteKey,
-        dummyDataplaneURL,
-        {},
-        { region: 'EU', source: 'load-time' },
-      );
+      analytics.load(dummyWriteKey, dummyDataplaneURL, {
+        context: { region: 'EU', source: 'load-time' },
+      });
       state.lifecycle.loaded.value = true;
 
       analytics.processDataInPreloadBuffer();

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -13,6 +13,11 @@ import {
 import { setExposedGlobal } from '../../../src/components/utilities/globals';
 import { resetState, state } from '../../../src/state';
 import { Analytics } from '../../../src/components/core/Analytics';
+import {
+  ADBLOCK_PAGE_CATEGORY,
+  ADBLOCK_PAGE_NAME,
+  ADBLOCK_PAGE_PATH,
+} from '../../../src/constants/app';
 
 jest.mock('../../../src/components/utilities/globals', () => {
   const originalModule = jest.requireActual('../../../src/components/utilities/globals');
@@ -867,6 +872,27 @@ describe('Core - Analytics', () => {
         {},
       );
     });
+
+    it('enriches an automatic adblock page event with current custom context', () => {
+      analytics.prepareInternalServices();
+      const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
+      analytics.customContextStore.set({ region: 'EU' });
+      state.lifecycle.loaded.value = true;
+      state.capabilities.isAdBlocked.value = true;
+
+      analytics.page({ name: 'customer-page' });
+
+      expect(addEventSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          type: 'page',
+          category: ADBLOCK_PAGE_CATEGORY,
+          name: ADBLOCK_PAGE_NAME,
+          properties: expect.objectContaining({ path: ADBLOCK_PAGE_PATH }),
+        }),
+        { region: 'EU' },
+      );
+    });
   });
 
   describe('track', () => {
@@ -1153,12 +1179,14 @@ describe('Core - Analytics', () => {
       analytics.prepareInternalServices();
       const leaveBreadcrumbSpy = jest.spyOn(analytics.errorHandler, 'leaveBreadcrumb');
       const resetSpy = jest.spyOn(analytics.userSessionManager!, 'reset');
+      analytics.customContextStore.set({ region: 'EU' });
 
       state.lifecycle.loaded.value = true;
       analytics.reset(true);
       expect(leaveBreadcrumbSpy).toHaveBeenCalledTimes(1);
       expect(resetSpy).toHaveBeenCalledTimes(1);
       expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([]);
+      expect(analytics.customContextStore.get()).toEqual({ region: 'EU' });
     });
 
     it('should process the preload buffer', () => {
@@ -1193,6 +1221,41 @@ describe('Core - Analytics', () => {
         name: 'buttonClicked',
         properties: { color: 'blue' },
       });
+    });
+
+    it('captures load-time context when processing preloaded event calls', () => {
+      jest.spyOn(analytics, 'startLifecycle').mockImplementation();
+      analytics.prepareInternalServices();
+      const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
+
+      analytics.enqueuePreloadBufferEvents([
+        ['identify', 'preloaded-user', { source: 'query-string' }],
+        ['track', 'preloaded-event', { source: 'preload-buffer' }],
+      ]);
+      analytics.load(
+        dummyWriteKey,
+        dummyDataplaneURL,
+        {},
+        { region: 'EU', source: 'load-time' },
+      );
+      state.lifecycle.loaded.value = true;
+
+      analytics.processDataInPreloadBuffer();
+
+      expect(addEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'identify',
+          userId: 'preloaded-user',
+        }),
+        { region: 'EU', source: 'load-time' },
+      );
+      expect(addEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'track',
+          name: 'preloaded-event',
+        }),
+        { region: 'EU', source: 'load-time' },
+      );
     });
   });
 
@@ -1352,6 +1415,7 @@ describe('Core - Analytics', () => {
 
     it('should add consent auto tracking events to the end of the buffered events', () => {
       analytics.prepareInternalServices();
+      analytics.customContextStore.set({ consentRegion: 'EU' });
 
       state.eventBuffer.toBeProcessedArray.value = [['identify', { userId: 'test_user_id' }]];
 
@@ -1377,6 +1441,7 @@ describe('Core - Analytics', () => {
             options: undefined,
             callback: undefined,
           },
+          { consentRegion: 'EU' },
         ],
         [
           'page',
@@ -1387,8 +1452,31 @@ describe('Core - Analytics', () => {
             options: undefined,
             callback: undefined,
           },
+          { consentRegion: 'EU' },
         ],
       ]);
+    });
+
+    it('replays consent-generated events with the context captured when queued', () => {
+      analytics.prepareInternalServices();
+      const addEventSpy = jest.spyOn(analytics.eventManager!, 'addEvent');
+      analytics.customContextStore.set({ consentRegion: 'before' });
+      state.consents.enabled.value = true;
+      state.lifecycle.loaded.value = true;
+      state.consents.initialized.value = false;
+
+      analytics.consent({ trackConsent: true }, true);
+      analytics.customContextStore.set({ consentRegion: 'after' });
+      analytics.processBufferedEvents();
+
+      expect(addEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'track',
+          name: 'Consent Management Interaction',
+        }),
+        { consentRegion: 'before' },
+      );
+      expect(analytics.customContextStore.get()).toEqual({ consentRegion: 'after' });
     });
 
     it('should refresh consents data when the API is invoked multiple times', () => {

--- a/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
+++ b/packages/analytics-js/__tests__/components/customContext/CustomContextStore.test.ts
@@ -52,6 +52,20 @@ describe('CustomContextStore', () => {
     });
   });
 
+  it('treats an empty array update as a no-op for an existing array', () => {
+    setContext({ tags: ['a', 'b', 'c'] });
+    setContext({ tags: [] });
+
+    expect(store.get()).toEqual({ tags: ['a', 'b', 'c'] });
+  });
+
+  it('deletes a complete array through its enclosing object property', () => {
+    setContext({ tags: ['a', 'b', 'c'], region: 'EU' });
+    setContext({ tags: null });
+
+    expect(store.get()).toEqual({ region: 'EU' });
+  });
+
   it('deletes top-level and nested paths while retaining an existing empty parent', () => {
     setContext({
       region: 'EU',

--- a/packages/analytics-js/__tests__/components/eventRepository/EventRepository.test.ts
+++ b/packages/analytics-js/__tests__/components/eventRepository/EventRepository.test.ts
@@ -291,6 +291,49 @@ describe('EventRepository', () => {
     invokeSingleSpy.mockRestore();
   });
 
+  it('should pass the same enriched context to cloud and device mode queues', () => {
+    const eventRepository = new EventRepository(
+      mockPluginsManager,
+      defaultStoreManager,
+      defaultHttpClient,
+      defaultErrorHandler,
+      defaultLogger,
+    );
+    const enrichedEvent = {
+      ...testEvent,
+      context: {
+        region: 'EU',
+        experiment: { bucket: 'treatment' },
+      },
+    } as RudderEvent;
+
+    eventRepository.init();
+    const invokeSingleSpy = jest.spyOn(mockPluginsManager, 'invokeSingle');
+    eventRepository.enqueue(enrichedEvent);
+
+    expect(invokeSingleSpy).toHaveBeenNthCalledWith(
+      1,
+      'dataplaneEventsQueue.enqueue',
+      state,
+      mockDataplaneEventsQueue,
+      {
+        ...enrichedEvent,
+        integrations: { All: true },
+      },
+      defaultErrorHandler,
+      defaultLogger,
+    );
+    expect(invokeSingleSpy).toHaveBeenNthCalledWith(
+      2,
+      'destinationsEventsQueue.enqueue',
+      state,
+      mockDestinationsEventsQueue,
+      enrichedEvent,
+      defaultErrorHandler,
+      defaultLogger,
+    );
+  });
+
   it('should invoke event callback function if provided', () => {
     const eventRepository = new EventRepository(
       mockPluginsManager,

--- a/packages/analytics-js/__tests__/components/preloadBuffer/index.test.ts
+++ b/packages/analytics-js/__tests__/components/preloadBuffer/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  consumePreloadBufferedEvent,
   getEventDataFromQueryString,
   getPreloadedLoadEvent,
   promotePreloadedConsentEventsToTop,
@@ -112,6 +113,34 @@ describe('Preload Buffer', () => {
     ]);
 
     expect(analytics.load).toHaveBeenCalledTimes(0);
+  });
+
+  it('routes custom context and event calls through the analytics APIs in preload order', () => {
+    const callOrder: string[] = [];
+    const instance = {
+      setCustomContext: jest.fn(() => callOrder.push('set')),
+      clearCustomContext: jest.fn(() => callOrder.push('clear')),
+      track: jest.fn((event: { name: string }) => callOrder.push(`track:${event.name}`)),
+    };
+    const orderedCalls: PreloadedEventCall[] = [
+      ['track', 'before-update'],
+      ['setCustomContext', { version: 'runtime' }],
+      ['track', 'after-set'],
+      ['clearCustomContext'],
+      ['track', 'after-clear'],
+    ];
+
+    orderedCalls.forEach(call => consumePreloadBufferedEvent(call, instance as any));
+
+    expect(callOrder).toEqual([
+      'track:before-update',
+      'set',
+      'track:after-set',
+      'clear',
+      'track:after-clear',
+    ]);
+    expect(instance.setCustomContext).toHaveBeenCalledWith({ version: 'runtime' });
+    expect(instance.clearCustomContext).toHaveBeenCalledTimes(1);
   });
 
   it('should not buffer any events if no preload array or query params exist', () => {

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -952,7 +952,7 @@ class Analytics implements IAnalytics {
       if (isBufferedInvocation) {
         state.eventBuffer.toBeProcessedArray.value = [
           ...state.eventBuffer.toBeProcessedArray.value,
-          ['track', trackOptions],
+          ['track', trackOptions, this.customContextStore.get()],
         ];
       } else {
         this.track(trackOptions);
@@ -964,7 +964,7 @@ class Analytics implements IAnalytics {
       if (isBufferedInvocation) {
         state.eventBuffer.toBeProcessedArray.value = [
           ...state.eventBuffer.toBeProcessedArray.value,
-          ['page', pageOptions],
+          ['page', pageOptions, this.customContextStore.get()],
         ];
       } else {
         this.page(pageOptions);

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -644,6 +644,8 @@ class Analytics implements IAnalytics {
           },
           state.loadOptions.value.sendAdblockPageOptions,
         ),
+        isBufferedInvocation,
+        invocationContext,
       );
     }
   }


### PR DESCRIPTION
## Summary

- cover load-time, runtime, buffered, reset, preload, and query-string context boundaries
- verify shared application-state ownership and full-state reset behavior
- verify customer-provided custom context is excluded from error-handler state metadata
- verify accepted-load routing and customer-visible automatic event paths
- prove the enriched canonical event reaches cloud and device delivery lanes
- add public type-boundary and finalized array-by-index contract coverage
- preserve custom-context updates when processing the preload buffer

## Validation

- 303 focused analytics-js tests passed across 9 suites
- 2 analytics-js-common public type tests passed
- analytics-js and analytics-js-common lint passed with zero errors
- legacy development bundle and `git diff --check` passed

Linear: [SDK-5059](https://linear.app/rudderstack/issue/SDK-5059/add-js-sdk-custom-context-unit-and-integration-test-coverage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom context is now preserved consistently across buffered, preloaded, replayed, ad-block, and consent-generated events.
  * Context updates and clearing operations are applied in the correct order during SDK initialization.
  * Clearing complete array values no longer removes unrelated custom context properties.
  * Queued events retain the context snapshot captured when they were created.
  * Enriched event context is preserved during delivery across destinations.

* **Tests**
  * Expanded coverage for custom context handling, public types, preload behavior, and event delivery consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->