### PR TITLE
fix(analytics-js): serialise server-side cookie writes per key

### DIFF
--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2683,6 +2683,59 @@ describe('User session manager', () => {
         expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
       });
 
+      // Storage migration rewrites the cookie client side. If the guard then skips, the cookie
+      // stays a script written cookie for good, and Safari ITP caps it at 7 days - which is the
+      // exact outcome server-side cookies exist to avoid.
+      it('should make a request for a cookie that storage migration rewrote', () => {
+        // Only stub the migration extension point. The store uses the same plugins manager
+        // for encryption, so a blanket mock would write the cookie unencrypted.
+        const originalInvokeSingle = defaultPluginsManager.invokeSingle.bind(defaultPluginsManager);
+        const migrateSpy = jest
+          .spyOn(defaultPluginsManager, 'invokeSingle')
+          .mockImplementation((extPoint?: string, ...args: any[]) =>
+            extPoint === 'storage.migrate'
+              ? dummyAnonymousId
+              : originalInvokeSingle(extPoint, ...args),
+          );
+        state.storage.migrate.value = true;
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        // Migration writes the value into the cookie client side
+        userSessionManager.migrateStorageIfNeeded(undefined, ['anonymousId']);
+        expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toEqual(dummyAnonymousId);
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+        migrateSpy.mockRestore();
+      });
+
+      // With two writes in flight for one key, the earlier response clears the shared
+      // in-progress flag while the later one is still outstanding. Skipping on the strength
+      // of that flag would let the later write land last and diverge the cookie from state.
+      it('should keep requesting after an earlier response clears the in-progress flag', () => {
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        state.session.anonymousId.value = 'pending_anonymousId';
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+        setServerSideCookiesSpy.mockClear();
+
+        // An earlier response lands and clears the shared flag, even though a write is
+        // still outstanding for this key
+        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = false;
+
+        // State returns to the value the cookie still holds
+        state.session.anonymousId.value = dummyAnonymousId;
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
+      });
+
       it('should make a request if the cookie does not exist yet', () => {
         state.session.anonymousId.value = dummyAnonymousId;
         const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2630,6 +2630,10 @@ describe('User session manager', () => {
       });
 
       afterEach(() => {
+        // The store is a shared singleton, so any override made here would otherwise leak
+        // into later tests. Drop them before handing the timers back.
+        delete (clientDataStoreCookie as Partial<Store>).set;
+        delete (clientDataStoreCookie as Partial<Store>).remove;
         jest.useRealTimers();
       });
 
@@ -2646,6 +2650,20 @@ describe('User session manager', () => {
 
       it('should make a request if the persisted value is different', () => {
         clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, 'stale_anonymousId');
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+      });
+
+      // An A -> B -> A transition: the B request is still pending when the value reverts to A.
+      // Skipping here would let B land afterwards, leaving the cookie and the state divergent.
+      it('should make a request if one is already pending for the same key', () => {
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
+        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = true;
         state.session.anonymousId.value = dummyAnonymousId;
         const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
 

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2616,6 +2616,91 @@ describe('User session manager', () => {
         done();
       }, 1000);
     });
+
+    describe('redundant server-side cookie requests', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+        // Earlier tests replace these on the shared store instance and never restore them.
+        // Drop the own properties so the real prototype implementations are used again.
+        delete (clientDataStoreCookie as Partial<Store>).set;
+        delete (clientDataStoreCookie as Partial<Store>).remove;
+        state.serverCookies.isEnabledServerSideCookies.value = true;
+        state.storage.entries.value = entriesWithOnlyCookieStorage;
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it('should not make a request if the persisted value is already up to date', () => {
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).not.toHaveBeenCalled();
+      });
+
+      it('should make a request if the persisted value is different', () => {
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, 'stale_anonymousId');
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+      });
+
+      it('should make a request if the cookie does not exist yet', () => {
+        state.session.anonymousId.value = dummyAnonymousId;
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+      });
+
+      // The session cookie must keep syncing, otherwise the persisted expiresAt goes stale and
+      // the next event would start a new session while the user is still active.
+      it('should still make a request for the session info as expiresAt changes', () => {
+        const persistedSessionInfo = {
+          id: 1234567890,
+          expiresAt: 1234567890 + DEFAULT_SESSION_TIMEOUT_MS,
+          autoTrack: true,
+          timeout: DEFAULT_SESSION_TIMEOUT_MS,
+        };
+        clientDataStoreCookie.set(COOKIE_KEYS.sessionInfo, persistedSessionInfo);
+        state.session.sessionInfo.value = {
+          ...persistedSessionInfo,
+          expiresAt: persistedSessionInfo.expiresAt + 60 * 1000,
+        };
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        userSessionManager.syncValueToStorage('sessionInfo');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+      });
+
+      it('should not skip the client-side write when server-side cookies are disabled', () => {
+        state.serverCookies.isEnabledServerSideCookies.value = false;
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
+        clientDataStoreCookie.set = jest.fn();
+        state.session.anonymousId.value = dummyAnonymousId;
+
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        expect(clientDataStoreCookie.set).toHaveBeenCalledWith(
+          COOKIE_KEYS.anonymousId,
+          dummyAnonymousId,
+        );
+      });
+    });
   });
 
   describe('setServerSideCookies', () => {

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2673,14 +2673,14 @@ describe('User session manager', () => {
 
         expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
         expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(true);
-        setServerSideCookiesSpy.mockClear();
 
-        // Back to A while B is still unresolved
+        // Back to A while B is still unresolved. The write must be held for reissue rather
+        // than skipped; it is not sent now, because concurrent writes can settle out of order.
         state.session.anonymousId.value = dummyAnonymousId;
         userSessionManager.syncValueToStorage('anonymousId');
         jest.advanceTimersByTime(1000);
 
-        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
+        expect(userSessionManager.serverSideCookiesResyncPending.anonymousId).toBe(true);
       });
 
       // Storage migration rewrites the cookie client side. If the guard then skips, the cookie
@@ -2722,18 +2722,19 @@ describe('User session manager', () => {
         state.session.anonymousId.value = 'pending_anonymousId';
         userSessionManager.syncValueToStorage('anonymousId');
         jest.advanceTimersByTime(1000);
-        setServerSideCookiesSpy.mockClear();
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
 
         // An earlier response lands and clears the shared flag, even though a write is
         // still outstanding for this key
         userSessionManager.serverSideCookiesRequestInProgress.anonymousId = false;
 
-        // State returns to the value the cookie still holds
+        // State returns to the value the cookie still holds. The guard must not skip, so
+        // the write is held for reissue once the outstanding response lands.
         state.session.anonymousId.value = dummyAnonymousId;
         userSessionManager.syncValueToStorage('anonymousId');
         jest.advanceTimersByTime(1000);
 
-        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
+        expect(userSessionManager.serverSideCookiesResyncPending.anonymousId).toBe(true);
       });
 
       it('should make a request if the cookie does not exist yet', () => {
@@ -2780,6 +2781,112 @@ describe('User session manager', () => {
           COOKIE_KEYS.anonymousId,
           dummyAnonymousId,
         );
+      });
+    });
+
+    describe('serialised server-side cookie writes', () => {
+      let capturedCallbacks: any[];
+
+      beforeEach(() => {
+        jest.useFakeTimers();
+        delete (clientDataStoreCookie as Partial<Store>).set;
+        delete (clientDataStoreCookie as Partial<Store>).remove;
+        state.serverCookies.isEnabledServerSideCookies.value = true;
+        state.storage.entries.value = entriesWithOnlyCookieStorage;
+        state.serverCookies.dataServiceUrl.value = 'https://dummy.dataplane.host.com/rsaRequest';
+        capturedCallbacks = [];
+        // Hold the response so the request stays genuinely in flight
+        userSessionManager.makeRequestToSetCookie = jest.fn((_data: any, cb: any) => {
+          capturedCallbacks.push(cb);
+        });
+      });
+
+      afterEach(() => {
+        delete (clientDataStoreCookie as Partial<Store>).set;
+        delete (clientDataStoreCookie as Partial<Store>).remove;
+        jest.useRealTimers();
+      });
+
+      const respond = (index: number) => capturedCallbacks[index]?.(null, { xhr: { status: 200 } });
+
+      it('should not issue a second request while one is in flight for the same key', () => {
+        state.session.anonymousId.value = 'value_b';
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(userSessionManager.makeRequestToSetCookie).toHaveBeenCalledTimes(1);
+
+        state.session.anonymousId.value = 'value_c';
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(userSessionManager.makeRequestToSetCookie).toHaveBeenCalledTimes(1);
+      });
+
+      it('should issue the held back write once the in-flight response lands', () => {
+        state.session.anonymousId.value = 'value_b';
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        state.session.anonymousId.value = 'value_c';
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        // Held back while the first request is outstanding
+        expect(userSessionManager.makeRequestToSetCookie).toHaveBeenCalledTimes(1);
+
+        respond(0);
+        jest.advanceTimersByTime(1000);
+
+        expect(userSessionManager.makeRequestToSetCookie).toHaveBeenCalledTimes(2);
+        expect(state.session.anonymousId.value).toEqual('value_c');
+      });
+
+      it('should keep the request in progress flag set while a resync is pending', () => {
+        state.session.anonymousId.value = 'value_b';
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        state.session.anonymousId.value = 'value_c';
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        respond(0);
+
+        expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(true);
+      });
+
+      it('should not resurrect a removed cookie from a queued write', () => {
+        state.session.anonymousId.value = 'value_b';
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        // Cleared before the debounce fires
+        state.session.anonymousId.value = '';
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        jest.advanceTimersByTime(1000);
+
+        expect(userSessionManager.makeRequestToSetCookie).not.toHaveBeenCalled();
+        expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toBeNull();
+        expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(false);
+      });
+
+      it('should re-apply a removal that happened while a request was in flight', () => {
+        state.session.anonymousId.value = 'value_b';
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(userSessionManager.makeRequestToSetCookie).toHaveBeenCalledTimes(1);
+
+        // Cleared while the request is still outstanding
+        state.session.anonymousId.value = '';
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        // The outstanding response lands and the server sets the cookie
+        clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, 'value_b');
+        respond(0);
+        jest.advanceTimersByTime(1000);
+
+        expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toBeNull();
       });
     });
   });

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2659,18 +2659,28 @@ describe('User session manager', () => {
         expect(setServerSideCookiesSpy).toHaveBeenCalled();
       });
 
-      // An A -> B -> A transition: the B request is still pending when the value reverts to A.
-      // Skipping here would let B land afterwards, leaving the cookie and the state divergent.
+      // A -> B -> A, driven through the real debounced path. The B request is still in flight
+      // when the value reverts to A, which is what the cookie already holds. Skipping there
+      // would leave B as the last write to land, diverging the cookie from the state.
       it('should make a request if one is already pending for the same key', () => {
         clientDataStoreCookie.set(COOKIE_KEYS.anonymousId, dummyAnonymousId);
-        userSessionManager.serverSideCookiesRequestInProgress.anonymousId = true;
-        state.session.anonymousId.value = dummyAnonymousId;
         const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
 
+        // B: let the debounce elapse so the request is genuinely in flight and unresolved
+        state.session.anonymousId.value = 'pending_anonymousId';
         userSessionManager.syncValueToStorage('anonymousId');
         jest.advanceTimersByTime(1000);
 
-        expect(setServerSideCookiesSpy).toHaveBeenCalled();
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
+        expect(userSessionManager.serverSideCookiesRequestInProgress.anonymousId).toBe(true);
+        setServerSideCookiesSpy.mockClear();
+
+        // Back to A while B is still unresolved
+        state.session.anonymousId.value = dummyAnonymousId;
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
       });
 
       it('should make a request if the cookie does not exist yet', () => {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -95,6 +95,13 @@ class UserSessionManager implements IUserSessionManager {
    * Tracks whether a server-side cookie setting request is in progress or not.
    */
   serverSideCookiesRequestInProgress: Record<UserSessionKey, boolean>;
+  /**
+   * Tracks the keys whose cookie the SDK has written during this page load, either
+   * client-side or through the data service. Once set, the value in the cookie can no
+   * longer be assumed to have been set by the data service, so the equal-value skip in
+   * syncValueToStorage no longer applies. Never cleared.
+   */
+  serverSideCookieSyncRequired: Record<UserSessionKey, boolean>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -111,6 +118,7 @@ class UserSessionManager implements IUserSessionManager {
     this.onError = this.onError.bind(this);
     this.serverSideCookieDebounceFuncs = {} as Record<UserSessionKey, number>;
     this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
+    this.serverSideCookieSyncRequired = {} as Record<UserSessionKey, boolean>;
   }
 
   /**
@@ -225,6 +233,8 @@ class UserSessionManager implements IUserSessionManager {
             const value = store.get(COOKIE_KEYS[key]);
             if (isDefinedNotNullAndNotEmptyString(value)) {
               curStore.set(COOKIE_KEYS[key], value);
+              // Written client-side, so it still needs syncing to the data service
+              this.serverSideCookieSyncRequired[key as UserSessionKey] = true;
             }
 
             store.remove(COOKIE_KEYS[key]);
@@ -273,6 +283,8 @@ class UserSessionManager implements IUserSessionManager {
         // migration failed
         if (!isNullOrUndefined(migratedVal)) {
           store.set(storageEntry, migratedVal);
+          // Written client-side, so it still needs syncing to the data service
+          this.serverSideCookieSyncRequired[storageKey as UserSessionKey] = true;
         }
       });
     });
@@ -574,11 +586,13 @@ class UserSessionManager implements IUserSessionManager {
           // Skip the request if the cookie already holds this exact value.
           // The cookie is set with a long max age, so it needs no periodic renewal.
           //
-          // Only safe while nothing is pending for this key. A queued or in-flight request
-          // may still write a different value, so skipping then would leave the cookie and
-          // the state divergent with nothing to reconcile them.
+          // Only safe before the SDK has written this cookie itself during this page load.
+          // Afterwards the stored value may have been written client-side (by storage
+          // migration or the fallback path), which Safari ITP caps at 7 days, or a write may
+          // still be pending, so the value cannot be assumed to have come from the data
+          // service. This flag is never cleared, so it cannot go stale.
           if (
-            !this.serverSideCookiesRequestInProgress[sessionKey] &&
+            !this.serverSideCookieSyncRequired[sessionKey] &&
             this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)
           ) {
             return;
@@ -586,6 +600,7 @@ class UserSessionManager implements IUserSessionManager {
 
           // Mark the requests as in progress.
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
+          this.serverSideCookieSyncRequired[sessionKey] = true;
 
           if (this.serverSideCookieDebounceFuncs[sessionKey]) {
             (globalThis as typeof window).clearTimeout(

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -102,6 +102,17 @@ class UserSessionManager implements IUserSessionManager {
    * syncValueToStorage no longer applies. Never cleared.
    */
   cookieWrittenInPageLoad: Record<UserSessionKey, boolean>;
+  /**
+   * Tracks the keys with a request actually on the wire, as opposed to one that is only
+   * queued behind the debounce. Only one request per key may be in flight, otherwise the
+   * responses can be applied out of order and leave the cookie on an older value.
+   */
+  serverSideCookiesInFlight: Record<UserSessionKey, boolean>;
+  /**
+   * Tracks the keys whose value changed while a request was in flight. The write is held
+   * back and reissued against the then current value once the response lands.
+   */
+  serverSideCookiesResyncPending: Record<UserSessionKey, boolean>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -119,6 +130,8 @@ class UserSessionManager implements IUserSessionManager {
     this.serverSideCookieDebounceFuncs = {} as Record<UserSessionKey, number>;
     this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
     this.cookieWrittenInPageLoad = {} as Record<UserSessionKey, boolean>;
+    this.serverSideCookiesInFlight = {} as Record<UserSessionKey, boolean>;
+    this.serverSideCookiesResyncPending = {} as Record<UserSessionKey, boolean>;
   }
 
   /**
@@ -466,9 +479,18 @@ class UserSessionManager implements IUserSessionManager {
       );
     });
 
-    const clearInProgressFlags = () => {
+    // Release each key once its request is done. A value that changed while the request was
+    // in flight was held back rather than sent concurrently, so reissue it now against the
+    // current value. That also re-applies a removal that happened mid-flight.
+    const completeRequest = () => {
       sessionKeys.forEach((sessionKey: UserSessionKey) => {
-        this.serverSideCookiesRequestInProgress[sessionKey] = false;
+        this.serverSideCookiesInFlight[sessionKey] = false;
+        if (this.serverSideCookiesResyncPending[sessionKey]) {
+          this.serverSideCookiesResyncPending[sessionKey] = false;
+          this.syncValueToStorage(sessionKey);
+        } else {
+          this.serverSideCookiesRequestInProgress[sessionKey] = false;
+        }
       });
     };
 
@@ -496,9 +518,6 @@ class UserSessionManager implements IUserSessionManager {
       if (encryptedCookieData.length > 0) {
         // make request to data service to set the cookie from server side
         this.makeRequestToSetCookie(encryptedCookieData, (res, details) => {
-          // Mark the cookie req status as done
-          clearInProgressFlags();
-
           if (details?.xhr?.status === 200) {
             getCurrentCookieValuesFromState().forEach(cData => {
               const originalCookieVal = originalCookieValues[cData.name];
@@ -525,12 +544,16 @@ class UserSessionManager implements IUserSessionManager {
             this.logger.error(DATA_SERVER_REQUEST_FAIL_ERROR(details?.xhr?.status));
             setCookiesClientSide();
           }
+
+          // Mark the cookie req status as done, after any client-side correction above, so
+          // that a resync reissued here sees the settled cookie value
+          completeRequest();
         });
       } else {
         setCookiesClientSide();
 
         // Mark the cookie req status as done
-        clearInProgressFlags();
+        completeRequest();
       }
     } catch (e) {
       this.onError(
@@ -541,7 +564,7 @@ class UserSessionManager implements IUserSessionManager {
       setCookiesClientSide();
 
       // Mark the cookie req status as done
-      clearInProgressFlags();
+      completeRequest();
     }
   }
 
@@ -602,6 +625,14 @@ class UserSessionManager implements IUserSessionManager {
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
           this.cookieWrittenInPageLoad[sessionKey] = true;
 
+          // Never put a second request for the same key on the wire. The browser applies
+          // Set-Cookie in response arrival order, so concurrent writes can settle on an
+          // older value. Hold this one back and reissue it once the response lands.
+          if (this.serverSideCookiesInFlight[sessionKey]) {
+            this.serverSideCookiesResyncPending[sessionKey] = true;
+            return;
+          }
+
           if (this.serverSideCookieDebounceFuncs[sessionKey]) {
             (globalThis as typeof window).clearTimeout(
               this.serverSideCookieDebounceFuncs[sessionKey],
@@ -610,6 +641,7 @@ class UserSessionManager implements IUserSessionManager {
 
           this.serverSideCookieDebounceFuncs[sessionKey] = (globalThis as typeof window).setTimeout(
             () => {
+              this.serverSideCookiesInFlight[sessionKey] = true;
               // Create a map of session key to cookie name
               const sessionToCookiesMap: SessionToCookiesMap = {
                 [sessionKey]: {
@@ -631,6 +663,29 @@ class UserSessionManager implements IUserSessionManager {
           curStore?.set(cookieName, cookieValue);
         }
       } else {
+        if (
+          state.serverCookies.isEnabledServerSideCookies.value &&
+          storageType === COOKIE_STORAGE
+        ) {
+          // Drop any write still waiting on the debounce, otherwise it would fire after this
+          // removal and resurrect the cookie.
+          if (this.serverSideCookieDebounceFuncs[sessionKey]) {
+            (globalThis as typeof window).clearTimeout(
+              this.serverSideCookieDebounceFuncs[sessionKey],
+            );
+            this.serverSideCookieDebounceFuncs[sessionKey] = 0;
+          }
+
+          if (this.serverSideCookiesInFlight[sessionKey]) {
+            // A request already on the wire cannot be recalled, and the server will set the
+            // cookie. Re-apply the removal once its response lands.
+            this.serverSideCookiesResyncPending[sessionKey] = true;
+          } else {
+            this.serverSideCookiesRequestInProgress[sessionKey] = false;
+            this.serverSideCookiesResyncPending[sessionKey] = false;
+          }
+        }
+
         curStore?.remove(cookieName);
       }
     }

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -540,7 +540,7 @@ class UserSessionManager implements IUserSessionManager {
    * @param cookieValue value that is about to be written
    * @returns true if the persisted value is identical to the value to be written
    */
-  isValueAlreadyPersisted(
+  private isValueAlreadyPersisted(
     store: IStore | undefined,
     cookieName: string,
     cookieValue: CookieValue,
@@ -573,7 +573,14 @@ class UserSessionManager implements IUserSessionManager {
         ) {
           // Skip the request if the cookie already holds this exact value.
           // The cookie is set with a long max age, so it needs no periodic renewal.
-          if (this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)) {
+          //
+          // Only safe while nothing is pending for this key. A queued or in-flight request
+          // may still write a different value, so skipping then would leave the cookie and
+          // the state divergent with nothing to reconcile them.
+          if (
+            !this.serverSideCookiesRequestInProgress[sessionKey] &&
+            this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)
+          ) {
             return;
           }
 

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -621,7 +621,12 @@ class UserSessionManager implements IUserSessionManager {
             return;
           }
 
-          // Mark the requests as in progress.
+          // Both are set at the point the write is committed to, not when the cookie
+          // actually changes. cookieWrittenInPageLoad is pre-emptive on purpose: the
+          // client-side fallback writes through the callback below without setting it, and
+          // a fallback only ever follows a request, so this is what covers that path. It
+          // also keeps the skip guard above off a key with an outstanding write, without
+          // the guard having to consult the pending state below.
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
           this.cookieWrittenInPageLoad[sessionKey] = true;
 

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -534,6 +534,24 @@ class UserSessionManager implements IUserSessionManager {
   }
 
   /**
+   * A function to check whether the value is already persisted in the storage as is
+   * @param store store to read the persisted value from
+   * @param cookieName name of the cookie
+   * @param cookieValue value that is about to be written
+   * @returns true if the persisted value is identical to the value to be written
+   */
+  isValueAlreadyPersisted(
+    store: IStore | undefined,
+    cookieName: string,
+    cookieValue: CookieValue,
+  ): boolean {
+    return (
+      stringifyWithoutCircular(store?.get(cookieName), false, []) ===
+      stringifyWithoutCircular(cookieValue, false, [])
+    );
+  }
+
+  /**
    * A function to sync values in storage
    * @param sessionKey
    */
@@ -553,6 +571,12 @@ class UserSessionManager implements IUserSessionManager {
           state.serverCookies.isEnabledServerSideCookies.value &&
           storageType === COOKIE_STORAGE
         ) {
+          // Skip the request if the cookie already holds this exact value.
+          // The cookie is set with a long max age, so it needs no periodic renewal.
+          if (this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)) {
+            return;
+          }
+
           // Mark the requests as in progress.
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
 

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -101,7 +101,7 @@ class UserSessionManager implements IUserSessionManager {
    * longer be assumed to have been set by the data service, so the equal-value skip in
    * syncValueToStorage no longer applies. Never cleared.
    */
-  serverSideCookieSyncRequired: Record<UserSessionKey, boolean>;
+  cookieWrittenInPageLoad: Record<UserSessionKey, boolean>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -118,7 +118,7 @@ class UserSessionManager implements IUserSessionManager {
     this.onError = this.onError.bind(this);
     this.serverSideCookieDebounceFuncs = {} as Record<UserSessionKey, number>;
     this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
-    this.serverSideCookieSyncRequired = {} as Record<UserSessionKey, boolean>;
+    this.cookieWrittenInPageLoad = {} as Record<UserSessionKey, boolean>;
   }
 
   /**
@@ -234,7 +234,7 @@ class UserSessionManager implements IUserSessionManager {
             if (isDefinedNotNullAndNotEmptyString(value)) {
               curStore.set(COOKIE_KEYS[key], value);
               // Written client-side, so it still needs syncing to the data service
-              this.serverSideCookieSyncRequired[key as UserSessionKey] = true;
+              this.cookieWrittenInPageLoad[key as UserSessionKey] = true;
             }
 
             store.remove(COOKIE_KEYS[key]);
@@ -284,7 +284,7 @@ class UserSessionManager implements IUserSessionManager {
         if (!isNullOrUndefined(migratedVal)) {
           store.set(storageEntry, migratedVal);
           // Written client-side, so it still needs syncing to the data service
-          this.serverSideCookieSyncRequired[storageKey as UserSessionKey] = true;
+          this.cookieWrittenInPageLoad[storageKey as UserSessionKey] = true;
         }
       });
     });
@@ -592,7 +592,7 @@ class UserSessionManager implements IUserSessionManager {
           // still be pending, so the value cannot be assumed to have come from the data
           // service. This flag is never cleared, so it cannot go stale.
           if (
-            !this.serverSideCookieSyncRequired[sessionKey] &&
+            !this.cookieWrittenInPageLoad[sessionKey] &&
             this.isValueAlreadyPersisted(curStore, cookieName, cookieValue)
           ) {
             return;
@@ -600,7 +600,7 @@ class UserSessionManager implements IUserSessionManager {
 
           // Mark the requests as in progress.
           this.serverSideCookiesRequestInProgress[sessionKey] = true;
-          this.serverSideCookieSyncRequired[sessionKey] = true;
+          this.cookieWrittenInPageLoad[sessionKey] = true;
 
           if (this.serverSideCookieDebounceFuncs[sessionKey]) {
             (globalThis as typeof window).clearTimeout(


### PR DESCRIPTION
> **Stacked on #3176.** Base is `feature/sdk-5409-…`, not `develop`. Review #3176 first; this diff is only the serialisation change on top of it.

## PR Description

Each `POST /rsaRequest` is issued with no ordering guarantee. The 10 ms debounce in `syncValueToStorage` only collapses changes inside its own window, so two changes further apart put **two requests on the wire for the same cookie**. The browser applies `Set-Cookie` in response arrival order, so if the older response lands second the cookie settles on the older value:

```
Req A (value B) sent, Req B (value C) sent
Resp C arrives → cookie = C. Callback: expected C, current C → match, no correction
Resp B arrives → cookie = B. Callback: expected B, current B → match, no correction
Final: cookie = B, state = C
```

The verification block cannot catch this. Each callback compares its **own request-time snapshot** against the cookie, so both see a match and neither corrects. The divergence is silent and permanent until the next write to that key.

Pre-existing on `develop` — surfaced by review on #3176, where the skip guard made one interleaving of it deterministic rather than merely possible. That specific interaction was fixed in #3176 itself; this PR fixes the underlying defect.

### Why serialise rather than track generations

Generation tracking can only *detect* a stale response — by the time a callback runs the browser has already applied that `Set-Cookie`, and it cannot be un-applied. Only repaired, and repair means a client-side write that Safari ITP caps at 7 days. Serialising prevents the reordering outright, which is what the acceptance criterion asks for.

### The change

The single in-progress boolean conflated two states. Splitting them is what makes the rest fall out:

- `serverSideCookiesInFlight` — request actually on the wire
- `serverSideCookiesResyncPending` — value changed while in flight

While a request is in flight for a key, a further change is **held back rather than sent concurrently**, and reissued against the then-current value once the response lands. Only one request per key is ever on the wire.

Two things follow for free:

1. **The in-progress flag becomes accurate.** With a single owner per key, `clearInProgressFlags` can no longer clear state a newer request still owns — which is what made `getUserSessionValue` fall back to storage while a write was outstanding.
2. **The removal path stops resurrecting cookies.** It now drops a queued write before removing, and if a request is already in flight it re-applies the removal once the response lands. A `reset()` racing a write can no longer bring the cookie back as an encrypted empty string.

`completeRequest()` also moved to the **end** of the response callback, after any client-side correction, so a resync reissued from it sees the settled cookie value.

## Linear task (optional)

[SDK-5411](https://linear.app/rudderstack/issue/SDK-5411/server-side-cookie-writes-are-not-serialised-per-key)

## Cross Browser Tests

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

Not run. The change is request-sequencing logic with no browser-specific API surface, but left unchecked rather than assumed.

## Sanity Suite

- [ ] All sanity suite test cases pass locally

Not run.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

## Test plan

Five new tests in a `serialised server-side cookie writes` block, using a deferred-callback harness so response timing is controlled rather than raced:

- no second request while one is in flight for the same key
- the held-back write is issued once the in-flight response lands
- the in-progress flag stays set while a resync is pending
- a queued write does not resurrect a removed cookie
- a removal during an in-flight request is re-applied after the response

Verified: 218 passed / 1 skipped, `nx affected -t test` green across all 3 affected projects, eslint 0 errors on changed files.

## Note for reviewers

Two tests from #3176 changed assertions here. They asserted a second request was issued immediately while one was in flight — which is exactly the behaviour this PR fixes. They now assert the write is **held for reissue** rather than lost, which is the invariant that actually matters: `serverSideCookiesResyncPending` is set instead of the write being dropped.

## Follow-up

SDK-4981 (batching) will rework this same pending machinery again — a batch covers several keys, so per-key in-flight state collapses into one pending map plus a single in-flight request. Merge order matters: #3176, then this, then batching.