### PR TITLE
fix(analytics-js): serialise server-side cookie batches

### DIFF
--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -2657,17 +2657,23 @@ describe('User session manager', () => {
       });
 
       it('should not resend the previous batch in a later one', () => {
+        let capturedCallback: any;
+        userSessionManager.makeRequestToSetCookie = jest.fn((_data: any, cb: any) => {
+          capturedCallback = cb;
+        });
         const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
 
         state.session.anonymousId.value = dummyAnonymousId;
         userSessionManager.syncValueToStorage('anonymousId');
         jest.advanceTimersByTime(1000);
+        capturedCallback(null, { xhr: { status: 200 } });
 
+        setServerSideCookiesSpy.mockClear();
         state.session.userId.value = 'dummy_userId';
         userSessionManager.syncValueToStorage('userId');
         jest.advanceTimersByTime(1000);
 
-        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(2);
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
         expect(setServerSideCookiesSpy).toHaveBeenLastCalledWith(
           { userId: { name: COOKIE_KEYS.userId } },
           expect.any(Function),
@@ -2721,6 +2727,83 @@ describe('User session manager', () => {
         capturedCallback(null, { xhr: { status: 200 } });
 
         expect(batchErrorCalls()).toHaveLength(0);
+      });
+
+      it('should not put a second batch on the wire while one is in flight', () => {
+        userSessionManager.makeRequestToSetCookie = jest.fn();
+
+        state.session.anonymousId.value = dummyAnonymousId;
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        expect(userSessionManager.makeRequestToSetCookie).toHaveBeenCalledTimes(1);
+
+        state.session.userId.value = 'dummy_userId';
+        userSessionManager.syncValueToStorage('userId');
+        jest.advanceTimersByTime(1000);
+
+        expect(userSessionManager.makeRequestToSetCookie).toHaveBeenCalledTimes(1);
+      });
+
+      it('should send the queued keys once the in-flight batch completes', () => {
+        let capturedCallback: any;
+        userSessionManager.makeRequestToSetCookie = jest.fn((_data: any, cb: any) => {
+          capturedCallback = cb;
+        });
+        const setServerSideCookiesSpy = jest.spyOn(userSessionManager, 'setServerSideCookies');
+
+        state.session.anonymousId.value = dummyAnonymousId;
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        state.session.userId.value = 'dummy_userId';
+        userSessionManager.syncValueToStorage('userId');
+        jest.advanceTimersByTime(1000);
+
+        setServerSideCookiesSpy.mockClear();
+        capturedCallback(null, { xhr: { status: 200 } });
+        jest.advanceTimersByTime(1000);
+
+        expect(setServerSideCookiesSpy).toHaveBeenCalledTimes(1);
+        expect(setServerSideCookiesSpy).toHaveBeenCalledWith(
+          { userId: { name: COOKIE_KEYS.userId } },
+          expect.any(Function),
+          expect.any(Object),
+        );
+      });
+
+      it('should keep a still queued key marked as in progress', () => {
+        let capturedCallback: any;
+        userSessionManager.makeRequestToSetCookie = jest.fn((_data: any, cb: any) => {
+          capturedCallback = cb;
+        });
+
+        state.session.anonymousId.value = dummyAnonymousId;
+        userSessionManager.syncValueToStorage('anonymousId');
+        jest.advanceTimersByTime(1000);
+
+        state.session.userId.value = 'dummy_userId';
+        userSessionManager.syncValueToStorage('userId');
+
+        capturedCallback(null, { xhr: { status: 200 } });
+
+        expect(userSessionManager.serverSideCookiesRequestInProgress.userId).toBe(true);
+      });
+
+      it('should not resurrect a removed cookie from a queued write', () => {
+        userSessionManager.makeRequestToSetCookie = jest.fn();
+
+        state.session.anonymousId.value = dummyAnonymousId;
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        // Cleared before the debounce fires
+        state.session.anonymousId.value = '';
+        userSessionManager.syncValueToStorage('anonymousId');
+
+        jest.advanceTimersByTime(1000);
+
+        expect(userSessionManager.makeRequestToSetCookie).not.toHaveBeenCalled();
+        expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toBeNull();
       });
 
       it('should not batch keys that are not backed by cookie storage', () => {

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -102,6 +102,12 @@ class UserSessionManager implements IUserSessionManager {
    */
   serverSideCookiesPending: Partial<Record<UserSessionKey, string>>;
   /**
+   * Whether a batch is currently on the wire. Only one may be, because the browser applies
+   * Set-Cookie in response arrival order, so concurrent requests can settle the cookies on
+   * an older value. Anything queued meanwhile goes out in the next batch.
+   */
+  isServerSideCookiesBatchInFlight: boolean;
+  /**
    * Tracks whether a server-side cookie setting request is in progress or not.
    */
   serverSideCookiesRequestInProgress: Record<UserSessionKey, boolean>;
@@ -121,6 +127,7 @@ class UserSessionManager implements IUserSessionManager {
     this.onError = this.onError.bind(this);
     this.serverSideCookiesDebounceTimer = 0;
     this.serverSideCookiesPending = {};
+    this.isServerSideCookiesBatchInFlight = false;
     this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
   }
 
@@ -467,8 +474,16 @@ class UserSessionManager implements IUserSessionManager {
 
     const clearInProgressFlags = () => {
       sessionKeys.forEach((sessionKey: UserSessionKey) => {
-        this.serverSideCookiesRequestInProgress[sessionKey] = false;
+        // A key queued again while this batch was outstanding is still not written, so it
+        // stays in progress until the batch carrying its newer value completes
+        if (!this.serverSideCookiesPending[sessionKey]) {
+          this.serverSideCookiesRequestInProgress[sessionKey] = false;
+        }
       });
+
+      // Release the wire and send whatever queued up behind this batch
+      this.isServerSideCookiesBatchInFlight = false;
+      this.flushServerSideCookies();
     };
 
     const setCookiesClientSide = () => {
@@ -569,6 +584,12 @@ class UserSessionManager implements IUserSessionManager {
    * A function to send every queued server-side cookie as a single request
    */
   flushServerSideCookies() {
+    // Hold the queue until the outstanding batch lands. Its keys stay pending and go out
+    // in the next one, so two responses can never race to set the same cookie.
+    if (this.isServerSideCookiesBatchInFlight) {
+      return;
+    }
+
     const sessionToCookiesMap = Object.entries(this.serverSideCookiesPending).reduce(
       (acc: SessionToCookiesMap, [sessionKey, cookieName]) => {
         acc[sessionKey as UserSessionKey] = { name: cookieName as string };
@@ -590,6 +611,7 @@ class UserSessionManager implements IUserSessionManager {
       storageClientDataStoreNameMap[COOKIE_STORAGE] as string,
     );
 
+    this.isServerSideCookiesBatchInFlight = true;
     this.setServerSideCookies(
       sessionToCookiesMap,
       (cookieName, cookieValue) => {
@@ -641,6 +663,11 @@ class UserSessionManager implements IUserSessionManager {
           curStore?.set(cookieName, cookieValue);
         }
       } else {
+        // Drop any queued write for this key, otherwise the next batch would resurrect the
+        // cookie that is being removed here
+        delete this.serverSideCookiesPending[sessionKey];
+        this.serverSideCookiesRequestInProgress[sessionKey] = false;
+
         curStore?.remove(cookieName);
       }
     }


### PR DESCRIPTION
> **Stacked on #3178.** Base is `feature/sdk-4981-…`, not `develop`. Review #3178 first; this diff is only the serialisation change on top of it.
>
> Replaces #3177, which was built before batching and is now closed. Same design, same tests, re-implemented against the batch model — where it turns out much smaller.

## PR Description

Requests are issued with no ordering guarantee. The debounce only collapses changes inside its own window, so two changes further apart put two requests on the wire for the same cookies. The browser applies `Set-Cookie` in response arrival order, so if the older response lands second the cookies settle on the older value:

```
Batch 1 (value B) sent, Batch 2 (value C) sent
Resp 2 arrives → cookie = C. Callback: expected C, current C → match, no correction
Resp 1 arrives → cookie = B. Callback: expected B, current B → match, no correction
Final: cookie = B, state = C
```

The readback cannot catch it. Each callback compares its **own request-time snapshot** against the cookie, so both see a match and neither corrects. The divergence is silent and permanent until the next write.

Pre-existing on `develop`, and batching widens it — one stale response moves several cookies backwards instead of one.

### Why serialise rather than track generations

Generation tracking can only *detect* a stale response. By the time a callback runs the browser has already applied that `Set-Cookie`, and it cannot be un-applied — only repaired, and repair means a client-side write that Safari ITP caps at 7 days. Serialising prevents the reordering outright.

### The change

Hold the queue while a batch is on the wire. Keys queued meanwhile stay pending and go out in the next batch, triggered by the completion handler.

**Batching makes this far cheaper than it was in #3177.** The pending map *is* the queue, so there is no need for per-key in-flight or resync records — one boolean replaces both:

```ts
if (this.isServerSideCookiesBatchInFlight) {
  return; // keys stay pending, the next batch carries them
}
```

Two things follow:

1. **A key queued again while a batch was outstanding stays marked in progress**, rather than being cleared by that batch's response. `getUserSessionValue` keeps reading from state until the newer value is actually written. This also closes the flag-clearing issue #3178 widens.
2. **The removal path drops any queued write for the key**, so a `reset()` racing a queued write can no longer resurrect the cookie.

## Linear task (optional)

[SDK-5411](https://linear.app/rudderstack/issue/SDK-5411/server-side-cookie-writes-are-not-serialised-per-key)

## Cross Browser Tests

- [x] Chrome
- [ ] Firefox
- [ ] IE11

Chrome via the `e2e/server-side-cookies` suite added in #3178, which includes a serialisation check. Firefox and IE11 not run.

## Sanity Suite

- [ ] All sanity suite test cases pass locally

Not run.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

## Test plan

Four new unit tests, using a deferred-callback harness so response timing is controlled rather than raced:

- no second batch goes on the wire while one is in flight
- the queued keys are sent once the in-flight batch completes, carrying only those keys
- a key queued behind an in-flight batch stays marked in progress
- a queued write does not resurrect a removed cookie

Verified: `nx affected -t test` green, **1296 passed** / 1 skipped, eslint 0 errors. Browser suite 9/9 against a local build of this branch with the fixed data service.

## Note for reviewers

One test from #3178 changed its assertion. `should not resend the previous batch in a later one` previously let a second batch go out while the first was still in flight — which is exactly what this PR prevents. It now completes the first batch before enqueuing the second, preserving its intent (that the pending map is drained and earlier keys are not resent).

## Known behaviour changes

- **A queued write can be lost on unload.** While a batch is in flight, queued keys wait. If the page unloads first, those writes are never sent, where previously they would have gone out concurrently. Needs two writes to the same key within one round trip plus an unload — plausible right after an `identify` on a slow connection. There is no `pagehide` flush in the session manager to catch it.
- **A hung request blocks the queue** until the XHR times out. Bounded at 10s by `DEFAULT_XHR_TIMEOUT_MS`, whose `ontimeout` path clears the flags and drains the queue.
- **Cookie updates can lag state by a round trip** when writes are frequent, since the second batch waits for the first response.

## Not covered

A removal that happens while its batch is **already in flight** cannot be recalled, so the server may still set the cookie and the client-side removal is not re-applied afterwards. SDK-5411's acceptance criterion covers the queued case, which this fixes; the in-flight case remains open on the ticket.