### PR TITLE
fix(analytics-js): use in-memory session on replay

### DIFF
--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1,4 +1,6 @@
 import { batch } from '@preact/signals-core';
+import { MEMORY_STORAGE } from '@rudderstack/analytics-js-common/constants/storages';
+import type { StorageEntries } from '@rudderstack/analytics-js-common/types/ApplicationState';
 import type { IPluginsManager } from '@rudderstack/analytics-js-common/types/PluginsManager';
 import { stringifyWithoutCircular } from '@rudderstack/analytics-js-common/utilities/json';
 import { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
@@ -2074,13 +2076,14 @@ describe('User session manager', () => {
     });
 
     // entriesWithInMemoryFallback stores sessionInfo as 'none', so it does not exercise
-    // memory storage for the session at all
-    const entriesWithOnlyMemoryStorage = Object.fromEntries(
+    // memory storage for the session at all. Typed as StorageEntries rather than as the
+    // cookie fixture, so a malformed entry is caught rather than hidden by the cast.
+    const entriesWithOnlyMemoryStorage: StorageEntries = Object.fromEntries(
       Object.entries(entriesWithOnlyCookieStorage).map(([key, entry]) => [
         key,
-        { ...entry, type: 'memoryStorage' },
+        { ...entry, type: MEMORY_STORAGE },
       ]),
-    ) as typeof entriesWithOnlyCookieStorage;
+    );
 
     it('should retain a manually started session for the events replayed after it', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;

--- a/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/UserSessionManager.test.ts
@@ -1,3 +1,4 @@
+import { batch } from '@preact/signals-core';
 import type { IPluginsManager } from '@rudderstack/analytics-js-common/types/PluginsManager';
 import { stringifyWithoutCircular } from '@rudderstack/analytics-js-common/utilities/json';
 import { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
@@ -18,6 +19,7 @@ import {
   entriesWithOnlyCookieStorage,
   entriesWithOnlyLocalStorage,
   entriesWithOnlyNoStorage,
+  entriesWithOnlySessionStorage,
   entriesWithStorageOnlyForAnonymousId,
 } from '../../../__fixtures__/fixtures';
 import { server } from '../../../__fixtures__/msw.server';
@@ -2055,6 +2057,198 @@ describe('User session manager', () => {
         // Should default to reading from storage
         expect(state.session.sessionInfo.value.id).toBe(1111111111);
       });
+    });
+  });
+
+  describe('Buffered event replay', () => {
+    // Buffered events are replayed from inside the lifecycle `effect`, which puts every
+    // state write in the same batch. The storage sync effects registered by `init` are
+    // queued behind that batch and do not run in between, so storage stays behind the
+    // state for the whole replay. `batch` reproduces exactly that condition.
+    const sessionInfoInStorage = (id: number) => ({
+      autoTrack: true,
+      timeout: 10 * 60 * 1000,
+      expiresAt: Date.now() + 5000,
+      id,
+      sessionStart: false,
+    });
+
+    // entriesWithInMemoryFallback stores sessionInfo as 'none', so it does not exercise
+    // memory storage for the session at all
+    const entriesWithOnlyMemoryStorage = Object.fromEntries(
+      Object.entries(entriesWithOnlyCookieStorage).map(([key, entry]) => [
+        key,
+        { ...entry, type: 'memoryStorage' },
+      ]),
+    ) as typeof entriesWithOnlyCookieStorage;
+
+    it('should retain a manually started session for the events replayed after it', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      const manualSessionId = 1029384756;
+
+      batch(() => {
+        // startSession() in the buffer
+        userSessionManager.start(manualSessionId);
+        // ...followed by a buffered track()
+        userSessionManager.refreshSession();
+      });
+
+      expect(state.session.sessionInfo.value.id).toBe(manualSessionId);
+      expect(state.session.sessionInfo.value.manualTrack).toBe(true);
+    });
+
+    it('should retain the new session created by a replayed reset', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      // Seeded rather than taken from the session init creates, whose ID is Date.now() and
+      // so can collide with the one reset creates a fraction of a millisecond later
+      setDataInCookieStorage({ rl_session: sessionInfoInStorage(1111111111) });
+      userSessionManager.init();
+
+      expect(state.session.sessionInfo.value.id).toBe(1111111111);
+
+      batch(() => {
+        // reset() in the buffer
+        userSessionManager.reset();
+        // ...followed by a buffered track()
+        userSessionManager.refreshSession();
+      });
+
+      expect(state.session.sessionInfo.value.id).not.toBe(1111111111);
+    });
+
+    it('should not resurrect an ended session for the events replayed after it', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      batch(() => {
+        // endSession() in the buffer
+        userSessionManager.end();
+        // ...followed by a buffered track()
+        userSessionManager.refreshSession();
+      });
+
+      expect(state.session.sessionInfo.value).toStrictEqual({});
+    });
+
+    it('should use the identity set by a replayed event for the events replayed after it', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      batch(() => {
+        // identify() in the buffer
+        userSessionManager.setUserId('user-from-state');
+        userSessionManager.setGroupId('group-from-state');
+
+        // ...must not read back the stale value that storage still holds
+        expect(userSessionManager.getUserId()).toBe('user-from-state');
+        expect(userSessionManager.getGroupId()).toBe('group-from-state');
+      });
+    });
+
+    it('should read from storage again once the queued sync has run', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      batch(() => {
+        userSessionManager.setUserId('user-from-state');
+      });
+
+      // The queued effect has now persisted it, so another tab's write must win again
+      setDataInCookieStorage({ rl_user_id: 'user-from-another-tab' });
+
+      expect(userSessionManager.getUserId()).toBe('user-from-another-tab');
+    });
+
+    it('should keep reading session info from storage outside a replay', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      userSessionManager.init();
+
+      // Another tab advances the session
+      setDataInCookieStorage({ rl_session: sessionInfoInStorage(1111111111) });
+
+      userSessionManager.refreshSession();
+
+      expect(state.session.sessionInfo.value.id).toBe(1111111111);
+    });
+
+    it('should not fragment the session when the stored one expires during the replay', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      setDataInCookieStorage({
+        rl_session: {
+          autoTrack: true,
+          timeout: 10 * 60 * 1000,
+          expiresAt: Date.now() - 1000, // already expired
+          id: 1111111111,
+          sessionStart: false,
+        },
+      });
+      userSessionManager.init();
+
+      // The expired session is replaced during init
+      const renewedSessionId = state.session.sessionInfo.value.id;
+      expect(renewedSessionId).not.toBe(1111111111);
+
+      batch(() => {
+        userSessionManager.refreshSession();
+        userSessionManager.refreshSession();
+        userSessionManager.refreshSession();
+      });
+
+      // One new session for the whole replay, not one per event
+      expect(state.session.sessionInfo.value.id).toBe(renewedSessionId);
+    });
+
+    it('should retain a manually started session while a server-side cookie write is pending', () => {
+      state.storage.entries.value = entriesWithOnlyCookieStorage;
+      state.serverCookies.isEnabledServerSideCookies.value = true;
+      userSessionManager.init();
+
+      const manualSessionId = 1029384756;
+
+      batch(() => {
+        userSessionManager.start(manualSessionId);
+        userSessionManager.refreshSession();
+      });
+
+      expect(state.session.sessionInfo.value.id).toBe(manualSessionId);
+    });
+
+    describe.each([
+      ['local storage', entriesWithOnlyLocalStorage],
+      ['session storage', entriesWithOnlySessionStorage],
+      ['in-memory storage', entriesWithOnlyMemoryStorage],
+    ])('with %s', (_label, entries) => {
+      it('should retain a manually started session for the events replayed after it', () => {
+        state.storage.entries.value = entries;
+        userSessionManager.init();
+
+        const manualSessionId = 1029384756;
+
+        batch(() => {
+          userSessionManager.start(manualSessionId);
+          userSessionManager.refreshSession();
+        });
+
+        expect(state.session.sessionInfo.value.id).toBe(manualSessionId);
+        expect(state.session.sessionInfo.value.manualTrack).toBe(true);
+      });
+    });
+
+    it('should not start a session during the replay when storage is disabled', () => {
+      // Session tracking is off entirely for storage type 'none', and must stay off. The
+      // state can never be ahead of a storage that holds nothing, so preferring it here
+      // would surface a session for the replayed events that then vanished on the next one.
+      state.storage.entries.value = entriesWithOnlyNoStorage;
+      userSessionManager.init();
+
+      batch(() => {
+        userSessionManager.start(1029384756);
+        userSessionManager.refreshSession();
+      });
+
+      expect(state.session.sessionInfo.value).toStrictEqual({});
     });
   });
 

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -105,6 +105,11 @@ class UserSessionManager implements IUserSessionManager {
    * Tracks whether a server-side cookie setting request is in progress or not.
    */
   serverSideCookiesRequestInProgress: Record<UserSessionKey, boolean>;
+  /**
+   * The value each key was last handed to storage with, recorded by the sync effect.
+   * Anything else in the state means storage has not been given the current value yet.
+   */
+  lastSyncedValues: Partial<Record<UserSessionKey, any>>;
 
   constructor(
     pluginsManager: IPluginsManager,
@@ -122,6 +127,7 @@ class UserSessionManager implements IUserSessionManager {
     this.serverSideCookiesDebounceTimer = 0;
     this.serverSideCookiesPending = {};
     this.serverSideCookiesRequestInProgress = {} as Record<UserSessionKey, boolean>;
+    this.lastSyncedValues = {};
   }
 
   /**
@@ -673,7 +679,11 @@ class UserSessionManager implements IUserSessionManager {
     // This will work as long as the user session entry key names are same as the state keys
     USER_SESSION_KEYS.forEach(sessionKey => {
       effect(() => {
+        // Read before syncing so the effect subscribes to the signal, and record after
+        // so that reads can tell whether storage has been given the current value yet
+        const value = state.session[sessionKey].value;
         this.syncValueToStorage(sessionKey);
+        this.lastSyncedValues[sessionKey] = value;
       });
     });
   }
@@ -766,15 +776,39 @@ class UserSessionManager implements IUserSessionManager {
   }
 
   /**
-   * Fetches the value for a session key. Preferably from storage, if the server-side
-   * cookies request is not in progress. Otherwise, from the state.
+   * Fetches the value for a session key. Preferably from storage, so that changes made by
+   * other tabs are picked up. Falls back to the state whenever storage is known to be
+   * behind it.
    * @param sessionKey - The session key to fetch the value for
    * @returns - The value for the session key
    */
   getUserSessionValue<T>(sessionKey: UserSessionKey): Nullable<T> {
-    // If the server-side cookies request is in progress, fetch the value from the state.
+    // peek() rather than value, as this is a plain read; subscribing here would make
+    // every enclosing effect depend on all the user session signals
+    const stateValue = state.session[sessionKey].peek();
+
+    // Until the sync effect has run for this key there is nothing to compare against, so
+    // storage stays authoritative. That is the case throughout init, where the state is
+    // still being hydrated from storage and the effects are not registered yet.
+    //
+    // The persistence check matters for storage types that hold nothing at all ('none'),
+    // where the state can never be ahead of storage because there is no destination.
+    // Without it, a session started during a replay would survive the replay and then
+    // disappear on the next event, once the sync effect had caught up.
+    const isSyncRecorded =
+      this.isPersistenceEnabledForStorageEntry(sessionKey) && sessionKey in this.lastSyncedValues;
+
+    // Storage has not been given this value yet. Buffered events are replayed from within
+    // the lifecycle effect, so the sync effects are queued behind that batch and do not
+    // run in between, leaving storage behind the state for the whole replay. Direct state
+    // writes such as start(), end() and reset() are in the same position.
+    if (isSyncRecorded && stateValue !== this.lastSyncedValues[sessionKey]) {
+      return stateValue as Nullable<T>;
+    }
+
+    // Storage has the value, but for server-side cookies it is only on its way there.
     if (this.serverSideCookiesRequestInProgress[sessionKey]) {
-      return state.session[sessionKey].value as Nullable<T>;
+      return stateValue as Nullable<T>;
     }
 
     // Otherwise, fetch the value from storage.

--- a/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
+++ b/packages/analytics-js/src/components/userSessionManager/UserSessionManager.ts
@@ -81,6 +81,7 @@ import type {
   IUserSessionManager,
   SessionToCookiesMap,
   UserSessionStorageKeysType,
+  UserSessionValue,
 } from './types';
 import { isPositiveInteger } from '../utilities/number';
 import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
@@ -109,7 +110,7 @@ class UserSessionManager implements IUserSessionManager {
    * The value each key was last handed to storage with, recorded by the sync effect.
    * Anything else in the state means storage has not been given the current value yet.
    */
-  lastSyncedValues: Partial<Record<UserSessionKey, any>>;
+  lastSyncedValues: Partial<Record<UserSessionKey, UserSessionValue>>;
 
   constructor(
     pluginsManager: IPluginsManager,

--- a/packages/analytics-js/src/components/userSessionManager/types.ts
+++ b/packages/analytics-js/src/components/userSessionManager/types.ts
@@ -6,6 +6,7 @@ import type { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/co
 import type { ResetOptions } from '@rudderstack/analytics-js-common/types/EventApi';
 import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
 import type { SessionInfo } from '@rudderstack/analytics-js-common/types/Session';
+import type { SessionState } from '@rudderstack/analytics-js-common/types/ApplicationState';
 
 export interface IUserSessionManager {
   storeManager?: IStoreManager;
@@ -30,6 +31,16 @@ export interface IUserSessionManager {
 }
 
 export type UserSessionStorageKeysType = keyof typeof COOKIE_KEYS;
+
+/**
+ * Any value a user session key can hold in the state, derived from the state contract so
+ * the two cannot drift apart. Deliberately not correlated per key: the only operation on
+ * these values is an identity comparison, and a per-key mapped type cannot be written
+ * through a union-typed key without a cast.
+ */
+export type UserSessionValue = {
+  [key in UserSessionKey]: SessionState[key]['value'];
+}[UserSessionKey];
 
 export type CookieValue = ApiObject | string | SessionInfo;
 


### PR DESCRIPTION
Resolves [SDK-4492](https://linear.app/rudderstack/issue/SDK-4492/use-session-information-from-in-memory-state-when-buffered-events-are), following the investigation in SDK-4443.

## Problem

Buffered events are replayed from inside the lifecycle `effect` (`Analytics.startLifecycle`), which puts every state write in one `@preact/signals-core` batch. The per-key storage sync effects registered by `UserSessionManager.init()` are queued behind that batch and **do not run in between**, so storage stays behind the state for the whole replay. They also coalesce — three writes produce one sync of the last value.

Verified against `signals-core@1.14.1` with a model of the same shape:

```
at effect registration  -> syncs = [0]
after buffered event 1 -> syncs = [0]     <- effect did NOT run
after buffered event 2 -> syncs = [0]
after buffered event 3 -> syncs = [0]
after lifecycle effect  -> syncs = [0,3]  <- ran once, last value only
post-load write         -> syncs = [0,3,4]
```

`refreshSession()` force-syncs session info during the replay, so a plain burst of `track` calls was already safe. State written **directly** never reached storage, so:

- a buffered `startSession(id)` was silently dropped — the next replayed event read the old session from the cookie and `startOrRenewAutoTracking()` overwrote the manual one
- a buffered `reset()` kept the pre-reset session
- a buffered `endSession()` had its session resurrected from the cookie

## Approach

Use the sync effect itself as the dirty-tracker: record the value it last handed to storage, and prefer the state whenever the signal has moved past it.

Reference identity is the right comparison — signals dedupe with `===`, so a same-reference assignment never queues the effect and never desyncs the record.

Storage stays authoritative otherwise, which is what keeps multi-tab session sharing working. Two guards on top:

- **persistence check** — with `storage.type: 'none'` the state can never be *ahead of* a storage that holds nothing. Without this, a session started during a replay survived the replay and then vanished on the next event.
- `peek()` rather than `.value`, so this read does not subscribe the enclosing lifecycle effect to all nine session signals.

The `useServerSideCookies` path needed nothing: the `serverSideCookiesRequestInProgress` guard added in SDK-4207 stays set for the whole synchronous replay.

## Testing

12 new unit tests reproduce the condition with `batch()` — the actual mechanism, so no lifecycle mocking. They cover manual start / reset / end during replay, expiry mid-replay, cookie / local / session / in-memory storage, `storage.type: 'none'`, and two guards proving reads return to storage once the sync has caught up.

- `UserSessionManager.test.ts` — 179 passed
- full `analytics-js` suite (incl. `browser.test.ts` preload-buffer specs) — 50 suites, 1293 passed
- `npm run check:size` — passes, no limit bump needed

A Playwright harness (not committed) drove a real browser through the loading snippet, asserting on **delivered event payloads**. Against `develop` it fails 3 of 9; with this change all 9 pass:

| Spec | develop | this PR |
| :--- | :--- | :--- |
| burst of buffered events shares a session | pass | pass |
| buffered `startSession` is honoured | **fail** | pass |
| buffered `reset` starts a new session | **fail** | pass |
| buffered `endSession` clears the session | **fail** | pass |
| `startSession` under server-side cookies | pass | pass |
| session survives `consent()` | pass | pass |
| two real tabs share one session | pass | pass |
| another tab's session wins after load | pass | pass |

Failure detail on `develop`: with a buffered `startSession(1029384756)`, the events replayed after it were stamped `1788418654013` instead.

Inverting the guard so the SDK *always* prefers in-memory state fails exactly one spec — "another tab's session wins after load" — confirming the multi-tab checks are real guards against over-applying this.

## Reviewer notes

- With `storage.type: 'none'` the behaviour is deliberately left **identical to `develop`** (session tracking stays off).
- The fix applies to all nine user-session keys since `getUserSessionValue` is shared, but in practice `sessionInfo` is the only key with readers during a replay — `Analytics.getUserId()` and friends read `state.session.*` directly rather than going through the session manager.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved user session reliability when events are replayed or storage updates are delayed.
- Ensured the latest session values remain available while storage synchronization is still in progress.
- Improved consistency for session data across supported storage modes, including in-memory storage.
- Strengthened handling of session value types to keep state and stored data aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->