### PR TITLE
feat(analytics-js): deprecate pre-consent storage strategy

### DIFF
--- a/packages/analytics-js-common/src/constants/loggerContexts.ts
+++ b/packages/analytics-js-common/src/constants/loggerContexts.ts
@@ -9,6 +9,7 @@ const PLUGIN_ENGINE = 'PluginEngine';
 const STORE_MANAGER = 'StoreManager';
 const READY_API = `Ready${API_SUFFIX}`;
 const LOAD_API = `Load${API_SUFFIX}`;
+const CONSENT_API = `Consent${API_SUFFIX}`;
 const EVENT_REPOSITORY = 'EventRepository';
 const EXTERNAL_SRC_LOADER = 'ExternalSrcLoader';
 const HTTP_CLIENT = 'HttpClient';
@@ -25,6 +26,7 @@ export {
   STORE_MANAGER,
   READY_API,
   LOAD_API,
+  CONSENT_API,
   EVENT_REPOSITORY,
   EXTERNAL_SRC_LOADER,
   HTTP_CLIENT,

--- a/packages/analytics-js-common/src/types/ApplicationState.ts
+++ b/packages/analytics-js-common/src/types/ApplicationState.ts
@@ -193,7 +193,6 @@ export type StorageEntries = {
 export type StorageState = {
   encryptionPluginName: Signal<PluginName | undefined>;
   migrate: Signal<boolean>;
-  type: Signal<StorageType | undefined>;
   cookie: Signal<CookieOptions | undefined>;
   entries: Signal<StorageEntries>;
   trulyAnonymousTracking: Signal<boolean>;

--- a/packages/analytics-js-common/src/types/LoadOptions.ts
+++ b/packages/analytics-js-common/src/types/LoadOptions.ts
@@ -107,13 +107,13 @@ export type StorageStrategy = 'none' | 'session' | 'anonymousId';
 
 export type PreConsentStorageOptions = {
   /**
-   * Applies the `storage` load API option during the pre-consent phase. Nothing is persisted
-   * before consent is given unless this is enabled. Takes precedence over `strategy`.
-   * Defaults to false.
+   * Applies the `storage` load API option during the pre-consent phase, taking precedence over
+   * `strategy`. When it is not enabled, `strategy` decides what is persisted instead, and with
+   * neither of them nothing is persisted before consent is given. Defaults to false.
    */
   enabled?: boolean;
   /**
-   * Only applies when `enabled` is not set.
+   * Only applies when `enabled` is not set. Defaults to persisting nothing.
    * @deprecated Enable `storage` in the pre-consent options and use the `storage` load API option instead. It will be removed in the next major version.
    */
   strategy?: StorageStrategy;

--- a/packages/analytics-js-common/src/types/LoadOptions.ts
+++ b/packages/analytics-js-common/src/types/LoadOptions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/deprecation */
 import type { LogLevel } from './Logger';
 import type { Nullable } from './Nullable';
 import type { PluginName } from './PluginsManager';

--- a/packages/analytics-js-common/src/types/LoadOptions.ts
+++ b/packages/analytics-js-common/src/types/LoadOptions.ts
@@ -99,10 +99,16 @@ export type OnLoadedCallback = (analytics: any) => void;
 
 export type DeliveryType = 'immediate' | 'buffer';
 
+/**
+ * @deprecated Use the `storage` load API option to control what is persisted before consent is given. It will be removed in the next major version.
+ */
 export type StorageStrategy = 'none' | 'session' | 'anonymousId';
 
 export type PreConsentStorageOptions = {
-  strategy: StorageStrategy;
+  /**
+   * @deprecated Use the `storage` load API option to control what is persisted before consent is given. It will be removed in the next major version.
+   */
+  strategy?: StorageStrategy;
 };
 
 export type PreConsentEventsOptions = {

--- a/packages/analytics-js-common/src/types/LoadOptions.ts
+++ b/packages/analytics-js-common/src/types/LoadOptions.ts
@@ -108,10 +108,12 @@ export type StorageStrategy = 'none' | 'session' | 'anonymousId';
 export type PreConsentStorageOptions = {
   /**
    * Applies the `storage` load API option during the pre-consent phase. Nothing is persisted
-   * before consent is given unless this is enabled. Defaults to false.
+   * before consent is given unless this is enabled. Takes precedence over `strategy`.
+   * Defaults to false.
    */
   enabled?: boolean;
   /**
+   * Only applies when `enabled` is not set.
    * @deprecated Enable `storage` in the pre-consent options and use the `storage` load API option instead. It will be removed in the next major version.
    */
   strategy?: StorageStrategy;

--- a/packages/analytics-js-common/src/types/LoadOptions.ts
+++ b/packages/analytics-js-common/src/types/LoadOptions.ts
@@ -107,7 +107,12 @@ export type StorageStrategy = 'none' | 'session' | 'anonymousId';
 
 export type PreConsentStorageOptions = {
   /**
-   * @deprecated Use the `storage` load API option to control what is persisted before consent is given. It will be removed in the next major version.
+   * Applies the `storage` load API option during the pre-consent phase. Nothing is persisted
+   * before consent is given unless this is enabled. Defaults to false.
+   */
+  enabled?: boolean;
+  /**
+   * @deprecated Enable `storage` in the pre-consent options and use the `storage` load API option instead. It will be removed in the next major version.
    */
   strategy?: StorageStrategy;
 };

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -83,7 +83,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (UMD)',
     path: 'dist/npm/modern/bundled/umd/index.js',
     import: '*',
-    limit: '41.5 KiB',
+    limit: '42 KiB',
   },
   {
     name: 'Core (Content Script) - Legacy - NPM (ESM)',
@@ -119,7 +119,7 @@ export default [
     name: 'Core (Content Script) - Modern - NPM (UMD)',
     path: 'dist/npm/modern/content-script/umd/index.js',
     import: '*',
-    limit: '41.5 KiB',
+    limit: '42 KiB',
   },
   {
     name: 'Core (Lite) - Legacy - NPM (ESM)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -36,7 +36,7 @@ export default [
     name: 'Core - Modern - NPM (CJS)',
     path: 'dist/npm/modern/cjs/index.cjs',
     import: '*',
-    limit: '28.5 KiB',
+    limit: '29 KiB',
   },
   {
     name: 'Core - Modern - NPM (UMD)',
@@ -71,7 +71,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (ESM)',
     path: 'dist/npm/modern/bundled/esm/index.mjs',
     import: '*',
-    limit: '41.5 KiB',
+    limit: '42 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (CJS)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -107,7 +107,7 @@ export default [
     name: 'Core (Content Script) - Modern - NPM (ESM)',
     path: 'dist/npm/modern/content-script/esm/index.mjs',
     import: '*',
-    limit: '41.5 KiB',
+    limit: '42 KiB',
   },
   {
     name: 'Core (Content Script) - Modern - NPM (CJS)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -71,7 +71,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (ESM)',
     path: 'dist/npm/modern/bundled/esm/index.mjs',
     import: '*',
-    limit: '42 KiB',
+    limit: '41.5 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (CJS)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -71,7 +71,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (ESM)',
     path: 'dist/npm/modern/bundled/esm/index.mjs',
     import: '*',
-    limit: '41.5 KiB',
+    limit: '42 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (CJS)',

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -190,9 +190,10 @@ describe('Config Manager Common Utilities', () => {
 
       updateStorageStateFromLoadOptions(mockLogger);
 
-      expect(state.storage.type.value).toBe('cookieStorage');
+      // An unsupported type is not a configured type, so the applicable default is used instead
+      expect(state.storage.type.value).toBeUndefined();
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'ConfigManager:: The storage type "random-type" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default type "cookieStorage" will be used instead.',
+        'ConfigManager:: The storage type "random-type" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default storage type will be used instead.',
       );
     });
 

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -182,21 +182,6 @@ describe('Config Manager Common Utilities', () => {
       expect(state.storage.encryptionPluginName.value).toBe('StorageEncryption');
     });
 
-    it('should log a warning if the specified storage type is not valid', () => {
-      state.loadOptions.value.storage = {
-        // @ts-expect-error testing invalid value
-        type: 'random-type',
-      };
-
-      updateStorageStateFromLoadOptions(mockLogger);
-
-      // An unsupported type is not a configured type, so the applicable default is used instead
-      expect(state.storage.type.value).toBeUndefined();
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'ConfigManager:: The storage type "random-type" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default storage type will be used instead.',
-      );
-    });
-
     it('should log a warning if the encryption version is not supported', () => {
       state.loadOptions.value.storage = {
         encryption: {

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -364,7 +364,7 @@ describe('Config Manager Common Utilities', () => {
 
       updateConsentsStateFromLoadOptions(mockLogger);
 
-      expect(state.consents.activeConsentManagerPluginName.value).toBe(undefined);
+      expect(state.consents.activeConsentManagerPluginName.value).toBeUndefined();
       expect(mockLogger.error).toHaveBeenCalledWith(
         'ConfigManager:: The consent manager "randomManager" is not supported. Please choose one of the following supported consent managers: "iubenda,oneTrust,ketch,custom".',
       );
@@ -544,7 +544,7 @@ describe('Config Manager Common Utilities', () => {
       expect(state.consents.metadata.value).toStrictEqual(
         mockSourceConfig.consentManagementMetadata,
       );
-      expect(state.consents.resolutionStrategy.value).toBe(undefined);
+      expect(state.consents.resolutionStrategy.value).toBeUndefined();
     });
 
     it('should not update the metadata and resolution strategy to state if the metadata in source config is not an object literal', () => {
@@ -555,7 +555,7 @@ describe('Config Manager Common Utilities', () => {
 
       updateConsentsState(mockSourceConfig);
 
-      expect(state.consents.metadata.value).toBe(undefined);
+      expect(state.consents.metadata.value).toBeUndefined();
       expect(state.consents.resolutionStrategy.value).toBe('and'); // default value
     });
 

--- a/packages/analytics-js/__tests__/components/configManager/validate.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/validate.test.ts
@@ -62,11 +62,14 @@ describe('Config manager util - validate load arguments', () => {
       expect(logger.warn).not.toHaveBeenCalled();
     });
 
-    it('should not warn if no storage options are provided', () => {
-      validateStorageOptions(undefined, 'ConfigManager', logger);
-
-      expect(logger.warn).not.toHaveBeenCalled();
-    });
+    it.each([undefined, null, 'a string', 42, true, [], () => {}])(
+      'should not warn or throw for a non object storage options value: %p',
+      storageOpts => {
+        // @ts-expect-error testing invalid values
+        expect(() => validateStorageOptions(storageOpts, 'ConsentAPI', logger)).not.toThrow();
+        expect(logger.warn).not.toHaveBeenCalled();
+      },
+    );
 
     it('should warn for an unsupported storage type', () => {
       // @ts-expect-error testing invalid value

--- a/packages/analytics-js/__tests__/components/configManager/validate.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/validate.test.ts
@@ -1,7 +1,9 @@
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import {
   getTopDomainUrl,
   getDataServiceUrl,
   isWebpageTopLevelDomain,
+  validateStorageOptions,
 } from '../../../src/components/configManager/util/validate';
 
 describe('Config manager util - validate load arguments', () => {
@@ -40,6 +42,63 @@ describe('Config manager util - validate load arguments', () => {
     it('should return false for subdomain', () => {
       const isTopLevel = isWebpageTopLevelDomain('sub.test-host.com');
       expect(isTopLevel).toBe(false);
+    });
+  });
+
+  describe('validateStorageOptions', () => {
+    const logger = { warn: jest.fn(), error: jest.fn() } as unknown as ILogger;
+
+    beforeEach(() => {
+      (logger.warn as jest.Mock).mockClear();
+    });
+
+    it('should not warn for supported storage options', () => {
+      validateStorageOptions(
+        { type: 'localStorage', entries: { anonymousId: { type: 'cookieStorage' } } },
+        'ConfigManager',
+        logger,
+      );
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should not warn if no storage options are provided', () => {
+      validateStorageOptions(undefined, 'ConfigManager', logger);
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should warn for an unsupported storage type', () => {
+      // @ts-expect-error testing invalid value
+      validateStorageOptions({ type: 'random-type' }, 'ConfigManager', logger);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'ConfigManager:: The storage type "random-type" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default storage type will be used instead.',
+      );
+    });
+
+    it('should warn for each entry with an unsupported storage type', () => {
+      validateStorageOptions(
+        {
+          entries: {
+            // @ts-expect-error testing invalid value
+            anonymousId: { type: 'localStoarge' },
+            sessionInfo: { type: 'cookieStorage' },
+            // @ts-expect-error testing invalid value
+            userId: { type: 'random-type' },
+          },
+        },
+        'ConsentAPI',
+        logger,
+      );
+
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'ConsentAPI:: The storage type "localStoarge" configured for the entry "anonymousId" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default storage type will be used instead.',
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        'ConsentAPI:: The storage type "random-type" configured for the entry "userId" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default storage type will be used instead.',
+      );
     });
   });
 });

--- a/packages/analytics-js/__tests__/components/core/Analytics.test.ts
+++ b/packages/analytics-js/__tests__/components/core/Analytics.test.ts
@@ -853,7 +853,9 @@ describe('Core - Analytics', () => {
   describe('page', () => {
     it('should buffer events until loaded', () => {
       analytics.page({ name: 'name' });
-      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([['page', { name: 'name' }]]);
+      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
+        ['page', { name: 'name' }],
+      ]);
     });
     it('should sent events if loaded', () => {
       analytics.prepareInternalServices();
@@ -1091,9 +1093,7 @@ describe('Core - Analytics', () => {
   describe('alias', () => {
     it('should buffer events until loaded', () => {
       analytics.alias({ to: 'to' });
-      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([
-        ['alias', { to: 'to' }],
-      ]);
+      expect(state.eventBuffer.toBeProcessedArray.value).toStrictEqual([['alias', { to: 'to' }]]);
     });
     it('should sent events if loaded', () => {
       state.storage.entries.value = entriesWithOnlyCookieStorage;
@@ -1302,7 +1302,7 @@ describe('Core - Analytics', () => {
       state.consents.enabled.value = true;
       state.lifecycle.loaded.value = true;
       state.consents.initialized.value = false;
-      state.storage.type.value = 'localStorage';
+      state.loadOptions.value.storage.type = 'localStorage';
       state.storage.entries.value = entriesWithMixStorage;
 
       const leaveBreadcrumbSpy = jest.spyOn(analytics.errorHandler, 'leaveBreadcrumb');
@@ -1398,7 +1398,6 @@ describe('Core - Analytics', () => {
       expect(resumeSpy).toHaveBeenCalledTimes(1);
       expect(loadDestinationsSpy).toHaveBeenCalledTimes(1);
 
-      expect(state.storage.type.value).toBe('cookieStorage');
       expect(state.storage.entries.value).toStrictEqual({
         userId: {
           type: 'sessionStorage',
@@ -1514,7 +1513,7 @@ describe('Core - Analytics', () => {
       state.consents.enabled.value = true;
       state.lifecycle.loaded.value = true;
       state.consents.initialized.value = false;
-      state.storage.type.value = 'localStorage';
+      state.loadOptions.value.storage.type = 'localStorage';
       state.storage.entries.value = entriesWithMixStorage;
 
       const invokeSingleSpy = jest.spyOn(

--- a/packages/analytics-js/__tests__/components/userSessionManager/preConsentStorageTransition.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/preConsentStorageTransition.test.ts
@@ -1,0 +1,151 @@
+import { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
+import type { StorageOpts } from '@rudderstack/analytics-js-common/types/Storage';
+import type { PreConsentOptions } from '@rudderstack/analytics-js-common/types/LoadOptions';
+import { UserSessionManager } from '../../../src/components/userSessionManager';
+import { StoreManager } from '../../../src/services/StoreManager';
+import type { Store } from '../../../src/services/StoreManager/Store';
+import { state, resetState } from '../../../src/state';
+import { defaultLogger } from '../../../src/services/Logger';
+import { defaultErrorHandler } from '../../../src/services/ErrorHandler';
+import { defaultHttpClient } from '../../../src/services/HttpClient';
+import { PluginsManager } from '../../../src/components/pluginsManager';
+import { defaultPluginEngine } from '../../../src/services/PluginEngine';
+import {
+  updateConsentsStateFromLoadOptions,
+  updateStorageStateFromLoadOptions,
+} from '../../../src/components/configManager/util/commonUtil';
+
+/**
+ * Without the deprecated storage strategy, the load API storage options decide what is persisted
+ * before consent is given. These cover the transition to the post-consent phase.
+ */
+describe('Pre-consent to post-consent storage transition', () => {
+  const defaultPluginsManager = new PluginsManager(
+    defaultPluginEngine,
+    defaultErrorHandler,
+    defaultLogger,
+  );
+  const storeManager = new StoreManager(defaultPluginsManager, defaultErrorHandler, defaultLogger);
+  storeManager.init();
+
+  const clientDataStoreCookie = storeManager.getStore('clientDataInCookie') as Store;
+  const clientDataStoreLS = storeManager.getStore('clientDataInLocalStorage') as Store;
+  const clientDataStoreSession = storeManager.getStore('clientDataInSessionStorage') as Store;
+
+  let userSessionManager: UserSessionManager;
+
+  beforeEach(() => {
+    Object.values(COOKIE_KEYS).forEach(key => {
+      clientDataStoreCookie.remove(key);
+      clientDataStoreLS.remove(key);
+      clientDataStoreSession.remove(key);
+    });
+
+    resetState();
+    defaultHttpClient.init(defaultErrorHandler);
+
+    state.loadOptions.value.consentManagement = { enabled: true, provider: 'oneTrust' };
+
+    userSessionManager = new UserSessionManager(
+      defaultPluginsManager,
+      storeManager,
+      defaultHttpClient,
+      defaultErrorHandler,
+      defaultLogger,
+    );
+  });
+
+  const loadBeforeConsent = (storage: StorageOpts, preConsent: PreConsentOptions) => {
+    state.loadOptions.value.storage = storage;
+    state.loadOptions.value.preConsent = preConsent;
+
+    updateStorageStateFromLoadOptions(defaultLogger);
+    updateConsentsStateFromLoadOptions(defaultLogger);
+    storeManager.initializeStorageState();
+    userSessionManager.init();
+  };
+
+  /**
+   * Mirrors what the consent API does once consent is given
+   */
+  const giveConsent = (postConsentStorage?: StorageOpts) => {
+    if (postConsentStorage) {
+      state.consents.postConsent.value = { storage: postConsentStorage };
+    }
+    state.consents.preConsent.value = { ...state.consents.preConsent.value, enabled: false };
+    storeManager.initializeStorageState();
+    userSessionManager.syncStorageDataToState();
+  };
+
+  it('should not persist anything before consent if no storage type is configured', () => {
+    loadBeforeConsent({}, { enabled: true, events: { delivery: 'buffer' } });
+
+    // The anonymous ID is only generated for a storage type that can hold it
+    expect(state.session.anonymousId.value).toBe('');
+    expect(state.storage.trulyAnonymousTracking.value).toBe(true);
+
+    giveConsent();
+
+    expect(state.session.anonymousId.value).not.toBe('');
+    expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toBe(
+      state.session.anonymousId.value,
+    );
+  });
+
+  it('should persist only the configured entries before consent', () => {
+    loadBeforeConsent(
+      { entries: { anonymousId: { type: 'cookieStorage' } } },
+      { enabled: true, events: { delivery: 'buffer' } },
+    );
+
+    const preConsentAnonymousId = state.session.anonymousId.value;
+
+    expect(preConsentAnonymousId).not.toBe('');
+    expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toBe(preConsentAnonymousId);
+    expect(clientDataStoreCookie.get(COOKIE_KEYS.userTraits)).toBeNull();
+
+    giveConsent();
+
+    expect(state.session.anonymousId.value).toBe(preConsentAnonymousId);
+  });
+
+  it('should relocate the persisted data if the post-consent storage type differs', () => {
+    loadBeforeConsent(
+      { entries: { anonymousId: { type: 'sessionStorage' } } },
+      { enabled: true, events: { delivery: 'buffer' } },
+    );
+
+    const preConsentAnonymousId = state.session.anonymousId.value;
+
+    expect(clientDataStoreSession.get(COOKIE_KEYS.anonymousId)).toBe(preConsentAnonymousId);
+    expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toBeNull();
+
+    giveConsent({ type: 'cookieStorage' });
+
+    expect(state.session.anonymousId.value).toBe(preConsentAnonymousId);
+    expect(clientDataStoreCookie.get(COOKIE_KEYS.anonymousId)).toBe(preConsentAnonymousId);
+    expect(clientDataStoreSession.get(COOKIE_KEYS.anonymousId)).toBeNull();
+  });
+
+  it('should retain the session generated before consent when the session info is persisted', () => {
+    loadBeforeConsent(
+      {
+        entries: {
+          anonymousId: { type: 'cookieStorage' },
+          sessionInfo: { type: 'cookieStorage' },
+        },
+      },
+      { enabled: true, events: { delivery: 'buffer' } },
+    );
+
+    const preConsentAnonymousId = state.session.anonymousId.value;
+    const preConsentSessionId = state.session.sessionInfo.value.id;
+
+    expect(preConsentSessionId).toBeDefined();
+
+    giveConsent();
+
+    expect(state.session.anonymousId.value).toBe(preConsentAnonymousId);
+    expect(state.session.sessionInfo.value.id).toBe(preConsentSessionId);
+  });
+});

--- a/packages/analytics-js/__tests__/components/userSessionManager/preConsentStorageTransition.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/preConsentStorageTransition.test.ts
@@ -101,7 +101,7 @@ describe('Pre-consent to post-consent storage transition', () => {
   it('should persist only the configured entries before consent', () => {
     loadBeforeConsent(
       { entries: { anonymousId: { type: 'cookieStorage' } } },
-      { enabled: true, events: { delivery: 'buffer' } },
+      { enabled: true, storage: { enabled: true }, events: { delivery: 'buffer' } },
     );
 
     const preConsentAnonymousId = state.session.anonymousId.value;
@@ -118,7 +118,7 @@ describe('Pre-consent to post-consent storage transition', () => {
   it('should relocate the persisted data if the post-consent storage type differs', () => {
     loadBeforeConsent(
       { entries: { anonymousId: { type: 'sessionStorage' } } },
-      { enabled: true, events: { delivery: 'buffer' } },
+      { enabled: true, storage: { enabled: true }, events: { delivery: 'buffer' } },
     );
 
     const preConsentAnonymousId = state.session.anonymousId.value;
@@ -141,7 +141,7 @@ describe('Pre-consent to post-consent storage transition', () => {
           sessionInfo: { type: 'cookieStorage' },
         },
       },
-      { enabled: true, events: { delivery: 'buffer' } },
+      { enabled: true, storage: { enabled: true }, events: { delivery: 'buffer' } },
     );
 
     const preConsentAnonymousId = state.session.anonymousId.value;

--- a/packages/analytics-js/__tests__/components/userSessionManager/preConsentStorageTransition.test.ts
+++ b/packages/analytics-js/__tests__/components/userSessionManager/preConsentStorageTransition.test.ts
@@ -26,13 +26,19 @@ describe('Pre-consent to post-consent storage transition', () => {
     defaultLogger,
   );
   const storeManager = new StoreManager(defaultPluginsManager, defaultErrorHandler, defaultLogger);
-  storeManager.init();
 
-  const clientDataStoreCookie = storeManager.getStore('clientDataInCookie') as Store;
-  const clientDataStoreLS = storeManager.getStore('clientDataInLocalStorage') as Store;
-  const clientDataStoreSession = storeManager.getStore('clientDataInSessionStorage') as Store;
-
+  let clientDataStoreCookie: Store;
+  let clientDataStoreLS: Store;
+  let clientDataStoreSession: Store;
   let userSessionManager: UserSessionManager;
+
+  beforeAll(() => {
+    storeManager.init();
+
+    clientDataStoreCookie = storeManager.getStore('clientDataInCookie') as Store;
+    clientDataStoreLS = storeManager.getStore('clientDataInLocalStorage') as Store;
+    clientDataStoreSession = storeManager.getStore('clientDataInSessionStorage') as Store;
+  });
 
   beforeEach(() => {
     Object.values(COOKIE_KEYS).forEach(key => {

--- a/packages/analytics-js/__tests__/services/StoreManager/StoreManager.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/StoreManager.test.ts
@@ -123,20 +123,20 @@ describe('StoreManager', () => {
     });
 
     it('should construct the storage entry state with global storage type if only global storage type is provided as load option', () => {
-      state.storage.type.value = LOCAL_STORAGE;
+      state.loadOptions.value.storage.type = LOCAL_STORAGE;
       storeManager.initClientDataStores();
       expect(state.storage.entries.value).toEqual(entriesWithOnlyLocalStorage);
     });
 
     it('should enable truly anonymous tracking if all the persisted data have storage type none', () => {
-      state.storage.type.value = NO_STORAGE;
+      state.loadOptions.value.storage.type = NO_STORAGE;
       storeManager.initClientDataStores();
       expect(state.storage.entries.value).toEqual(entriesWithOnlyNoStorage);
       expect(state.storage.trulyAnonymousTracking.value).toBe(true);
     });
 
     it('should construct the storage entry state with global type session storage', () => {
-      state.storage.type.value = SESSION_STORAGE;
+      state.loadOptions.value.storage.type = SESSION_STORAGE;
       getStorageEngine.mockImplementation(() => ({
         isEnabled: true,
         getItem: jest.fn(),
@@ -148,7 +148,7 @@ describe('StoreManager', () => {
     });
 
     it('should construct the storage entry state with global type and load options', () => {
-      state.storage.type.value = MEMORY_STORAGE;
+      state.loadOptions.value.storage.type = MEMORY_STORAGE;
       state.loadOptions.value.storage.entries = loadOptionWithEntry;
       storeManager.initClientDataStores();
       expect(state.storage.entries.value).toEqual(entriesWithMixStorage);
@@ -158,8 +158,8 @@ describe('StoreManager', () => {
     it('should construct the valid storage entry state if invalid storage entry in load option', () => {
       state.loadOptions.value.storage.entries = loadOptionWithInvalidEntry;
       storeManager.initClientDataStores();
+      // The unsupported types are reported where the options enter the SDK, not here
       expect(state.storage.entries.value).toEqual(entriesWithOnlyCookieStorage);
-      expect(logger.warn).toHaveBeenCalled();
       expect(state.storage.trulyAnonymousTracking.value).toBe(false);
     });
 

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -281,7 +281,7 @@ describe('Pre-consent storage resolution', () => {
         },
         {
           enabled: true,
-          storage: { enabled: true, storage: { enabled: true } },
+          storage: { enabled: true },
           events: { delivery: 'buffer' },
         },
       );
@@ -342,7 +342,7 @@ describe('Pre-consent storage resolution', () => {
         { entries: { anonymousId: { type: 'localStoarge' } } },
         {
           enabled: true,
-          storage: { enabled: true, storage: { enabled: true } },
+          storage: { enabled: true },
           events: { delivery: 'buffer' },
         },
       );

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -1,0 +1,216 @@
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import type { StorageOpts, StorageType } from '@rudderstack/analytics-js-common/types/Storage';
+import type { PreConsentOptions } from '@rudderstack/analytics-js-common/types/LoadOptions';
+import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
+import { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
+import { getStorageEngine } from '../../../src/services/StoreManager/storages/storageEngine';
+import { state, resetState } from '../../../src/state';
+import { StoreManager } from '../../../src/services/StoreManager';
+import { PluginsManager } from '../../../src/components/pluginsManager';
+import { defaultPluginEngine } from '../../../src/services/PluginEngine';
+import { defaultErrorHandler } from '../../../src/services/ErrorHandler';
+import { defaultLogger } from '../../../src/services/Logger';
+import { USER_SESSION_KEYS } from '../../../src/constants/storage';
+import {
+  updateConsentsStateFromLoadOptions,
+  updateStorageStateFromLoadOptions,
+} from '../../../src/components/configManager/util/commonUtil';
+
+jest.mock('../../../src/services/StoreManager/storages/storageEngine', () => ({
+  __esModule: true,
+  configureStorageEngines: jest.fn(),
+  getStorageEngine: jest.fn().mockReturnValue({
+    isEnabled: true,
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  }),
+}));
+
+/**
+ * Builds the expected `state.storage.entries` value: every user session key resolves to
+ * `defaultType` unless it is named in `overrides`.
+ */
+const buildExpectedEntries = (
+  defaultType: StorageType,
+  overrides: Partial<Record<UserSessionKey, StorageType>> = {},
+) =>
+  USER_SESSION_KEYS.reduce(
+    (entries, sessionKey) => ({
+      ...entries,
+      [sessionKey]: {
+        type: overrides[sessionKey] ?? defaultType,
+        key: COOKIE_KEYS[sessionKey],
+      },
+    }),
+    {},
+  );
+
+type TestCase = {
+  description: string;
+  storage?: StorageOpts;
+  preConsent: PreConsentOptions;
+  expectedEntries: ReturnType<typeof buildExpectedEntries>;
+  expectedTrulyAnonymousTracking: boolean;
+};
+
+/**
+ * Locks in the storage resolution behaviour of every supported `preConsent.storage.strategy`
+ * value against the load API storage options, across the full pipeline:
+ * load options -> config manager -> store manager -> `state.storage.entries`.
+ *
+ * These expectations must not change when `strategy` is deprecated in favour of the granular
+ * `type`/`entries` options, so they are asserted against explicitly constructed values rather
+ * than shared fixtures.
+ */
+describe('Pre-consent storage resolution', () => {
+  let logger: ILogger;
+  let storeManager: StoreManager;
+  const defaultPluginsManager = new PluginsManager(
+    defaultPluginEngine,
+    defaultErrorHandler,
+    defaultLogger,
+  );
+
+  beforeEach(() => {
+    resetState();
+    // Every storage type is available, so the availability fallbacks never kick in
+    (getStorageEngine as jest.Mock).mockImplementation(() => ({
+      isEnabled: true,
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    }));
+    logger = { error: jest.fn(), warn: jest.fn() } as unknown as ILogger;
+    storeManager = new StoreManager(defaultPluginsManager, { onError: jest.fn() } as any, logger);
+    // Pre-consent is only active when consent management is enabled and not already initialized
+    state.loadOptions.value.consentManagement = {
+      enabled: true,
+      provider: 'oneTrust',
+    };
+  });
+
+  afterEach(() => {
+    storeManager.isInitialized = false;
+    jest.resetAllMocks();
+  });
+
+  const testCases: TestCase[] = [
+    {
+      description: 'no storage options at all persists nothing',
+      preConsent: { enabled: true },
+      expectedEntries: buildExpectedEntries('none'),
+      expectedTrulyAnonymousTracking: true,
+    },
+    {
+      description: 'strategy "none" persists nothing',
+      preConsent: { enabled: true, storage: { strategy: 'none' } },
+      expectedEntries: buildExpectedEntries('none'),
+      expectedTrulyAnonymousTracking: true,
+    },
+    {
+      description: 'strategy "none" persists nothing even with load API storage options',
+      storage: { type: 'localStorage', entries: { anonymousId: { type: 'cookieStorage' } } },
+      preConsent: { enabled: true, storage: { strategy: 'none' } },
+      expectedEntries: buildExpectedEntries('none'),
+      expectedTrulyAnonymousTracking: true,
+    },
+    {
+      description: 'strategy "session" persists only sessionInfo in the default storage type',
+      preConsent: { enabled: true, storage: { strategy: 'session' } },
+      expectedEntries: buildExpectedEntries('none', { sessionInfo: 'cookieStorage' }),
+      expectedTrulyAnonymousTracking: false,
+    },
+    {
+      description: 'strategy "session" persists sessionInfo in the load API global storage type',
+      storage: { type: 'localStorage' },
+      preConsent: { enabled: true, storage: { strategy: 'session' } },
+      expectedEntries: buildExpectedEntries('none', { sessionInfo: 'localStorage' }),
+      expectedTrulyAnonymousTracking: false,
+    },
+    {
+      description: 'strategy "session" persists sessionInfo in its load API entry storage type',
+      storage: {
+        type: 'localStorage',
+        entries: {
+          sessionInfo: { type: 'sessionStorage' },
+          anonymousId: { type: 'cookieStorage' },
+        },
+      },
+      preConsent: { enabled: true, storage: { strategy: 'session' } },
+      expectedEntries: buildExpectedEntries('none', { sessionInfo: 'sessionStorage' }),
+      expectedTrulyAnonymousTracking: false,
+    },
+    {
+      description: 'strategy "session" persists nothing if the load API storage type is none',
+      storage: { type: 'none' },
+      preConsent: { enabled: true, storage: { strategy: 'session' } },
+      expectedEntries: buildExpectedEntries('none'),
+      expectedTrulyAnonymousTracking: true,
+    },
+    {
+      description: 'strategy "anonymousId" persists only anonymousId in the default storage type',
+      preConsent: { enabled: true, storage: { strategy: 'anonymousId' } },
+      expectedEntries: buildExpectedEntries('none', { anonymousId: 'cookieStorage' }),
+      expectedTrulyAnonymousTracking: false,
+    },
+    {
+      description:
+        'strategy "anonymousId" persists anonymousId in the load API global storage type',
+      storage: { type: 'sessionStorage' },
+      preConsent: { enabled: true, storage: { strategy: 'anonymousId' } },
+      expectedEntries: buildExpectedEntries('none', { anonymousId: 'sessionStorage' }),
+      expectedTrulyAnonymousTracking: false,
+    },
+    {
+      description: 'strategy "anonymousId" persists anonymousId in its load API entry storage type',
+      storage: {
+        type: 'localStorage',
+        entries: {
+          anonymousId: { type: 'sessionStorage' },
+          sessionInfo: { type: 'cookieStorage' },
+        },
+      },
+      preConsent: { enabled: true, storage: { strategy: 'anonymousId' } },
+      expectedEntries: buildExpectedEntries('none', { anonymousId: 'sessionStorage' }),
+      expectedTrulyAnonymousTracking: false,
+    },
+    {
+      description: 'strategy "anonymousId" persists nothing if its load API entry type is none',
+      storage: { type: 'localStorage', entries: { anonymousId: { type: 'none' } } },
+      preConsent: { enabled: true, storage: { strategy: 'anonymousId' } },
+      expectedEntries: buildExpectedEntries('none'),
+      expectedTrulyAnonymousTracking: true,
+    },
+    {
+      description: 'an unsupported strategy falls back to persisting nothing',
+      storage: { type: 'localStorage' },
+      // @ts-expect-error testing invalid value
+      preConsent: { enabled: true, storage: { strategy: 'random-strategy' } },
+      expectedEntries: buildExpectedEntries('none'),
+      expectedTrulyAnonymousTracking: true,
+    },
+    {
+      description: 'the strategy is ignored when pre-consent is disabled',
+      storage: { type: 'localStorage', entries: { sessionInfo: { type: 'sessionStorage' } } },
+      preConsent: { enabled: false, storage: { strategy: 'none' } },
+      expectedEntries: buildExpectedEntries('localStorage', { sessionInfo: 'sessionStorage' }),
+      expectedTrulyAnonymousTracking: false,
+    },
+  ];
+
+  it.each(testCases)(
+    '$description',
+    ({ storage, preConsent, expectedEntries, expectedTrulyAnonymousTracking }) => {
+      state.loadOptions.value.storage = { ...state.loadOptions.value.storage, ...storage };
+      state.loadOptions.value.preConsent = preConsent;
+
+      updateStorageStateFromLoadOptions(logger);
+      updateConsentsStateFromLoadOptions(logger);
+      storeManager.initClientDataStores();
+
+      expect(state.storage.entries.value).toEqual(expectedEntries);
+      expect(state.storage.trulyAnonymousTracking.value).toBe(expectedTrulyAnonymousTracking);
+    },
+  );
+});

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -59,9 +59,9 @@ type TestCase = {
  * value against the load API storage options, across the full pipeline:
  * load options -> config manager -> store manager -> `state.storage.entries`.
  *
- * These expectations must not change when `strategy` is deprecated in favour of the granular
- * `type`/`entries` options, so they are asserted against explicitly constructed values rather
- * than shared fixtures.
+ * These expectations must not change now that `strategy` is deprecated in favour of the storage
+ * load API option, so they are asserted against explicitly constructed values rather than shared
+ * fixtures.
  */
 describe('Pre-consent storage resolution', () => {
   let logger: ILogger;
@@ -94,6 +94,22 @@ describe('Pre-consent storage resolution', () => {
     storeManager.isInitialized = false;
     jest.resetAllMocks();
   });
+
+  /**
+   * Runs the load options through the whole resolution pipeline:
+   * config manager -> store manager -> `state.storage.entries`
+   */
+  const resolveStorageEntries = (
+    storage: StorageOpts | undefined,
+    preConsent: PreConsentOptions,
+  ) => {
+    state.loadOptions.value.storage = { ...state.loadOptions.value.storage, ...storage };
+    state.loadOptions.value.preConsent = preConsent;
+
+    updateStorageStateFromLoadOptions(logger);
+    updateConsentsStateFromLoadOptions(logger);
+    storeManager.initClientDataStores();
+  };
 
   const testCases: TestCase[] = [
     {
@@ -202,15 +218,88 @@ describe('Pre-consent storage resolution', () => {
   it.each(testCases)(
     '$description',
     ({ storage, preConsent, expectedEntries, expectedTrulyAnonymousTracking }) => {
-      state.loadOptions.value.storage = { ...state.loadOptions.value.storage, ...storage };
-      state.loadOptions.value.preConsent = preConsent;
-
-      updateStorageStateFromLoadOptions(logger);
-      updateConsentsStateFromLoadOptions(logger);
-      storeManager.initClientDataStores();
+      resolveStorageEntries(storage, preConsent);
 
       expect(state.storage.entries.value).toEqual(expectedEntries);
       expect(state.storage.trulyAnonymousTracking.value).toBe(expectedTrulyAnonymousTracking);
     },
   );
+
+  describe('without the storage strategy', () => {
+    it('should persist both the anonymous ID and the session info if they are the only configured entries', () => {
+      resolveStorageEntries(
+        {
+          entries: {
+            anonymousId: { type: 'cookieStorage' },
+            sessionInfo: { type: 'cookieStorage' },
+          },
+        },
+        { enabled: true, events: { delivery: 'buffer' } },
+      );
+
+      expect(state.storage.entries.value).toEqual(
+        buildExpectedEntries('none', {
+          anonymousId: 'cookieStorage',
+          sessionInfo: 'cookieStorage',
+        }),
+      );
+      expect(state.storage.trulyAnonymousTracking.value).toBe(false);
+    });
+
+    it('should persist every entry if the storage type is configured', () => {
+      resolveStorageEntries({ type: 'localStorage' }, { enabled: true });
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('localStorage'));
+      expect(state.storage.trulyAnonymousTracking.value).toBe(false);
+    });
+
+    it('should give the entry storage type precedence over the storage type', () => {
+      resolveStorageEntries(
+        { type: 'localStorage', entries: { anonymousId: { type: 'sessionStorage' } } },
+        { enabled: true },
+      );
+
+      expect(state.storage.entries.value).toEqual(
+        buildExpectedEntries('localStorage', { anonymousId: 'sessionStorage' }),
+      );
+    });
+
+    it('should not persist an entry that is configured with no storage', () => {
+      resolveStorageEntries(
+        { type: 'localStorage', entries: { anonymousId: { type: 'none' } } },
+        { enabled: true },
+      );
+
+      expect(state.storage.entries.value).toEqual(
+        buildExpectedEntries('localStorage', { anonymousId: 'none' }),
+      );
+    });
+
+    it('should not log a deprecation warning', () => {
+      resolveStorageEntries({ type: 'localStorage' }, { enabled: true });
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with the deprecated storage strategy', () => {
+    it('should take precedence over the storage options', () => {
+      resolveStorageEntries(
+        { type: 'localStorage', entries: { anonymousId: { type: 'cookieStorage' } } },
+        { enabled: true, storage: { strategy: 'session' } },
+      );
+
+      expect(state.storage.entries.value).toEqual(
+        buildExpectedEntries('none', { sessionInfo: 'localStorage' }),
+      );
+    });
+
+    it('should log a deprecation warning', () => {
+      resolveStorageEntries(undefined, { enabled: true, storage: { strategy: 'session' } });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'ConfigManager:: The pre-consent storage strategy option is deprecated. Please use the "storage" load API option instead.',
+      );
+    });
+  });
 });

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -281,6 +281,30 @@ describe('Pre-consent storage resolution', () => {
 
       expect(logger.warn).not.toHaveBeenCalled();
     });
+
+    it('should not persist an entry whose storage type is unsupported', () => {
+      resolveStorageEntries(
+        // @ts-expect-error testing an invalid value
+        { entries: { anonymousId: { type: 'localStoarge' } } },
+        { enabled: true, events: { delivery: 'buffer' } },
+      );
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('none'));
+      expect(state.storage.trulyAnonymousTracking.value).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'StoreManager:: The storage type "localStoarge" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default type "none" will be used instead.',
+      );
+    });
+
+    it('should still resolve an unsupported entry storage type after consent is given', () => {
+      // @ts-expect-error testing an invalid value
+      resolveStorageEntries(
+        { entries: { anonymousId: { type: 'localStoarge' } } },
+        { enabled: false },
+      );
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('cookieStorage'));
+    });
   });
 
   describe('with the deprecated storage strategy', () => {

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -396,7 +396,7 @@ describe('Pre-consent storage resolution', () => {
       resolveStorageEntries(undefined, { enabled: true, storage: { strategy: 'session' } });
 
       expect(logger.warn).toHaveBeenCalledWith(
-        'ConfigManager:: The pre-consent storage strategy option is deprecated. Please use the "storage" load API option instead.',
+        'ConfigManager:: The pre-consent storage strategy option is deprecated. Please enable "storage" in the pre-consent options and use the "storage" load API option instead.',
       );
     });
   });

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -296,6 +296,21 @@ describe('Pre-consent storage resolution', () => {
       );
     });
 
+    it('should not persist anything if the storage type is unsupported', () => {
+      // @ts-expect-error testing an invalid value
+      resolveStorageEntries({ type: 'random-type' }, { enabled: true });
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('none'));
+      expect(state.storage.trulyAnonymousTracking.value).toBe(true);
+    });
+
+    it('should still resolve an unsupported storage type after consent is given', () => {
+      // @ts-expect-error testing an invalid value
+      resolveStorageEntries({ type: 'random-type' }, { enabled: false });
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('cookieStorage'));
+    });
+
     it('should still resolve an unsupported entry storage type after consent is given', () => {
       // @ts-expect-error testing an invalid value
       resolveStorageEntries(

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -15,6 +15,7 @@ import {
   updateConsentsStateFromLoadOptions,
   updateStorageStateFromLoadOptions,
 } from '../../../src/components/configManager/util/commonUtil';
+import { normalizeLoadOptions } from '../../../src/components/utilities/loadOptions';
 
 jest.mock('../../../src/services/StoreManager/storages/storageEngine', () => ({
   __esModule: true,
@@ -300,6 +301,44 @@ describe('Pre-consent storage resolution', () => {
       expect(logger.warn).toHaveBeenCalledWith(
         'ConfigManager:: The pre-consent storage strategy option is deprecated. Please use the "storage" load API option instead.',
       );
+    });
+  });
+
+  describe('with no storage options supplied to the load API', () => {
+    /**
+     * Runs the load options through `normalizeLoadOptions` first, exactly as the load API does,
+     * so that any default it fills in is included in the resolution.
+     */
+    const loadWithoutStorageOptions = (preConsent: PreConsentOptions) => {
+      state.loadOptions.value = normalizeLoadOptions(state.loadOptions.value, {
+        consentManagement: { enabled: true, provider: 'oneTrust' },
+        preConsent,
+      });
+
+      updateStorageStateFromLoadOptions(logger);
+      updateConsentsStateFromLoadOptions(logger);
+      storeManager.initClientDataStores();
+    };
+
+    it('should not default the storage type or the entries', () => {
+      loadWithoutStorageOptions({ enabled: true });
+
+      expect(state.loadOptions.value.storage?.type).toBeUndefined();
+      expect(state.loadOptions.value.storage?.entries).toBeUndefined();
+    });
+
+    it('should not persist anything before consent', () => {
+      loadWithoutStorageOptions({ enabled: true, events: { delivery: 'buffer' } });
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('none'));
+      expect(state.storage.trulyAnonymousTracking.value).toBe(true);
+    });
+
+    it('should persist everything in the default storage type if pre-consent is not enabled', () => {
+      loadWithoutStorageOptions({ enabled: false });
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('cookieStorage'));
+      expect(state.storage.trulyAnonymousTracking.value).toBe(false);
     });
   });
 });

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -1,6 +1,7 @@
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import type { StorageOpts, StorageType } from '@rudderstack/analytics-js-common/types/Storage';
 import type { PreConsentOptions } from '@rudderstack/analytics-js-common/types/LoadOptions';
+import type { ConsentOptions } from '@rudderstack/analytics-js-common/types/Consent';
 import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
 import { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
 import { getStorageEngine } from '../../../src/services/StoreManager/storages/storageEngine';
@@ -16,6 +17,7 @@ import {
   updateStorageStateFromLoadOptions,
 } from '../../../src/components/configManager/util/commonUtil';
 import { normalizeLoadOptions } from '../../../src/components/utilities/loadOptions';
+import { getValidPostConsentOptions } from '../../../src/components/utilities/consent';
 
 jest.mock('../../../src/services/StoreManager/storages/storageEngine', () => ({
   __esModule: true,
@@ -292,7 +294,7 @@ describe('Pre-consent storage resolution', () => {
       expect(state.storage.entries.value).toEqual(buildExpectedEntries('none'));
       expect(state.storage.trulyAnonymousTracking.value).toBe(true);
       expect(logger.warn).toHaveBeenCalledWith(
-        'StoreManager:: The storage type "localStoarge" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default storage type will be used instead.',
+        'ConfigManager:: The storage type "localStoarge" configured for the entry "anonymousId" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default storage type will be used instead.',
       );
     });
 
@@ -378,6 +380,47 @@ describe('Pre-consent storage resolution', () => {
 
       expect(state.storage.entries.value).toEqual(buildExpectedEntries('cookieStorage'));
       expect(state.storage.trulyAnonymousTracking.value).toBe(false);
+    });
+  });
+
+  describe('across consent API invocations', () => {
+    /**
+     * Mirrors what the consent API does with the storage options
+     */
+    const giveConsent = (options?: ConsentOptions) => {
+      state.consents.preConsent.value = { ...state.consents.preConsent.value, enabled: false };
+      state.consents.postConsent.value = getValidPostConsentOptions(options, logger);
+      storeManager.initializeStorageState();
+    };
+
+    it('should leave the storage as it is if an invocation provides no storage options', () => {
+      resolveStorageEntries({ type: 'localStorage' }, { enabled: true });
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('localStorage'));
+
+      giveConsent({
+        storage: { type: 'cookieStorage', entries: { anonymousId: { type: 'sessionStorage' } } },
+      });
+
+      const afterFirstConsent = buildExpectedEntries('cookieStorage', {
+        anonymousId: 'sessionStorage',
+      });
+      expect(state.storage.entries.value).toEqual(afterFirstConsent);
+
+      giveConsent();
+
+      expect(state.storage.entries.value).toEqual(afterFirstConsent);
+    });
+
+    it('should replace the storage options if a later invocation provides them', () => {
+      resolveStorageEntries({ type: 'localStorage' }, { enabled: true });
+      giveConsent({
+        storage: { type: 'cookieStorage', entries: { anonymousId: { type: 'sessionStorage' } } },
+      });
+
+      giveConsent({ storage: { type: 'sessionStorage' } });
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('sessionStorage'));
     });
   });
 });

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -228,7 +228,49 @@ describe('Pre-consent storage resolution', () => {
     },
   );
 
-  describe('without the storage strategy', () => {
+  describe('without opting in to the storage before consent', () => {
+    // The storage load API options must not reach the pre-consent phase on their own, so an
+    // existing configuration keeps persisting nothing after upgrading.
+    const notOptedIn: [string, StorageOpts, PreConsentOptions][] = [
+      ['a global storage type', { type: 'localStorage' }, { enabled: true }],
+      [
+        'storage entries',
+        { entries: { anonymousId: { type: 'cookieStorage' } } },
+        { enabled: true },
+      ],
+      ['a global type and no events options', { type: 'localStorage' }, { enabled: true }],
+      [
+        'a global type and an empty pre-consent storage object',
+        { type: 'localStorage' },
+        { enabled: true, storage: {} },
+      ],
+      [
+        'a global type and the storage explicitly not enabled',
+        { type: 'localStorage' },
+        { enabled: true, storage: { enabled: false } },
+      ],
+      [
+        'a single non identifier entry',
+        { entries: { userId: { type: 'localStorage' } } },
+        { enabled: true },
+      ],
+    ];
+
+    it.each(notOptedIn)('should persist nothing with %s', (_desc, storage, preConsent) => {
+      resolveStorageEntries(storage, preConsent);
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('none'));
+      expect(state.storage.trulyAnonymousTracking.value).toBe(true);
+    });
+
+    it('should persist the storage options once consent is given', () => {
+      resolveStorageEntries({ type: 'localStorage' }, { enabled: false });
+
+      expect(state.storage.entries.value).toEqual(buildExpectedEntries('localStorage'));
+    });
+  });
+
+  describe('with the storage enabled before consent', () => {
     it('should persist both the anonymous ID and the session info if they are the only configured entries', () => {
       resolveStorageEntries(
         {
@@ -237,7 +279,11 @@ describe('Pre-consent storage resolution', () => {
             sessionInfo: { type: 'cookieStorage' },
           },
         },
-        { enabled: true, events: { delivery: 'buffer' } },
+        {
+          enabled: true,
+          storage: { enabled: true, storage: { enabled: true } },
+          events: { delivery: 'buffer' },
+        },
       );
 
       expect(state.storage.entries.value).toEqual(
@@ -250,7 +296,10 @@ describe('Pre-consent storage resolution', () => {
     });
 
     it('should persist every entry if the storage type is configured', () => {
-      resolveStorageEntries({ type: 'localStorage' }, { enabled: true });
+      resolveStorageEntries(
+        { type: 'localStorage' },
+        { enabled: true, storage: { enabled: true } },
+      );
 
       expect(state.storage.entries.value).toEqual(buildExpectedEntries('localStorage'));
       expect(state.storage.trulyAnonymousTracking.value).toBe(false);
@@ -259,7 +308,7 @@ describe('Pre-consent storage resolution', () => {
     it('should give the entry storage type precedence over the storage type', () => {
       resolveStorageEntries(
         { type: 'localStorage', entries: { anonymousId: { type: 'sessionStorage' } } },
-        { enabled: true },
+        { enabled: true, storage: { enabled: true } },
       );
 
       expect(state.storage.entries.value).toEqual(
@@ -270,7 +319,7 @@ describe('Pre-consent storage resolution', () => {
     it('should not persist an entry that is configured with no storage', () => {
       resolveStorageEntries(
         { type: 'localStorage', entries: { anonymousId: { type: 'none' } } },
-        { enabled: true },
+        { enabled: true, storage: { enabled: true } },
       );
 
       expect(state.storage.entries.value).toEqual(
@@ -279,7 +328,10 @@ describe('Pre-consent storage resolution', () => {
     });
 
     it('should not log a deprecation warning', () => {
-      resolveStorageEntries({ type: 'localStorage' }, { enabled: true });
+      resolveStorageEntries(
+        { type: 'localStorage' },
+        { enabled: true, storage: { enabled: true } },
+      );
 
       expect(logger.warn).not.toHaveBeenCalled();
     });
@@ -288,7 +340,11 @@ describe('Pre-consent storage resolution', () => {
       resolveStorageEntries(
         // @ts-expect-error testing an invalid value
         { entries: { anonymousId: { type: 'localStoarge' } } },
-        { enabled: true, events: { delivery: 'buffer' } },
+        {
+          enabled: true,
+          storage: { enabled: true, storage: { enabled: true } },
+          events: { delivery: 'buffer' },
+        },
       );
 
       expect(state.storage.entries.value).toEqual(buildExpectedEntries('none'));
@@ -300,7 +356,7 @@ describe('Pre-consent storage resolution', () => {
 
     it('should not persist anything if the storage type is unsupported', () => {
       // @ts-expect-error testing an invalid value
-      resolveStorageEntries({ type: 'random-type' }, { enabled: true });
+      resolveStorageEntries({ type: 'random-type' }, { enabled: true, storage: { enabled: true } });
 
       expect(state.storage.entries.value).toEqual(buildExpectedEntries('none'));
       expect(state.storage.trulyAnonymousTracking.value).toBe(true);
@@ -394,7 +450,10 @@ describe('Pre-consent storage resolution', () => {
     };
 
     it('should leave the storage as it is if an invocation provides no storage options', () => {
-      resolveStorageEntries({ type: 'localStorage' }, { enabled: true });
+      resolveStorageEntries(
+        { type: 'localStorage' },
+        { enabled: true, storage: { enabled: true } },
+      );
 
       expect(state.storage.entries.value).toEqual(buildExpectedEntries('localStorage'));
 
@@ -413,7 +472,10 @@ describe('Pre-consent storage resolution', () => {
     });
 
     it('should replace the storage options if a later invocation provides them', () => {
-      resolveStorageEntries({ type: 'localStorage' }, { enabled: true });
+      resolveStorageEntries(
+        { type: 'localStorage' },
+        { enabled: true, storage: { enabled: true } },
+      );
       giveConsent({
         storage: { type: 'cookieStorage', entries: { anonymousId: { type: 'sessionStorage' } } },
       });

--- a/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
+++ b/packages/analytics-js/__tests__/services/StoreManager/preConsentStorageResolution.test.ts
@@ -292,7 +292,7 @@ describe('Pre-consent storage resolution', () => {
       expect(state.storage.entries.value).toEqual(buildExpectedEntries('none'));
       expect(state.storage.trulyAnonymousTracking.value).toBe(true);
       expect(logger.warn).toHaveBeenCalledWith(
-        'StoreManager:: The storage type "localStoarge" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default type "none" will be used instead.',
+        'StoreManager:: The storage type "localStoarge" is not supported. Please choose one of the following supported types: "localStorage,memoryStorage,cookieStorage,sessionStorage,none". The default storage type will be used instead.',
       );
     });
 

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -4,10 +4,7 @@ import { CONFIG_MANAGER } from '@rudderstack/analytics-js-common/constants/logge
 import { batch } from '@preact/signals-core';
 import { isDefined, isUndefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import { isSDKRunningInChromeExtension } from '@rudderstack/analytics-js-common/utilities/detect';
-import {
-  DEFAULT_STORAGE_TYPE,
-  type CookieOptions,
-} from '@rudderstack/analytics-js-common/types/Storage';
+import type { CookieOptions } from '@rudderstack/analytics-js-common/types/Storage';
 import type {
   DeliveryType,
   StorageStrategy,
@@ -74,6 +71,7 @@ const getSDKUrl = (): string | undefined => {
   const scripts = document.getElementsByTagName('script');
   const sdkFileNameRegex = /(?:^|\/)rsa(\.min)?\.js$/;
 
+  // eslint-disable-next-line no-restricted-syntax
   for (const script of scripts) {
     const src = script.getAttribute('src');
     if (src && sdkFileNameRegex.test(src)) {
@@ -178,8 +176,9 @@ const updateStorageStateFromLoadOptions = (logger: ILogger): void => {
   const { storage: storageOptsFromLoad } = state.loadOptions.value;
   let storageType = storageOptsFromLoad?.type;
   if (isDefined(storageType) && !isValidStorageType(storageType)) {
-    logger.warn(STORAGE_TYPE_VALIDATION_WARNING(CONFIG_MANAGER, storageType, DEFAULT_STORAGE_TYPE));
-    storageType = DEFAULT_STORAGE_TYPE;
+    logger.warn(STORAGE_TYPE_VALIDATION_WARNING(CONFIG_MANAGER, storageType));
+    // An unsupported type is not a configured type, so the applicable default is used instead
+    storageType = undefined;
   }
 
   let storageEncryptionVersion = storageOptsFromLoad?.encryption?.version;

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -235,11 +235,16 @@ const updateConsentsStateFromLoadOptions = (logger: ILogger): void => {
   // Pre-consent
   const preConsentOpts = state.loadOptions.value.preConsent;
 
-  // The storage strategy is deprecated. When it is not set, the storage load API option decides
-  // what is persisted before consent is given.
-  let storageStrategy: StorageStrategy | undefined = preConsentOpts?.storage?.strategy;
-  if (isDefined(storageStrategy)) {
+  const configuredStrategy = preConsentOpts?.storage?.strategy;
+  if (isDefined(configuredStrategy)) {
     logger.warn(DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY(CONFIG_MANAGER));
+  }
+
+  // The storage load API options drive the pre-consent phase only when it is explicitly enabled,
+  // so an existing configuration keeps persisting nothing before consent is given.
+  let storageStrategy: StorageStrategy | undefined;
+  if (preConsentOpts?.storage?.enabled !== true) {
+    storageStrategy = configuredStrategy ?? DEFAULT_PRE_CONSENT_STORAGE_STRATEGY;
 
     const StorageStrategies = ['none', 'session', 'anonymousId'];
     if (!StorageStrategies.includes(storageStrategy as string)) {
@@ -248,7 +253,7 @@ const updateConsentsStateFromLoadOptions = (logger: ILogger): void => {
       logger.warn(
         UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY(
           CONFIG_MANAGER,
-          preConsentOpts?.storage?.strategy,
+          configuredStrategy,
           DEFAULT_PRE_CONSENT_STORAGE_STRATEGY,
         ),
       );

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -30,7 +30,6 @@ import { state } from '../../../state';
 import {
   INVALID_CONFIG_URL_WARNING,
   STORAGE_DATA_MIGRATION_OVERRIDE_WARNING,
-  STORAGE_TYPE_VALIDATION_WARNING,
   UNSUPPORTED_BEACON_API_WARNING,
   UNSUPPORTED_PRE_CONSENT_EVENTS_DELIVERY_TYPE,
   UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY,
@@ -50,7 +49,7 @@ import {
   DEFAULT_STORAGE_ENCRYPTION_VERSION,
   StorageEncryptionVersionsToPluginNameMap,
 } from '../constants';
-import { getDataServiceUrl, isValidStorageType, isWebpageTopLevelDomain } from './validate';
+import { getDataServiceUrl, isWebpageTopLevelDomain, validateStorageOptions } from './validate';
 import { getConsentManagementData } from '../../utilities/consent';
 
 /**
@@ -174,12 +173,10 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
 
 const updateStorageStateFromLoadOptions = (logger: ILogger): void => {
   const { storage: storageOptsFromLoad } = state.loadOptions.value;
-  let storageType = storageOptsFromLoad?.type;
-  if (isDefined(storageType) && !isValidStorageType(storageType)) {
-    logger.warn(STORAGE_TYPE_VALIDATION_WARNING(CONFIG_MANAGER, storageType));
-    // An unsupported type is not a configured type, so the applicable default is used instead
-    storageType = undefined;
-  }
+
+  // Only reported here. The applicable default depends on the consent phase, so the unsupported
+  // values are resolved in the store manager.
+  validateStorageOptions(storageOptsFromLoad, CONFIG_MANAGER, logger);
 
   let storageEncryptionVersion = storageOptsFromLoad?.encryption?.version;
   const encryptionPluginName =
@@ -219,8 +216,6 @@ const updateStorageStateFromLoadOptions = (logger: ILogger): void => {
   const { sscEnabled, finalDataServiceUrl, cookieOptions } = getServerSideCookiesStateData(logger);
 
   batch(() => {
-    state.storage.type.value = storageType;
-
     state.storage.cookie.value = cookieOptions;
 
     state.serverCookies.isEnabledServerSideCookies.value = sscEnabled;

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -36,6 +36,7 @@ import {
   UNSUPPORTED_BEACON_API_WARNING,
   UNSUPPORTED_PRE_CONSENT_EVENTS_DELIVERY_TYPE,
   UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY,
+  DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY,
   UNSUPPORTED_STORAGE_ENCRYPTION_VERSION_WARNING,
   SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
 } from '../../../constants/logMessages';
@@ -240,19 +241,24 @@ const updateConsentsStateFromLoadOptions = (logger: ILogger): void => {
   // Pre-consent
   const preConsentOpts = state.loadOptions.value.preConsent;
 
-  let storageStrategy: StorageStrategy =
-    preConsentOpts?.storage?.strategy ?? DEFAULT_PRE_CONSENT_STORAGE_STRATEGY;
-  const StorageStrategies = ['none', 'session', 'anonymousId'];
-  if (isDefined(storageStrategy) && !StorageStrategies.includes(storageStrategy)) {
-    storageStrategy = DEFAULT_PRE_CONSENT_STORAGE_STRATEGY;
+  // The storage strategy is deprecated. When it is not set, the storage load API option decides
+  // what is persisted before consent is given.
+  let storageStrategy: StorageStrategy | undefined = preConsentOpts?.storage?.strategy;
+  if (isDefined(storageStrategy)) {
+    logger.warn(DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY(CONFIG_MANAGER));
 
-    logger.warn(
-      UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY(
-        CONFIG_MANAGER,
-        preConsentOpts?.storage?.strategy,
-        DEFAULT_PRE_CONSENT_STORAGE_STRATEGY,
-      ),
-    );
+    const StorageStrategies = ['none', 'session', 'anonymousId'];
+    if (!StorageStrategies.includes(storageStrategy as string)) {
+      storageStrategy = DEFAULT_PRE_CONSENT_STORAGE_STRATEGY;
+
+      logger.warn(
+        UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY(
+          CONFIG_MANAGER,
+          preConsentOpts?.storage?.strategy,
+          DEFAULT_PRE_CONSENT_STORAGE_STRATEGY,
+        ),
+      );
+    }
   }
 
   let eventsDeliveryType: DeliveryType =

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/deprecation */
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import { CONFIG_MANAGER } from '@rudderstack/analytics-js-common/constants/loggerContexts';
 import { batch } from '@preact/signals-core';
@@ -73,7 +74,6 @@ const getSDKUrl = (): string | undefined => {
   const scripts = document.getElementsByTagName('script');
   const sdkFileNameRegex = /(?:^|\/)rsa(\.min)?\.js$/;
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const script of scripts) {
     const src = script.getAttribute('src');
     if (src && sdkFileNameRegex.test(src)) {

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -241,7 +241,9 @@ const updateConsentsStateFromLoadOptions = (logger: ILogger): void => {
   }
 
   // The storage load API options drive the pre-consent phase only when it is explicitly enabled,
-  // so an existing configuration keeps persisting nothing before consent is given.
+  // so an existing configuration keeps persisting nothing before consent is given. Enabling it
+  // takes precedence over the deprecated strategy, otherwise a migration that leaves the strategy
+  // in place would silently do nothing.
   let storageStrategy: StorageStrategy | undefined;
   if (preConsentOpts?.storage?.enabled !== true) {
     storageStrategy = configuredStrategy ?? DEFAULT_PRE_CONSENT_STORAGE_STRATEGY;

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -65,7 +65,7 @@ const getTopDomain = (url: string) => {
   // Handle different cases, especially for co.uk or similar TLDs
   if (parts.length > 2) {
     // Join the last two parts for the top-level domain
-    topDomain = `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+    topDomain = `${parts.at(-2)}.${parts.at(-1)}`;
   } else {
     // If only two parts or less, return as it is
     topDomain = host;

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -1,9 +1,15 @@
 import { isObjectLiteralAndNotNull } from '@rudderstack/analytics-js-common/utilities/object';
-import { isNullOrUndefined } from '@rudderstack/analytics-js-common/utilities/checks';
+import { isDefined, isNullOrUndefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import {
   SUPPORTED_STORAGE_TYPES,
+  type StorageOpts,
   type StorageType,
 } from '@rudderstack/analytics-js-common/types/Storage';
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import {
+  STORAGE_TYPE_VALIDATION_WARNING,
+  UNSUPPORTED_STORAGE_ENTRY_TYPE_WARNING,
+} from '../../../constants/logMessages';
 
 const isValidSourceConfig = (res: any): boolean =>
   isObjectLiteralAndNotNull(res) &&
@@ -14,6 +20,37 @@ const isValidSourceConfig = (res: any): boolean =>
 
 const isValidStorageType = (storageType?: StorageType): boolean =>
   typeof storageType === 'string' && SUPPORTED_STORAGE_TYPES.includes(storageType);
+
+/**
+ * Warns about the unsupported storage types in the storage options. It only reports them, as the
+ * applicable default depends on the consent phase and is determined at resolution time.
+ * @param storageOpts Storage options from the load API options or the consent API options
+ * @param context Logger context
+ * @param logger Logger instance
+ */
+const validateStorageOptions = (
+  storageOpts: StorageOpts | undefined,
+  context: string,
+  logger?: ILogger,
+): void => {
+  if (!storageOpts) {
+    return;
+  }
+
+  const { type, entries } = storageOpts;
+  if (isDefined(type) && !isValidStorageType(type)) {
+    logger?.warn(STORAGE_TYPE_VALIDATION_WARNING(context, type));
+  }
+
+  if (entries) {
+    Object.entries(entries).forEach(([entryKey, entryOpts]) => {
+      const entryType = entryOpts?.type;
+      if (isDefined(entryType) && !isValidStorageType(entryType)) {
+        logger?.warn(UNSUPPORTED_STORAGE_ENTRY_TYPE_WARNING(context, entryKey, entryType));
+      }
+    });
+  }
+};
 
 const getTopDomain = (url: string) => {
   // Create a URL object
@@ -55,6 +92,7 @@ const isWebpageTopLevelDomain = (providedDomain: string): boolean => {
 export {
   isValidSourceConfig,
   isValidStorageType,
+  validateStorageOptions,
   getTopDomainUrl,
   getDataServiceUrl,
   isWebpageTopLevelDomain,

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -65,7 +65,7 @@ const getTopDomain = (url: string) => {
   // Handle different cases, especially for co.uk or similar TLDs
   if (parts.length > 2) {
     // Join the last two parts for the top-level domain
-    topDomain = `${parts.at(-2)}.${parts.at(-1)}`;
+    topDomain = `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
   } else {
     // If only two parts or less, return as it is
     topDomain = host;

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -33,7 +33,7 @@ const validateStorageOptions = (
   context: string,
   logger?: ILogger,
 ): void => {
-  if (!storageOpts) {
+  if (!isObjectLiteralAndNotNull(storageOpts)) {
     return;
   }
 

--- a/packages/analytics-js/src/components/core/Analytics.ts
+++ b/packages/analytics-js/src/components/core/Analytics.ts
@@ -911,7 +911,7 @@ class Analytics implements IAnalytics {
 
     batch(() => {
       state.consents.preConsent.value = { ...state.consents.preConsent.value, enabled: false };
-      state.consents.postConsent.value = getValidPostConsentOptions(options);
+      state.consents.postConsent.value = getValidPostConsentOptions(options, this.logger);
 
       const { initialized, consentsData } = getConsentManagementData(
         state.consents.postConsent.value.consentManagement,

--- a/packages/analytics-js/src/components/utilities/consent.ts
+++ b/packages/analytics-js/src/components/utilities/consent.ts
@@ -1,4 +1,7 @@
-import { CONFIG_MANAGER } from '@rudderstack/analytics-js-common/constants/loggerContexts';
+import {
+  CONFIG_MANAGER,
+  CONSENT_API,
+} from '@rudderstack/analytics-js-common/constants/loggerContexts';
 import type {
   ConsentManagementOptions,
   ConsentManagementProvider,
@@ -13,9 +16,11 @@ import {
   isObjectLiteralAndNotNull,
   mergeDeepRight,
 } from '@rudderstack/analytics-js-common/utilities/object';
+import { isDefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import { clone } from 'ramda';
 import { state } from '../../state';
 import { UNSUPPORTED_CONSENT_MANAGER_ERROR } from '../../constants/logMessages';
+import { validateStorageOptions } from '../configManager/util/validate';
 import { ConsentManagersToPluginNameMap } from '../configManager/constants';
 
 /**
@@ -50,16 +55,24 @@ const getUserSelectedConsentManager = (
  * @param options Consent options provided by the user
  * @returns Validated and normalized consent options
  */
-const getValidPostConsentOptions = (options?: ConsentOptions) => {
+const getValidPostConsentOptions = (options?: ConsentOptions, logger?: ILogger) => {
   const validOptions: ConsentOptions = {
     sendPageEvent: false,
     trackConsent: false,
     discardPreConsentEvents: false,
   };
+
+  // The storage options persist across consent API invocations, so an invocation that does not
+  // provide them leaves the storage as it is
+  validOptions.storage = state.consents.postConsent.value.storage;
+
   if (isObjectLiteralAndNotNull(options)) {
     const clonedOptions = clone(options);
 
-    validOptions.storage = clonedOptions.storage;
+    if (isDefined(clonedOptions.storage)) {
+      validateStorageOptions(clonedOptions.storage, CONSENT_API, logger);
+      validOptions.storage = clonedOptions.storage;
+    }
     if (isNonEmptyObject(clonedOptions.integrations)) {
       validOptions.integrations = clonedOptions.integrations;
     }

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -234,6 +234,9 @@ const UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The pre-consent storage strategy "${selectedStrategy}" is not supported. Please choose one of the following supported strategies: "none, session, anonymousId". The default strategy "${defaultStrategy}" will be used instead.`;
 
+const DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY = (context: string): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The pre-consent storage strategy option is deprecated. Please use the "storage" load API option instead.`;
+
 const UNSUPPORTED_PRE_CONSENT_EVENTS_DELIVERY_TYPE = (
   context: string,
   selectedDeliveryType: DeliveryType | undefined,
@@ -319,6 +322,7 @@ export {
   INVALID_CONFIG_URL_WARNING,
   POLYFILL_SCRIPT_LOAD_ERROR,
   UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY,
+  DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY,
   UNSUPPORTED_PRE_CONSENT_EVENTS_DELIVERY_TYPE,
   SOURCE_CONFIG_RESOLUTION_ERROR,
   DATA_SERVER_URL_INVALID_ERROR,

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -105,6 +105,13 @@ const COLLAPSED_COOKIE_BATCH_ERROR = (missingCookies: string[], batchSize: numbe
 const STORAGE_TYPE_VALIDATION_WARNING = (context: string, storageType: any): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The storage type "${storageType}" is not supported. Please choose one of the following supported types: "${SUPPORTED_STORAGE_TYPES}". The default storage type will be used instead.`;
 
+const UNSUPPORTED_STORAGE_ENTRY_TYPE_WARNING = (
+  context: string,
+  entry: string,
+  storageType: any,
+): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The storage type "${storageType}" configured for the entry "${entry}" is not supported. Please choose one of the following supported types: "${SUPPORTED_STORAGE_TYPES}". The default storage type will be used instead.`;
+
 const UNSUPPORTED_ERROR_REPORTING_PROVIDER_WARNING = (
   context: string,
   selectedErrorReportingProvider: string | undefined,
@@ -309,6 +316,7 @@ export {
   PLUGIN_EXT_POINT_MISSING_ERROR,
   PLUGIN_EXT_POINT_INVALID_ERROR,
   STORAGE_TYPE_VALIDATION_WARNING,
+  UNSUPPORTED_STORAGE_ENTRY_TYPE_WARNING,
   INVALID_CONFIG_URL_WARNING,
   POLYFILL_SCRIPT_LOAD_ERROR,
   UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY,

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -4,10 +4,7 @@ import {
   SUPPORTED_STORAGE_TYPES,
 } from '@rudderstack/analytics-js-common/types/Storage';
 import { LOG_CONTEXT_SEPARATOR } from '@rudderstack/analytics-js-common/constants/logMessages';
-import type {
-  DeliveryType,
-  StorageStrategy,
-} from '@rudderstack/analytics-js-common/types/LoadOptions';
+import type { DeliveryType } from '@rudderstack/analytics-js-common/types/LoadOptions';
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
 
 // CONSTANT
@@ -229,8 +226,8 @@ const POLYFILL_SCRIPT_LOAD_ERROR = (scriptId: string, url: string): string =>
 
 const UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY = (
   context: string,
-  selectedStrategy: StorageStrategy | undefined,
-  defaultStrategy: StorageStrategy,
+  selectedStrategy: string | undefined,
+  defaultStrategy: string,
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The pre-consent storage strategy "${selectedStrategy}" is not supported. Please choose one of the following supported strategies: "none, session, anonymousId". The default strategy "${defaultStrategy}" will be used instead.`;
 

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -1,8 +1,5 @@
 import type { PluginName } from '@rudderstack/analytics-js-common/types/PluginsManager';
-import {
-  type StorageType,
-  SUPPORTED_STORAGE_TYPES,
-} from '@rudderstack/analytics-js-common/types/Storage';
+import { SUPPORTED_STORAGE_TYPES } from '@rudderstack/analytics-js-common/types/Storage';
 import { LOG_CONTEXT_SEPARATOR } from '@rudderstack/analytics-js-common/constants/logMessages';
 import type { DeliveryType } from '@rudderstack/analytics-js-common/types/LoadOptions';
 import type { Nullable } from '@rudderstack/analytics-js-common/types/Nullable';
@@ -105,12 +102,8 @@ const COLLAPSED_COOKIE_BATCH_ERROR = (missingCookies: string[], batchSize: numbe
   `The server did not set ${missingCookies.length} of the ${batchSize} cookies sent in one request: ${missingCookies.join(', ')}. A fallback to set them client side was attempted. Check that the data service and any proxy preserve every "Set-Cookie" header, and that the cookie domain and SameSite/Secure attributes are valid.`;
 
 // WARNING
-const STORAGE_TYPE_VALIDATION_WARNING = (
-  context: string,
-  storageType: any,
-  defaultStorageType: StorageType,
-): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}The storage type "${storageType}" is not supported. Please choose one of the following supported types: "${SUPPORTED_STORAGE_TYPES}". The default type "${defaultStorageType}" will be used instead.`;
+const STORAGE_TYPE_VALIDATION_WARNING = (context: string, storageType: any): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The storage type "${storageType}" is not supported. Please choose one of the following supported types: "${SUPPORTED_STORAGE_TYPES}". The default storage type will be used instead.`;
 
 const UNSUPPORTED_ERROR_REPORTING_PROVIDER_WARNING = (
   context: string,

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -232,7 +232,7 @@ const UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY = (
   `${context}${LOG_CONTEXT_SEPARATOR}The pre-consent storage strategy "${selectedStrategy}" is not supported. Please choose one of the following supported strategies: "none, session, anonymousId". The default strategy "${defaultStrategy}" will be used instead.`;
 
 const DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY = (context: string): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}The pre-consent storage strategy option is deprecated. Please use the "storage" load API option instead.`;
+  `${context}${LOG_CONTEXT_SEPARATOR}The pre-consent storage strategy option is deprecated. Please enable "storage" in the pre-consent options and use the "storage" load API option instead.`;
 
 const UNSUPPORTED_PRE_CONSENT_EVENTS_DELIVERY_TYPE = (
   context: string,

--- a/packages/analytics-js/src/services/StoreManager/StoreManager.ts
+++ b/packages/analytics-js/src/services/StoreManager/StoreManager.ts
@@ -123,6 +123,15 @@ class StoreManager implements IStoreManager {
       entriesOptions = postConsentStorageOpts?.entries;
     }
 
+    // Without the deprecated pre-consent storage strategy, the storage options decide what is
+    // persisted before consent is given. Only the fallback changes: nothing is persisted unless
+    // a storage type has been explicitly configured.
+    const preConsentOpts = state.consents.preConsent.value;
+    const defaultStorageType =
+      preConsentOpts.enabled && !preConsentOpts.storage?.strategy
+        ? NO_STORAGE
+        : DEFAULT_STORAGE_TYPE;
+
     let trulyAnonymousTracking = true;
     let storageEntries = {};
     USER_SESSION_KEYS.forEach(sessionKey => {
@@ -134,7 +143,7 @@ class StoreManager implements IStoreManager {
 
       // Storage type precedence order: pre-consent strategy > entry type > global type > default
       const storageType =
-        preConsentStorageType ?? configuredStorageType ?? globalStorageType ?? DEFAULT_STORAGE_TYPE;
+        preConsentStorageType ?? configuredStorageType ?? globalStorageType ?? defaultStorageType;
 
       const finalStorageType = this.getResolvedStorageTypeForEntry(storageType, sessionKey);
 

--- a/packages/analytics-js/src/services/StoreManager/StoreManager.ts
+++ b/packages/analytics-js/src/services/StoreManager/StoreManager.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/deprecation */
 import type {
   IStoreConfig,
   IStoreManager,
@@ -20,6 +21,7 @@ import {
 } from '@rudderstack/analytics-js-common/utilities/object';
 import {
   DEFAULT_STORAGE_TYPE,
+  SUPPORTED_STORAGE_TYPES,
   type StorageType,
 } from '@rudderstack/analytics-js-common/types/Storage';
 import type { UserSessionKey } from '@rudderstack/analytics-js-common/types/UserSessionStorage';
@@ -27,7 +29,10 @@ import { batch } from '@preact/signals-core';
 import { isDefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
 import { USER_SESSION_KEYS } from '../../constants/storage';
-import { STORAGE_UNAVAILABLE_WARNING } from '../../constants/logMessages';
+import {
+  STORAGE_TYPE_VALIDATION_WARNING,
+  STORAGE_UNAVAILABLE_WARNING,
+} from '../../constants/logMessages';
 import { type StoreManagerOptions, storageClientDataStoreNameMap } from './types';
 import { state } from '../../state';
 import { configureStorageEngines, getStorageEngine } from './storages/storageEngine';
@@ -127,10 +132,11 @@ class StoreManager implements IStoreManager {
     // persisted before consent is given. Only the fallback changes: nothing is persisted unless
     // a storage type has been explicitly configured.
     const preConsentOpts = state.consents.preConsent.value;
-    const defaultStorageType =
-      preConsentOpts.enabled && !preConsentOpts.storage?.strategy
-        ? NO_STORAGE
-        : DEFAULT_STORAGE_TYPE;
+    const isStorageFromLoadOptionsBeforeConsent =
+      preConsentOpts.enabled === true && !preConsentOpts.storage?.strategy;
+    const defaultStorageType = isStorageFromLoadOptionsBeforeConsent
+      ? NO_STORAGE
+      : DEFAULT_STORAGE_TYPE;
 
     let trulyAnonymousTracking = true;
     let storageEntries = {};
@@ -142,8 +148,15 @@ class StoreManager implements IStoreManager {
       const preConsentStorageType = getStorageTypeFromPreConsentIfApplicable(state, sessionKey);
 
       // Storage type precedence order: pre-consent strategy > entry type > global type > default
-      const storageType =
+      let storageType =
         preConsentStorageType ?? configuredStorageType ?? globalStorageType ?? defaultStorageType;
+
+      // Entry storage types are not validated at config time, so an unsupported value would
+      // otherwise resolve to a persistent storage type and store the data before consent is given
+      if (isStorageFromLoadOptionsBeforeConsent && !SUPPORTED_STORAGE_TYPES.includes(storageType)) {
+        this.logger.warn(STORAGE_TYPE_VALIDATION_WARNING(STORE_MANAGER, storageType, NO_STORAGE));
+        storageType = NO_STORAGE;
+      }
 
       const finalStorageType = this.getResolvedStorageTypeForEntry(storageType, sessionKey);
 

--- a/packages/analytics-js/src/services/StoreManager/StoreManager.ts
+++ b/packages/analytics-js/src/services/StoreManager/StoreManager.ts
@@ -29,10 +29,7 @@ import { batch } from '@preact/signals-core';
 import { isDefined } from '@rudderstack/analytics-js-common/utilities/checks';
 import { COOKIE_KEYS } from '@rudderstack/analytics-js-cookies/constants/cookies';
 import { USER_SESSION_KEYS } from '../../constants/storage';
-import {
-  STORAGE_TYPE_VALIDATION_WARNING,
-  STORAGE_UNAVAILABLE_WARNING,
-} from '../../constants/logMessages';
+import { STORAGE_UNAVAILABLE_WARNING } from '../../constants/logMessages';
 import { type StoreManagerOptions, storageClientDataStoreNameMap } from './types';
 import { state } from '../../state';
 import { configureStorageEngines, getStorageEngine } from './storages/storageEngine';
@@ -118,7 +115,7 @@ class StoreManager implements IStoreManager {
   }
 
   initializeStorageState() {
-    let globalStorageType = state.storage.type.value;
+    let globalStorageType = state.loadOptions.value.storage?.type;
     let entriesOptions = state.loadOptions.value.storage?.entries;
 
     // Use the storage options from post consent if anything is defined
@@ -138,6 +135,12 @@ class StoreManager implements IStoreManager {
       ? NO_STORAGE
       : DEFAULT_STORAGE_TYPE;
 
+    // The unsupported values are reported where the options enter the SDK, so they are only
+    // resolved here, against the default that applies to the current consent phase
+    if (globalStorageType !== undefined && !SUPPORTED_STORAGE_TYPES.includes(globalStorageType)) {
+      globalStorageType = undefined;
+    }
+
     let trulyAnonymousTracking = true;
     let storageEntries = {};
     USER_SESSION_KEYS.forEach(sessionKey => {
@@ -151,9 +154,7 @@ class StoreManager implements IStoreManager {
       let storageType =
         preConsentStorageType ?? configuredStorageType ?? globalStorageType ?? defaultStorageType;
 
-      // Entry storage types are not validated at config time, unlike the global storage type
       if (!SUPPORTED_STORAGE_TYPES.includes(storageType)) {
-        this.logger.warn(STORAGE_TYPE_VALIDATION_WARNING(STORE_MANAGER, storageType));
         storageType = defaultStorageType;
       }
 
@@ -173,7 +174,6 @@ class StoreManager implements IStoreManager {
     });
 
     batch(() => {
-      state.storage.type.value = globalStorageType;
       state.storage.entries.value = storageEntries;
       state.storage.trulyAnonymousTracking.value = trulyAnonymousTracking;
     });

--- a/packages/analytics-js/src/services/StoreManager/StoreManager.ts
+++ b/packages/analytics-js/src/services/StoreManager/StoreManager.ts
@@ -138,17 +138,6 @@ class StoreManager implements IStoreManager {
       ? NO_STORAGE
       : DEFAULT_STORAGE_TYPE;
 
-    // An unsupported storage type is normalized to the default type at config time, which would
-    // otherwise read here as an explicitly configured type and persist the data before consent
-    const configuredGlobalStorageType = state.loadOptions.value.storage?.type;
-    if (
-      isStorageFromLoadOptionsBeforeConsent &&
-      configuredGlobalStorageType !== undefined &&
-      !SUPPORTED_STORAGE_TYPES.includes(configuredGlobalStorageType)
-    ) {
-      globalStorageType = undefined;
-    }
-
     let trulyAnonymousTracking = true;
     let storageEntries = {};
     USER_SESSION_KEYS.forEach(sessionKey => {
@@ -162,11 +151,10 @@ class StoreManager implements IStoreManager {
       let storageType =
         preConsentStorageType ?? configuredStorageType ?? globalStorageType ?? defaultStorageType;
 
-      // Entry storage types are not validated at config time, so an unsupported value would
-      // otherwise resolve to a persistent storage type and store the data before consent is given
-      if (isStorageFromLoadOptionsBeforeConsent && !SUPPORTED_STORAGE_TYPES.includes(storageType)) {
-        this.logger.warn(STORAGE_TYPE_VALIDATION_WARNING(STORE_MANAGER, storageType, NO_STORAGE));
-        storageType = NO_STORAGE;
+      // Entry storage types are not validated at config time, unlike the global storage type
+      if (!SUPPORTED_STORAGE_TYPES.includes(storageType)) {
+        this.logger.warn(STORAGE_TYPE_VALIDATION_WARNING(STORE_MANAGER, storageType));
+        storageType = defaultStorageType;
       }
 
       const finalStorageType = this.getResolvedStorageTypeForEntry(storageType, sessionKey);

--- a/packages/analytics-js/src/services/StoreManager/StoreManager.ts
+++ b/packages/analytics-js/src/services/StoreManager/StoreManager.ts
@@ -138,6 +138,17 @@ class StoreManager implements IStoreManager {
       ? NO_STORAGE
       : DEFAULT_STORAGE_TYPE;
 
+    // An unsupported storage type is normalized to the default type at config time, which would
+    // otherwise read here as an explicitly configured type and persist the data before consent
+    const configuredGlobalStorageType = state.loadOptions.value.storage?.type;
+    if (
+      isStorageFromLoadOptionsBeforeConsent &&
+      configuredGlobalStorageType !== undefined &&
+      !SUPPORTED_STORAGE_TYPES.includes(configuredGlobalStorageType)
+    ) {
+      globalStorageType = undefined;
+    }
+
     let trulyAnonymousTracking = true;
     let storageEntries = {};
     USER_SESSION_KEYS.forEach(sessionKey => {

--- a/packages/analytics-js/src/state/slices/storage.ts
+++ b/packages/analytics-js/src/state/slices/storage.ts
@@ -4,7 +4,6 @@ import type { StorageState } from '@rudderstack/analytics-js-common/types/Applic
 const storageState: StorageState = {
   encryptionPluginName: signal(undefined),
   migrate: signal(false),
-  type: signal(undefined),
   cookie: signal(undefined),
   entries: signal({}),
   trulyAnonymousTracking: signal(false),


### PR DESCRIPTION
## PR Description

Deprecates `preConsent.storage.strategy`. The `storage` load API option now decides what is persisted before consent is given, so storage is configured in exactly one place.

You opt in with `preConsent.storage.enabled`, and then the load storage options drive the pre-consent phase, where only the **fallback** changes: an entry is persisted only if a storage type has been explicitly configured. Without the opt-in the deprecated `strategy` still decides what is persisted, and with neither of them nothing is persisted before consent.

```ts
const defaultStorageType = isStorageFromLoadOptionsBeforeConsent ? NO_STORAGE : DEFAULT_STORAGE_TYPE;

// Storage type precedence order: pre-consent strategy > entry type > global type > default
const storageType =
  preConsentStorageType ?? configuredStorageType ?? globalStorageType ?? defaultStorageType;
```

The #3170 request becomes two entries in the load storage options — no second storage block:

```js
storage: {
  entries: {
    anonymousId: { type: 'cookieStorage' },
    sessionInfo: { type: 'cookieStorage' },
  },
},
preConsent: {
  enabled: true,
  storage: { enabled: true },        // opt in; without it nothing is persisted before consent
  events: { delivery: 'buffer' },
}
```

### Motivation

`strategy` is a closed enum (`none`, `session`, `anonymousId`), and internally it was never a strategy — [`getStorageTypeFromPreConsentIfApplicable`](https://github.com/rudderlabs/rudder-sdk-js/blob/45b2c32e4b07917d503e672e95a67e1786d2824c/packages/analytics-js/src/services/StoreManager/utils.ts#L6-L31) forces every `UserSessionKey` to `none` except one whitelisted key. So it is a hardcoded single-entry allow-list over the granular storage configuration the SDK already supports everywhere else, which means:

- combinations outside those three have no expression — including "persist `anonymousId` **and** `sessionInfo`", the one most customers ask for;
- every new customer need requires a new enum member and a new SDK release;
- pre-consent is the only place in the SDK where storage is configured through an enum rather than `type`/`entries`.

The enum ([#1411](https://github.com/rudderlabs/rudder-sdk-js/pull/1411), Oct 2023) landed six weeks *after* granular storage ([#1329](https://github.com/rudderlabs/rudder-sdk-js/pull/1329), Aug 2023). This converges the two rather than adding a second storage config.

Resolves #3170. Also serves point 2 of #2092, which #2100 left open.

### Deprecation

`strategy` is annotated `@deprecated` and warns at runtime. It behaves exactly as before — `getStorageTypeFromPreConsentIfApplicable` is untouched — so existing configurations produce identical storage. Removal is deferred to the next major.

Precedence between the two is explicit: **`preConsent.storage.enabled` wins over `strategy`.** If both are set, the storage load API options drive the phase and the strategy is ignored, with the deprecation warning still firing. The alternative — letting a stale `strategy` override the opt-in — would make a half-finished migration silently do nothing, which is the worse failure.

### Validation moved to where the options enter

A single `validateStorageOptions` is called on the load API options and on the consent API options. It only **reports** unsupported storage types; the store manager **resolves** them against the default that applies to the current consent phase. Consequences:

- Consent API storage options are validated for the first time — previously an unsupported type there produced only a confusing "not available" message from the availability fallback.
- The warning no longer names a default type, because which one applies depends on the phase.
- `state.storage.type` is deleted. It existed only to carry the validated/effective type between the config manager and the store manager, and both jobs are now done locally.

## Behaviour changes

Two, both deliberate, and **neither affects an existing configuration**. Verified against a `develop` build in real Chromium across 37 configuration shapes: zero differences for any config that does not opt in.

**1. Storage options now persist across `consent()` invocations.** An invocation that provides no storage options leaves storage as it is.

This was previously half-implemented, and the asymmetry was a bug: the global type carried over through `state.storage.type`'s write-back while `entries` silently reverted to the load API options. Measured on `develop`:

```
after consent #1 : anonymousId=sessionStorage  userId=cookieStorage   <- {type: cookieStorage, entries: {anonymousId: sessionStorage}}
after consent #2 : anonymousId=cookieStorage   userId=cookieStorage   <- no storage options passed
```

`anonymousId` moved out of `sessionStorage` on a consent update that said nothing about storage, relocating data through `migrateDataFromPreviousStorage`. It now stays put. Options supplied by an invocation still replace wholesale; they are not deep-merged. This is the only change that can reach an application which never touches pre-consent, and only one that calls `consent()` more than once with entry-level storage options.

**2. `preConsent.storage.enabled` opts into the new pre-consent behaviour.** Without it, an absent `strategy` still resolves to `'none'` and nothing is persisted before consent, exactly as today. The deprecated `strategy` continues to work unchanged and takes effect whenever the opt-in is absent.

## Tests

The first commit is a table-driven regression baseline over `{none, session, anonymousId} × load storage.type variants × storage.entries overrides`, asserting resolved `state.storage.entries` across the whole pipeline. It was committed green against unmodified `develop`, so it guards the deprecation rather than restating it, and it still passes unchanged. `StoreManager.test.ts` keeps its `strategy` cases untouched — that is the back-compat proof.

On top of that: the mixed configuration from #3170, precedence of `strategy` over the storage options, the deprecation warn firing only when `strategy` is set, every unsupported-type path on both sides of consent, `validateStorageOptions` unit coverage, the three-pass consent stickiness case, and the pre-consent → post-consent transition (entry relocation, anonymous ID and session continuity).

52 suites / 1344 tests green, plus `analytics-js-common`, `analytics-js-plugins` and `analytics-js-cookies`.

## Bundle size

Five limits raised by 0.5 KiB — `Core - Modern - NPM (CJS)` 28.5 → 29, and the four modern bundled and content-script ESM/UMD entries 41.5 → 42. Measured against a fresh `develop` build, not guessed.

## Out of scope

- Removing `strategy` — deprecated only; removal is a breaking change for the next major.
- E2E (`rudder-client-side-test`) and docs (`rudder-hugo`) — tracked on the parent ticket. The docs must land before or with the release and must cover behaviour change 1.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-5448/granular-pre-consent-storage-configuration-typeentries-and-deprecate

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

Storage configuration is privacy-relevant, so the default is conservative: with nothing configured, pre-consent persists nothing, and an unsupported value resolves to the phase default rather than to a persistent store. The one behaviour change that widens what is persisted is called out above rather than left implicit.
