### PR TITLE
fix: sdk-5333 publish tags for versioned packages

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -193,17 +193,18 @@ jobs:
           echo "Release branch HEAD: $release_sha"
 
           for pj in packages/*/project.json; do
-            tag=$(jq -r '.targets.github.options.tag // empty' "$pj")
-            [ -z "$tag" ] && continue
-
             pkg_dir=$(dirname "$pj")
-            current_version=$(git show "origin/${BRANCH_NAME}:${pkg_dir}/package.json" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
+            current_package=$(git show "origin/${BRANCH_NAME}:${pkg_dir}/package.json" 2>/dev/null || echo "")
+            current_version=$(printf '%s' "$current_package" | jq -r '.version // empty' 2>/dev/null || echo "")
             prev_version=$(git show "origin/main:${pkg_dir}/package.json" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
 
-            if [ -z "$current_version" ]; then
-              echo "::error::Unable to read version for ${pkg_dir}; refusing to tag ${tag}"
+            if [ -z "$current_package" ] || [ -z "$current_version" ]; then
+              echo "::error::Unable to read package metadata for ${pkg_dir}; refusing to create a release tag"
               exit 1
             fi
+
+            tag=$(printf '%s' "$current_package" | node ./scripts/get-release-version-tag.js "$pj")
+            [ -z "$tag" ] && continue
 
             if [ -n "$prev_version" ] && [ "$current_version" = "$prev_version" ]; then
               echo "Skipping ${tag} — version unchanged vs origin/main"

--- a/scripts/get-release-version-tag.js
+++ b/scripts/get-release-version-tag.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+
+const JSCUTLERY_VERSION_EXECUTOR = '@jscutlery/semver:version';
+
+function getReleaseVersionTag(projectConfig, packageMetadata) {
+  if (projectConfig.targets?.version?.executor !== JSCUTLERY_VERSION_EXECUTOR) {
+    return null;
+  }
+
+  const { name: packageName, version: packageVersion } = packageMetadata;
+
+  if (!packageName || !packageVersion) {
+    throw new Error('Package name and version are required for a release tag');
+  }
+
+  return `${packageName}@${packageVersion}`;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const [projectConfigPath] = argv;
+
+  if (!projectConfigPath) {
+    throw new Error('Project configuration path is required');
+  }
+
+  const projectConfig = JSON.parse(fs.readFileSync(projectConfigPath, 'utf8'));
+  const packageMetadata = JSON.parse(fs.readFileSync(0, 'utf8'));
+  const tag = getReleaseVersionTag(projectConfig, packageMetadata);
+
+  if (tag) {
+    process.stdout.write(tag);
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  getReleaseVersionTag,
+};

--- a/scripts/run-release-version-targets.test.js
+++ b/scripts/run-release-version-targets.test.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
+const { getReleaseVersionTag } = require('./get-release-version-tag');
 const { orderDependentsBeforeDependencies } = require('./run-release-version-targets');
 
 const repoRoot = path.resolve(__dirname, '..');
@@ -149,6 +150,42 @@ test('orders version targets from dependents to dependencies', () => {
   });
 
   assert.deepEqual(ordered, ['parent', 'middle', 'leaf']);
+});
+
+test('builds a release tag for a versioned project without a github target', () => {
+  const tag = getReleaseVersionTag(
+    {
+      targets: {
+        version: {
+          executor: '@jscutlery/semver:version',
+        },
+      },
+    },
+    {
+      name: '@rudderstack/analytics-js-sanity-suite',
+      version: '3.6.2',
+    },
+  );
+
+  assert.equal(tag, '@rudderstack/analytics-js-sanity-suite@3.6.2');
+});
+
+test('does not build a release tag for a project without a version target', () => {
+  const tag = getReleaseVersionTag(
+    {
+      targets: {
+        github: {
+          executor: '@jscutlery/semver:github',
+        },
+      },
+    },
+    {
+      name: '@rudderstack/example',
+      version: '1.0.0',
+    },
+  );
+
+  assert.equal(tag, null);
 });
 
 test('bumps a three-level trackDeps chain with skipCommit tags', () => {


### PR DESCRIPTION
## Summary

- derive release tags from each JSCutlery version target and package metadata
- publish tags for private versioned packages without requiring a GitHub release target
- add regression coverage for the sanity-suite configuration

## Validation

- `npm run test:release-versioning`
- Prettier checks for the changed JavaScript files
- YAML syntax validation for `draft-new-release.yml`
- release-tag discovery verified across all current version targets

## Linear

[SDK-5333](https://linear.app/rudderstack/issue/SDK-5333/fix-repeated-sanity-suite-changelog-version-in-releases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release tags are now generated from package metadata on the release branch.
  * Tag generation supports versioned projects without requiring a GitHub target configuration.

* **Bug Fixes**
  * Added validation for missing package metadata and version information.
  * Invalid release configurations now fail with clear errors instead of producing incorrect tags.

* **Tests**
  * Added coverage for versioned projects and projects without version targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->