### PR TITLE
fix: use final dependency versions in changelogs

### DIFF
--- a/scripts/run-release-version-targets.js
+++ b/scripts/run-release-version-targets.js
@@ -57,6 +57,103 @@ function getVersionProjects(graph) {
     }));
 }
 
+function readProjectVersions(graph, workspaceRoot = process.cwd()) {
+  return new Map(
+    getVersionProjects(graph).map(project => {
+      const packagePath = path.join(workspaceRoot, project.root, 'package.json');
+      const packageMetadata = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+
+      if (!packageMetadata.name || !packageMetadata.version) {
+        throw new Error(`Package name and version are required in ${packagePath}`);
+      }
+
+      return [
+        project.name,
+        {
+          name: packageMetadata.name,
+          root: project.root,
+          version: packageMetadata.version,
+        },
+      ];
+    }),
+  );
+}
+
+function updateLatestChangelogDependencyVersions(changelog, dependencyVersions) {
+  const firstReleaseIndex = changelog.search(/^## \[/m);
+
+  if (firstReleaseIndex === -1) {
+    return changelog;
+  }
+
+  const nextReleaseOffset = changelog.slice(firstReleaseIndex + 1).search(/^## \[/m);
+  const latestReleaseEnd =
+    nextReleaseOffset === -1 ? changelog.length : firstReleaseIndex + 1 + nextReleaseOffset;
+  const latestRelease = changelog.slice(firstReleaseIndex, latestReleaseEnd);
+  const updatedLatestRelease = latestRelease.replace(
+    /^(\* `([^`]+)` updated to version `)([^`]+)(`)$/gm,
+    (line, prefix, dependencyName, currentVersion, suffix) => {
+      const finalVersion = dependencyVersions.get(dependencyName);
+
+      return finalVersion && finalVersion !== currentVersion
+        ? `${prefix}${finalVersion}${suffix}`
+        : line;
+    },
+  );
+
+  return (
+    changelog.slice(0, firstReleaseIndex) + updatedLatestRelease + changelog.slice(latestReleaseEnd)
+  );
+}
+
+function updateChangedDependencyVersionsInChangelogs(
+  graph,
+  initialVersions,
+  finalVersions,
+  workspaceRoot = process.cwd(),
+) {
+  const changedProjects = new Set(
+    [...finalVersions.entries()]
+      .filter(([projectName, metadata]) => {
+        return initialVersions.get(projectName)?.version !== metadata.version;
+      })
+      .map(([projectName]) => projectName),
+  );
+  const updatedChangelogs = [];
+
+  for (const projectName of changedProjects) {
+    const project = finalVersions.get(projectName);
+    const changelogPath = path.join(workspaceRoot, project.root, 'CHANGELOG.md');
+
+    if (!fs.existsSync(changelogPath)) {
+      continue;
+    }
+
+    const dependencyVersions = new Map(
+      (graph.dependencies?.[projectName] || [])
+        .filter(dependency => changedProjects.has(dependency.target))
+        .map(dependency => {
+          const dependencyMetadata = finalVersions.get(dependency.target);
+          return [dependencyMetadata.name, dependencyMetadata.version];
+        }),
+    );
+
+    if (dependencyVersions.size === 0) {
+      continue;
+    }
+
+    const changelog = fs.readFileSync(changelogPath, 'utf8');
+    const updatedChangelog = updateLatestChangelogDependencyVersions(changelog, dependencyVersions);
+
+    if (updatedChangelog !== changelog) {
+      fs.writeFileSync(changelogPath, updatedChangelog);
+      updatedChangelogs.push(path.relative(workspaceRoot, changelogPath));
+    }
+  }
+
+  return updatedChangelogs;
+}
+
 function compareProjects(a, b) {
   return a.root.localeCompare(b.root) || a.name.localeCompare(b.name);
 }
@@ -130,6 +227,7 @@ function runVersionTargets(projects, forwardedArgs, workspaceRoot = process.cwd(
 function main(argv = process.argv.slice(2)) {
   const graph = readProjectGraph();
   const projects = orderDependentsBeforeDependencies(graph);
+  const initialVersions = readProjectVersions(graph);
 
   console.log(`${VERSION_TARGET} target order:`);
   projects.forEach((project, index) => {
@@ -137,6 +235,19 @@ function main(argv = process.argv.slice(2)) {
   });
 
   runVersionTargets(projects, argv);
+
+  // Dependents run before their dependencies. Align the newest changelog entries
+  // after all version targets have produced their final package versions.
+  const finalVersions = readProjectVersions(graph);
+  const updatedChangelogs = updateChangedDependencyVersionsInChangelogs(
+    graph,
+    initialVersions,
+    finalVersions,
+  );
+
+  updatedChangelogs.forEach(changelog => {
+    console.log(`Updated dependency versions in ${changelog}`);
+  });
 }
 
 if (require.main === module) {
@@ -152,5 +263,8 @@ module.exports = {
   getVersionProjects,
   orderDependentsBeforeDependencies,
   readProjectGraph,
+  readProjectVersions,
   runVersionTargets,
+  updateChangedDependencyVersionsInChangelogs,
+  updateLatestChangelogDependencyVersions,
 };

--- a/scripts/run-release-version-targets.test.js
+++ b/scripts/run-release-version-targets.test.js
@@ -6,7 +6,10 @@ const path = require('node:path');
 const test = require('node:test');
 
 const { getReleaseVersionTag } = require('./get-release-version-tag');
-const { orderDependentsBeforeDependencies } = require('./run-release-version-targets');
+const {
+  orderDependentsBeforeDependencies,
+  updateLatestChangelogDependencyVersions,
+} = require('./run-release-version-targets');
 
 const repoRoot = path.resolve(__dirname, '..');
 const runnerPath = path.join(repoRoot, 'scripts/run-release-version-targets.js');
@@ -40,6 +43,33 @@ function readPackageVersion(workspaceRoot, project) {
   return pkg.version;
 }
 
+function runReleaseVersioning(workspaceRoot) {
+  const env = {
+    ...process.env,
+    NX_DAEMON: 'false',
+    PATH: `${path.join(rootNodeModules, '.bin')}${path.delimiter}${process.env.PATH}`,
+  };
+
+  run('node', [runnerPath, '--skipCommit=true', '--baseBranch=main'], {
+    cwd: workspaceRoot,
+    env,
+  });
+}
+
+function assertReleasedProject(workspaceRoot, project) {
+  assert.equal(readPackageVersion(workspaceRoot, project), '1.0.1');
+  run('git', ['rev-parse', `${project}@1.0.1`], { cwd: workspaceRoot });
+}
+
+function assertDependencyVersion(workspaceRoot, project, dependency) {
+  const changelog = fs.readFileSync(
+    path.join(workspaceRoot, 'packages', project, 'CHANGELOG.md'),
+    'utf8',
+  );
+
+  assert.match(changelog, new RegExp(`\\* \`${dependency}\` updated to version \`1\\.0\\.1\``));
+}
+
 function createProject(workspaceRoot, project, dependencies = []) {
   const projectRoot = path.join(workspaceRoot, 'packages', project);
   const dependencyMap = Object.fromEntries(dependencies.map(dependency => [dependency, '*']));
@@ -62,7 +92,6 @@ function createProject(workspaceRoot, project, dependencies = []) {
           preset: 'conventionalcommits',
           tagPrefix: '{projectName}@',
           trackDeps: true,
-          skipProjectChangelog: true,
         },
       },
     },
@@ -71,7 +100,7 @@ function createProject(workspaceRoot, project, dependencies = []) {
   fs.writeFileSync(path.join(projectRoot, 'src/index.js'), `export const name = '${project}';\n`);
 }
 
-function createWorkspace() {
+function createWorkspace(changedProjects = ['leaf']) {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rudder-release-version-test-'));
   const workspaceRoot = path.join(tmpRoot, 'workspace');
 
@@ -118,14 +147,14 @@ function createWorkspace() {
     });
   }
 
-  fs.appendFileSync(
-    path.join(workspaceRoot, 'packages/leaf/src/index.js'),
-    'export const fix = true;\n',
-  );
-  run('git', ['add', 'packages/leaf/src/index.js'], { cwd: workspaceRoot });
-  run('git', ['commit', '--quiet', '-m', 'fix(leaf): patch leaf'], {
-    cwd: workspaceRoot,
-  });
+  for (const project of changedProjects) {
+    const sourcePath = path.join(workspaceRoot, 'packages', project, 'src/index.js');
+    fs.appendFileSync(sourcePath, 'export const fix = true;\n');
+    run('git', ['add', sourcePath], { cwd: workspaceRoot });
+    run('git', ['commit', '--quiet', '-m', `fix(${project}): patch ${project}`], {
+      cwd: workspaceRoot,
+    });
+  }
 
   return {
     workspaceRoot,
@@ -188,28 +217,56 @@ test('does not build a release tag for a project without a version target', () =
   assert.equal(tag, null);
 });
 
+test('updates dependency versions only in the latest changelog release', () => {
+  const changelog = `# Changelog
+
+## [2.0.0](https://example.com/2.0.0)
+
+### Dependency Updates
+
+* \`middle\` updated to version \`1.0.0\`
+
+## [1.0.0](https://example.com/1.0.0)
+
+### Dependency Updates
+
+* \`middle\` updated to version \`0.9.0\`
+`;
+
+  assert.equal(
+    updateLatestChangelogDependencyVersions(changelog, new Map([['middle', '1.0.1']])),
+    changelog.replace(
+      '* `middle` updated to version `1.0.0`',
+      '* `middle` updated to version `1.0.1`',
+    ),
+  );
+});
+
 test('bumps a three-level trackDeps chain with skipCommit tags', () => {
   const fixture = createWorkspace();
 
   try {
-    const env = {
-      ...process.env,
-      NX_DAEMON: 'false',
-      PATH: `${path.join(rootNodeModules, '.bin')}${path.delimiter}${process.env.PATH}`,
-    };
-
-    run('node', [runnerPath, '--skipCommit=true', '--baseBranch=main'], {
-      cwd: fixture.workspaceRoot,
-      env,
-    });
-
-    assert.equal(readPackageVersion(fixture.workspaceRoot, 'parent'), '1.0.1');
-    assert.equal(readPackageVersion(fixture.workspaceRoot, 'middle'), '1.0.1');
-    assert.equal(readPackageVersion(fixture.workspaceRoot, 'leaf'), '1.0.1');
-
+    runReleaseVersioning(fixture.workspaceRoot);
     for (const project of ['parent', 'middle', 'leaf']) {
-      run('git', ['rev-parse', `${project}@1.0.1`], { cwd: fixture.workspaceRoot });
+      assertReleasedProject(fixture.workspaceRoot, project);
     }
+    assertDependencyVersion(fixture.workspaceRoot, 'parent', 'middle');
+    assertDependencyVersion(fixture.workspaceRoot, 'middle', 'leaf');
+  } finally {
+    fixture.remove();
+  }
+});
+
+test('uses final versions for dependencies with direct changes', () => {
+  const fixture = createWorkspace(['middle', 'leaf']);
+
+  try {
+    runReleaseVersioning(fixture.workspaceRoot);
+    for (const project of ['parent', 'middle', 'leaf']) {
+      assertReleasedProject(fixture.workspaceRoot, project);
+    }
+    assertDependencyVersion(fixture.workspaceRoot, 'parent', 'middle');
+    assertDependencyVersion(fixture.workspaceRoot, 'middle', 'leaf');
   } finally {
     fixture.remove();
   }


### PR DESCRIPTION
## PR Description

Preserve the dependents-first release order that fixes transitive package bumps. After all version targets finish, update dependency entries in each new changelog section with the final package versions from the same release.

The update is limited to changed versioned projects, their changed direct dependencies, and the newest changelog release section. Older release notes remain unchanged.

Regression coverage now verifies:

- transitive-only version bumps, tags, and changelog dependency versions
- dependencies with direct changes, which previously produced stale changelog versions
- older changelog sections remain unchanged

### Validation

- `npx --yes node@24 --test scripts/run-release-version-targets.test.js`
- `npx prettier --check scripts/run-release-version-targets.js scripts/run-release-version-targets.test.js`
- `BASE_REF=origin/develop npm run check:lint:ci`
- `git diff --check`

## Linear task (optional)

[SDK-5351](https://linear.app/rudderstack/issue/SDK-5351/fix-stale-dependency-versions-in-generated-js-sdk-changelogs)

## Cross Browser Tests

Not applicable. This change only affects release tooling.

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

Not applicable. The real JSCutlery release fixture covers this change.

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release versioning now captures package versions before and after release commands.
  * Updated dependency versions are automatically synchronized in the latest changelog release entries.
  * Release reports identify the changelog files that were updated.

* **Bug Fixes**
  * Improved validation for package names and version values during release processing.
  * Changelog updates now support full dependency chains and projects with direct changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->