### PR TITLE
fix: sdk-5415 refresh production source config fixture

### DIFF
--- a/packages/sanity-suite/__fixtures__/sourceConfig1.json
+++ b/packages/sanity-suite/__fixtures__/sourceConfig1.json
@@ -46,7 +46,8 @@
         },
         "updatedAt": "2024-10-01T10:20:52.025Z",
         "shouldApplyDeviceModeTransformation": false,
-        "propagateEventsUntransformedOnError": false
+        "propagateEventsUntransformedOnError": false,
+        "version": 1
       },
       {
         "id": "2M5amK3AVQ31yy9uxD8Usk0y34Q",
@@ -92,7 +93,8 @@
         },
         "updatedAt": "2024-10-01T09:56:28.946Z",
         "shouldApplyDeviceModeTransformation": false,
-        "propagateEventsUntransformedOnError": false
+        "propagateEventsUntransformedOnError": false,
+        "version": 1
       },
       {
         "id": "2MBKOwDUcq0pKzHDNWL4NZH1nvW",
@@ -122,7 +124,8 @@
         },
         "updatedAt": "2024-10-01T10:20:16.906Z",
         "shouldApplyDeviceModeTransformation": false,
-        "propagateEventsUntransformedOnError": false
+        "propagateEventsUntransformedOnError": false,
+        "version": 1
       },
       {
         "id": "2L8KyN0Fo6CmtL1jZ7Rccas42ry",
@@ -197,7 +200,8 @@
         },
         "updatedAt": "2024-09-18T11:17:44.316Z",
         "shouldApplyDeviceModeTransformation": false,
-        "propagateEventsUntransformedOnError": false
+        "propagateEventsUntransformedOnError": false,
+        "version": 1
       },
       {
         "id": "2LoXypOO5xdh7R5xJynzIyWeYJf",
@@ -211,6 +215,7 @@
           "enableBrazeLogging": false,
           "enableNestedArrayOperations": false,
           "supportDedup": false,
+          "useEcommerceRecommendedEvents": false,
           "blacklistedEvents": [
             {
               "eventName": ""
@@ -236,7 +241,8 @@
         },
         "updatedAt": "2024-09-19T10:57:33.488Z",
         "shouldApplyDeviceModeTransformation": false,
-        "propagateEventsUntransformedOnError": false
+        "propagateEventsUntransformedOnError": false,
+        "version": 1
       },
       {
         "id": "2LoUwsaZMiRBsdhwc3zXcNk4oOw",
@@ -330,7 +336,8 @@
         },
         "updatedAt": "2024-10-01T09:57:51.189Z",
         "shouldApplyDeviceModeTransformation": true,
-        "propagateEventsUntransformedOnError": true
+        "propagateEventsUntransformedOnError": true,
+        "version": 1
       },
       {
         "id": "2LoR1TbVG2bcISXvy7DamldfkgO",
@@ -394,7 +401,8 @@
         },
         "updatedAt": "2024-10-01T10:07:57.063Z",
         "shouldApplyDeviceModeTransformation": true,
-        "propagateEventsUntransformedOnError": true
+        "propagateEventsUntransformedOnError": true,
+        "version": 1
       },
       {
         "id": "2M5dOW6kipDywRHHLJy8blGeaIM",
@@ -426,7 +434,8 @@
         },
         "updatedAt": "2024-10-01T10:13:31.740Z",
         "shouldApplyDeviceModeTransformation": false,
-        "propagateEventsUntransformedOnError": false
+        "propagateEventsUntransformedOnError": false,
+        "version": 1
       },
       {
         "id": "2M5beBXLTjTto62OdCBwFNejrkY",
@@ -463,7 +472,8 @@
         },
         "updatedAt": "2024-10-01T10:19:05.596Z",
         "shouldApplyDeviceModeTransformation": false,
-        "propagateEventsUntransformedOnError": false
+        "propagateEventsUntransformedOnError": false,
+        "version": 1
       },
       {
         "id": "2MB1bEpAABLRC9oI5G3IXrrBTos",
@@ -522,7 +532,8 @@
         },
         "updatedAt": "2024-10-01T10:17:50.293Z",
         "shouldApplyDeviceModeTransformation": false,
-        "propagateEventsUntransformedOnError": false
+        "propagateEventsUntransformedOnError": false,
+        "version": 1
       }
     ],
     "updatedAt": "2023-12-01T16:12:28.443Z"


### PR DESCRIPTION
## PR Description

Refresh the production source-config fixture used by the sanity suite.

The live response now includes `version: 1` on all 10 destinations. The Braze config also includes `useEcommerceRecommendedEvents: false`. The strict fixture comparison caused one failed check in every browser scenario.

Failed workflow: https://github.com/rudderlabs/rudder-client-side-test/actions/runs/33630351058

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-5415/fix-js-sdk-sanity-suite-source-config-fixture-drift

## Test plan

- `npm run build:sanity`
- `npm run check:lint --workspace=@rudderstack/analytics-js-sanity-suite` (passes with existing warnings)
- Compare the fixture with the live production response after the suite timestamp normalization

## Cross Browser Tests

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request will not create security issues.