### PR TITLE
fix(analytics-js): skip no-op server-side cookie writes

### DIFF
--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2683,6 +2683,59 @@ describe('User session manager', () => {
         expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
       });
 
+      // Storage migration rewrites the cookie client side. If the guard then skips, the cookie
+      // stays a script written cookie for good, and Safari ITP caps it at 7 days - which is the
+      // exact outcome server-side cookies exist to avoid.
+      it('should make a request for a cookie that storage migration rewrote', () => {
+        // Only stub the migration extension point. The store uses the same plugins manager
+        // for encryption, so a blanket mock would write the cookie unencrypted.
+        const originalInvokeSingle = defaultPluginsManager.invokeSingle.bind(defaultPluginsManager);
+        const migrateSpy = jest
+          .spyOn(defaultPluginsManager, 'invokeSingle')
+          .mockImplementation((extPoint?: string, ...args: any[]) =>
+            extPoint === 'storage.migrate'
+              ? dummyAnonymousId
+              : originalInvokeSingle(extPoint, ...args),
+          );
+        state.storage.migrate.value = true;
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        // Migration writes the value into the cookie client side
+        userSessionManager.migrateStorageIfNeeded(undefined, ['anonymousId']);
+        expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toEqual(dummyAnonymousId);
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+        migrateSpy.mockRestore();
+      });
+
+      // With two writes in flight for one key, the earlier response clears the shared
+      // in-progress flag while the later one is still outstanding. Skipping on the strength
+      // of that flag would let the later write land last and diverge the cookie from state.
+      it('should keep requesting after an earlier response clears the in-progress flag', () => {
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        state.session.anonymousId.value = 'pending_anonymousId';
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+        setServerSideCookiesSpy.mockClear();
+
+        // An earlier response lands and clears the shared flag, even though a write is
+        // still outstanding for this key
+        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = false;
+
+        // State returns to the value the cookie still holds
+        state.session.anonymousId.value = dummyAnonymousId;
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
+      });
+
       it('should make a request if the cookie does not exist yet', () => {
         state.session.anonymousId.value = dummyAnonymousId;
         const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2630,6 +2630,10 @@ describe('User session manager', () => {
       });
 
       afterEach(() => {
+        // The store is a shared singleton, so any override made here would otherwise leak
+        // into later tests. Drop them before handing the timers back.
+        delete (clientDataStoreCookie as Partial<Store>).set;
+        delete (clientDataStoreCookie as Partial<Store>).remove;
         jest.useRealTimers();
       });
 
@@ -2646,6 +2650,20 @@ describe('User session manager', () => {
 
       it('should make a request if the persisted value is different', () => {
         clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, 'stale_anonymousId');
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+      });
+
+      // An A -> B -> A transition: the B request is still pending when the value reverts to A.
+      // Skipping here would let B land afterwards, leaving the cookie and the state divergent.
+      it('should make a request if one is already pending for the same key', () => {
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
+        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = true;
         state.session.anonymousId.value = dummyAnonymousId;
         const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
 

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2616,6 +2616,91 @@ describe('User session manager', () => {
         done();
       }, 1000);
     });
+
+    describe('redundant server-side cookie requests', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+        // Earlier tests replace these on the shared store instance and never restore them.
+        // Drop the own properties so the real prototype implementations are used again.
+        delete (clientDataStoreCookie as Partial<Store>).set;
+        delete (clientDataStoreCookie as Partial<Store>).remove;
+        state.serverCookies.isEnabledServerSideCookies.value = true;
+        state.storage.entries.value = entriesWithOnlyCookieStorage;
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it('should not make a request if the persisted value is already up to date', () => {
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).not.toHaveBeenCalled();
+      });
+
+      it('should make a request if the persisted value is different', () => {
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, 'stale_anonymousId');
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+      });
+
+      it('should make a request if the cookie does not exist yet', () => {
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+      });
+
+      // The session cookie must keep syncing, otherwise the persisted expiresAt goes stale and
+      // the next event would start a new session while the user is still active.
+      it('should still make a request for the session info as expiresAt changes', () => {
+        const persistedSessionInfo = {
+          id: 1234567890,
+          expiresAt: 1234567890 + DEFAULT_SESSION_TIMEOUT_MS,
+          autoTrack: true,
+          timeout: DEFAULT_SESSION_TIMEOUT_MS,
+        };
+        clientDataStoreCookie.set(COOKIE_KEYS.sessionInfo, persistedSessionInfo);
+        state.session.sessionInfo.value = {
+          ...persistedSessionInfo,
+          expiresAt: persistedSessionInfo.expiresAt + 60 * 1000,
+        };
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('sessionInfo');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+      });
+
+      it('should not skip the client-side write when server-side cookies are disabled', () => {
+        state.serverCookies.isEnabledServerSideCookies.value = false;
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
+        clientDataStoreCookie.set = jest.fn();
+        state.session.anonymousId.value = dummyAnonymousId;
+
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        expect(clientDataStoreCookie.set).toHaveBeenCalledWith(
+          COOKIE_KEYS.anonymousId,
+          dummyAnonymousId,
+        );
+      });
+    });
   });
 
   describe('setServerSideCookies', () => {

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2659,18 +2659,28 @@ describe('User session manager', () => {
         expect(setServerSideCookiesSpy).toHaveBeenCalled();
       });
 
-      // An A -> B -> A transition: the B request is still pending when the value reverts to A.
-      // Skipping here would let B land afterwards, leaving the cookie and the state divergent.
+      // A -> B -> A, driven through the real debounced path. The B request is still in flight
+      // when the value reverts to A, which is what the cookie already holds. Skipping there
+      // would leave B as the last write to land, diverging the cookie from the state.
       it('should make a request if one is already pending for the same key', () => {
         clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
-        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = true;
-        state.session.anonymousId.value = dummyAnonymousId;
         const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
 
+        // B: let the debounce elapse so the request is genuinely in flight and unresolved
+        state.session.anonymousId.value = 'pending_anonymousId';
         userSessionManager.syncValueToStorage('anonymousId');
         jest.advanceTimersByTime(1000);
 
-        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
+        expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(true);
+        setServerSideCookiesSpy.mockClear();
+
+        // Back to A while B is still unresolved
+        state.session.anonymousId.value = dummyAnonymousId;
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
       });
 
       it('should make a request if the cookie does not exist yet', () => {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -95,6 +95,13 @@ class UserSessionManager implements IUserSessionManager {
    * Tracks whether a server-side cookie setting request is in progress or not.
    */
   serverSideCookiesRequestInProgress: Record<UserSessionKey, boolean>;
+  /**
+   * Tracks the keys whose cookie the SDK has written during this page load, either
+   * client-side or through the data service. Once set, the value in the cookie can no
+   * longer be assumed to have been set by the data service, so the equal-value skip in
+   * syncValueToStorage no longer applies. Never cleared.
+   */
+  serverSideCookieSyncRequired: Record<UserSessionKey, boolean>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -111,6 +118,7 @@ class UserSessionManager implements IUserSessionManager {
     this.onError = this.onError.bind(this);
     this.serverSideCookieDebounceFuncs = {} as Record<UserSessionKey, number>;
     this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
+    this.serverSideCookieSyncRequired = {} as Record<UserSessionKey, boolean>;
   }
 
   /**
@@ -225,6 +233,8 @@ class UserSessionManager implements IUserSessionManager {
             const value = store.get(COOKIE_KEYS[key]);
             if (isDefinedNotNullAndNotEmptyString(value)) {
               curStore.set(COOKIE_KEYS[key], value);
+              // Written client-side, so it still needs syncing to the data service
+              this.serverSideCookieSyncRequired[key as UserSessionKey] = true;
             }
 
             store.remove(COOKIE_KEYS[key]);
@@ -273,6 +283,8 @@ class UserSessionManager implements IUserSessionManager {
         // migration failed
         if (!isNullOrUndefined(migratedVal)) {
           store.set(storageEntry, migratedVal);
+          // Written client-side, so it still needs syncing to the data service
+          this.serverSideCookieSyncRequired[storageKey as UserSessionKey] = true;
         }
       });
     });
@@ -574,11 +586,13 @@ class UserSessionManager implements IUserSessionManager {
           // Skip the request if the cookie already holds this exact value.
           // The cookie is set with a long max age, so it needs no periodic renewal.
           //
-          // Only safe while nothing is pending for this key. A queued or in-flight request
-          // may still write a different value, so skipping then would leave the cookie and
-          // the state divergent with nothing to reconcile them.
+          // Only safe before the SDK has written this cookie itself during this page load.
+          // Afterwards the stored value may have been written client-side (by storage
+          // migration or the fallback path), which Safari ITP caps at 7 days, or a write may
+          // still be pending, so the value cannot be assumed to have come from the data
+          // service. This flag is never cleared, so it cannot go stale.
           if (
-            !this.serverSideCookiesRequestInProgress[sessionKey] &&
+            !this.serverSideCookieSyncRequired[sessionKey] &&
             this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)
           ) {
             return;
@@ -586,6 +600,7 @@ class UserSessionManager implements IUserSessionManager {
 
           // Mark the requests as in progress.
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
+          this.serverSideCookieSyncRequired[sessionKey] = true;
 
           if (this.serverSideCookieDebounceFuncs[sessionKey]) {
             (globalThis as typeof window).clearTimeout(

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -540,7 +540,7 @@ class UserSessionManager implements IUserSessionManager {
    * @param cookieValue value that is about to be written
    * @returns true if the persisted value is identical to the value to be written
    */
-  isValueAlreadyPersisted(
+  private isValueAlreadyPersisted(
     store: IStore | undefined,
     cookieName: string,
     cookieValue: CookieValue,
@@ -573,7 +573,14 @@ class UserSessionManager implements IUserSessionManager {
         ) {
           // Skip the request if the cookie already holds this exact value.
           // The cookie is set with a long max age, so it needs no periodic renewal.
-          if (this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)) {
+          //
+          // Only safe while nothing is pending for this key. A queued or in-flight request
+          // may still write a different value, so skipping then would leave the cookie and
+          // the state divergent with nothing to reconcile them.
+          if (
+            !this.serverSideCookiesRequestInProgress[sessionKey] &&
+            this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)
+          ) {
             return;
           }
 

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -534,6 +534,24 @@ class UserSessionManager implements IUserSessionManager {
   }
 
   /**
+   * A function to check whether the value is already persisted in the storage as is
+   * @param store store to read the persisted value from
+   * @param cookieName name of the cookie
+   * @param cookieValue value that is about to be written
+   * @returns true if the persisted value is identical to the value to be written
+   */
+  isValueAlreadyPersisted(
+    store: IStore | undefined,
+    cookieName: string,
+    cookieValue: CookieValue,
+  ): boolean {
+    return (
+      stringifyWithoutCircular(store?.get(cookieName), false, []) ===
+      stringifyWithoutCircular(cookieValue, false, [])
+    );
+  }
+
+  /**
    * A function to sync values in storage
    * @param sessionKey
    */
@@ -553,6 +571,12 @@ class UserSessionManager implements IUserSessionManager {
           state.serverCookies.isEnabledServerSideCookies.value &&
           storageType === COOKIE_STORAGE
         ) {
+          // Skip the request if the cookie already holds this exact value.
+          // The cookie is set with a long max age, so it needs no periodic renewal.
+          if (this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)) {
+            return;
+          }
+
           // Mark the requests as in progress.
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
 

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -101,7 +101,7 @@ class UserSessionManager implements IUserSessionManager {
    * longer be assumed to have been set by the data service, so the equal-value skip in
    * syncValueToStorage no longer applies. Never cleared.
    */
-  serverSideCookieSyncRequired: Record<UserSessionKey, boolean>;
+  cookieWrittenInPageLoad: Record<UserSessionKey, boolean>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -118,7 +118,7 @@ class UserSessionManager implements IUserSessionManager {
     this.onError = this.onError.bind(this);
     this.serverSideCookieDebounceFuncs = {} as Record<UserSessionKey, number>;
     this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
-    this.serverSideCookieSyncRequired = {} as Record<UserSessionKey, boolean>;
+    this.cookieWrittenInPageLoad = {} as Record<UserSessionKey, boolean>;
   }
 
   /**
@@ -234,7 +234,7 @@ class UserSessionManager implements IUserSessionManager {
             if (isDefinedNotNullAndNotEmptyString(value)) {
               curStore.set(COOKIE_KEYS[key], value);
               // Written client-side, so it still needs syncing to the data service
-              this.serverSideCookieSyncRequired[key as UserSessionKey] = true;
+              this.cookieWrittenInPageLoad[key as UserSessionKey] = true;
             }
 
             store.remove(COOKIE_KEYS[key]);
@@ -284,7 +284,7 @@ class UserSessionManager implements IUserSessionManager {
         if (!isNullOrUndefined(migratedVal)) {
           store.set(storageEntry, migratedVal);
           // Written client-side, so it still needs syncing to the data service
-          this.serverSideCookieSyncRequired[storageKey as UserSessionKey] = true;
+          this.cookieWrittenInPageLoad[storageKey as UserSessionKey] = true;
         }
       });
     });
@@ -592,7 +592,7 @@ class UserSessionManager implements IUserSessionManager {
           // still be pending, so the value cannot be assumed to have come from the data
           // service. This flag is never cleared, so it cannot go stale.
           if (
-            !this.serverSideCookieSyncRequired[sessionKey] &&
+            !this.cookieWrittenInPageLoad[sessionKey] &&
             this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)
           ) {
             return;
@@ -600,7 +600,7 @@ class UserSessionManager implements IUserSessionManager {
 
           // Mark the requests as in progress.
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
-          this.serverSideCookieSyncRequired[sessionKey] = true;
+          this.cookieWrittenInPageLoad[sessionKey] = true;
 
           if (this.serverSideCookieDebounceFuncs[sessionKey]) {
             (globalThis as typeof window).clearTimeout(


### PR DESCRIPTION
## PR Description

With `useServerSideCookies: true`, every cookie-backed session key holding a value fires a `POST /rsaRequest` on **each page load** — typically four (`rl_anonymous_id`, `rl_session`, `rl_page_init_referrer`, `rl_page_init_referring_domain`). Three of those four send a value byte-identical to the cookie already stored.

`registerEffects()` registers one `effect()` per session key and they all run on init, so nothing distinguishes "this value changed" from "this value is exactly what is already persisted". This is the core of [#2967](https://github.com/rudderlabs/rudder-sdk-js/issues/2967), where the reporter turned the feature off because four extra requests per page load was too high a price for the Safari ITP workaround.

### The change

A guard at the top of the server-side-cookie branch in `syncValueToStorage`:

```ts
// Skip the request if the cookie already holds this exact value.
// The cookie is set with a long max age, so it needs no periodic renewal.
if (this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)) {
  return;
}
```

`isValueAlreadyPersisted` reuses the same `stringifyWithoutCircular` comparison the response verification already performs in `setServerSideCookies`. Values are compared **after decryption**, so the check is unaffected by which encryption version a cookie was written with.

The comparison fails safe: string equality can only hold when the content is genuinely identical, so a differing key order causes an *unnecessary write* rather than a missed one. There is no input for which this skips a write it should have made.

### Why the redundant writes are not worth keeping

They were previously justified as renewing the cookie's server-issued TTL. `DEFAULT_COOKIE_MAX_AGE_MS` is **1 year**, and a genuine first-party cookie delivered via `Set-Cookie` is not subject to Safari ITP's 7-day cap — that cap applies to script-written cookies and CNAME-cloaked responses. Re-issuing a 1-year cookie on every page load buys nothing.

### Effect

Repeat page load: **4 requests → 1**. `rl_session` still writes every time, because `expiresAt` genuinely moves — which is deliberate and load-bearing. `refreshSession()` reads `sessionInfo` back from storage on every event and feeds it to `hasSessionExpired`; if the persisted `expiresAt` ever went stale, the next event would mint a **new session id** while the user was still active. A test pins that behaviour.

A first-time visitor still writes all four keys since they are genuinely new — that case is covered by the batching work in SDK-4981, so the two changes remain complementary.

**Out of scope:** throttling the per-event `sessionInfo` sync, and any new persisted state. Both are recorded on the Linear task with the reasoning.

## Linear task (optional)

[SDK-5409](https://linear.app/rudderstack/issue/SDK-5409/suppress-redundant-server-side-cookie-requests-in-the-js-sdk)

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

Not yet run for this change — the logic is storage-comparison only with no browser-specific API surface, but this is left unchecked deliberately rather than assumed.

## Sanity Suite

- [ ] All sanity suite test cases pass locally

Not yet run.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

## Test plan

Five new tests in a `redundant server-side cookie requests` block, written before the implementation:

- skips the request when the persisted value is already up to date
- still requests when the persisted value differs
- still requests when no cookie exists yet
- **still requests for `sessionInfo` as `expiresAt` changes** — the session-continuity regression guard
- does not skip the client-side write when server-side cookies are disabled

Verified locally:

- `userSessionManager` suite — 210 passed, 1 skipped
- `nx affected -t test` (the pre-commit gate) — passed across all 3 affected projects
- `check:size:build` and `check:size:json` — all bundles within limits
- `eslint` on changed files — 0 errors (2 warnings, both pre-existing)
- `tsc --noEmit` — no errors in the changed files

## Note for reviewers

The new tests restore `clientDataStoreCookie.set`/`.remove` in their `beforeEach`. Earlier tests in this file assign `jest.fn()` to those on the **shared store singleton** and never restore them, so any later test that tries to seed a real cookie silently writes nothing. That cost me a false green before I caught it. Worked around locally rather than refactoring the file — worth a separate cleanup.

Also deliberate: skipping does **not** cancel an already-scheduled debounce timer. If a value flips back to the persisted one inside the 10 ms window, that pending request still fires — harmless and rare. Cancelling it correctly also requires clearing `serverSideCookiesRequestInProgress`, which belongs with the separate `reset()`-race bug (removal path at `UserSessionManager.ts:588` clears neither), tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented server-side cookie synchronization from being skipped when a matching request is already pending or when the cookie was rewritten during storage migration.
  * Preserved synchronization after an earlier response clears the in-progress state, improving consistency across repeated updates.

* **Tests**
  * Added coverage for pending requests, storage migration, repeated synchronization, and cleanup of shared test state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->