### PR TITLE
chore: sdk-5254 resolve bing ads sonar findings

### DIFF
--- a/packages/analytics-js-integrations/__tests__/integrations/BingAds/utils.test.js
+++ b/packages/analytics-js-integrations/__tests__/integrations/BingAds/utils.test.js
@@ -221,7 +221,7 @@ describe('Construct PID payload for enahcned conversions', () => {
     const result = constructPidPayload(message, true);
 
     // Assert
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   // Returns undefined when email is invalid
@@ -249,6 +249,26 @@ describe('Construct PID payload for enahcned conversions', () => {
       context: {
         traits: {
           email: 'test+1@example.com',
+        },
+      },
+    };
+
+    // Act
+    const result = constructPidPayload(message, true);
+
+    // Assert
+    expect(result).toEqual({
+      em: '973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b',
+      '': '',
+    });
+  });
+
+  it('should remove all characters between the first plus sign and at sign before hashing', () => {
+    // Arrange
+    const message = {
+      context: {
+        traits: {
+          email: 'test+one+two@example.com',
         },
       },
     };

--- a/packages/analytics-js-integrations/src/integrations/BingAds/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/BingAds/utils.js
@@ -114,7 +114,7 @@ const formatAndHashEmailAddress = emailString => {
   let email = emailString.trim().toLowerCase();
 
   // Remove everything between “+” and “@”
-  email = email.replace(/\+[^@]+/g, '');
+  email = email.replace(/\+[^@]+/, '');
 
   // Remove any periods that come before “@”
   email = email.replace(/\./g, (match, offset) => {

--- a/packages/analytics-js-integrations/src/integrations/BingAds/utils.js
+++ b/packages/analytics-js-integrations/src/integrations/BingAds/utils.js
@@ -114,10 +114,10 @@ const formatAndHashEmailAddress = emailString => {
   let email = emailString.trim().toLowerCase();
 
   // Remove everything between “+” and “@”
-  email = email.replace(/\+[^@]+/, '');
+  email = email.replace(/\+[^@]+/g, '');
 
   // Remove any periods that come before “@”
-  email = email.replace(/\./g, (match, offset) => {
+  email = email.replace(/* NOSONAR */ /\./g, (match, offset) => {
     if (offset < email.indexOf('@')) {
       return '';
     }


### PR DESCRIPTION
## PR Description

Resolve the two minor SonarCloud findings in the Bing Ads integration.

- Use the dedicated Jest matcher for undefined values.
- Suppress the `replaceAll()` recommendation to retain existing behavior and legacy-browser compatibility.
- Add coverage for multiple plus-tag segments before the at sign.

The existing global replacement behavior is retained. The Sonar finding is suppressed because `String.prototype.replaceAll()` is unavailable in supported legacy browsers.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-5254/resolve-minor-sonarcloud-findings-in-bing-ads-integration

## Testing

- Focused Bing Ads tests: 19 passed.
- ESLint for both changed files: passed.
- Prettier check for both changed files: passed.
- Analytics integrations lint: passed with existing warnings.
- Repository affected tests: existing unrelated failures remain in Heap and Optimizely tests.

## Cross Browser Tests

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request will not create security issues with how the software is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bing Ads email normalization so text after a plus sign and before the “@” is consistently removed before hashing.
  - Updated Bing Ads payload validation to correctly handle undefined values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->