### PR TITLE
fix(release): suffix and deprecate betas for all packages

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -167,6 +167,12 @@ jobs:
 
             IS_PRIVATE=$(jq -r '.private // "false"' "$PROJECT_ROOT/package.json")
             if [ "$IS_PRIVATE" != "true" ]; then
+              PACKAGE_NAME=$(jq -r '.name // empty' "$PROJECT_ROOT/package.json")
+              if [ -z "$PACKAGE_NAME" ]; then
+                echo "::warning::No name found in $PROJECT_ROOT/package.json; skipping"
+                continue
+              fi
+
               echo "Affected publishable project: $project"
               if [ -n "$PUBLISHABLE_PROJECTS" ]; then
                 PUBLISHABLE_PROJECTS="$PUBLISHABLE_PROJECTS,$project"
@@ -211,8 +217,19 @@ jobs:
           echo "Updating versions:"
 
           for PACKAGE_JSON in packages/*/package.json; do
+            # Guards against an unmatched glob, which would otherwise be passed to jq verbatim
+            if [ ! -f "$PACKAGE_JSON" ]; then
+              continue
+            fi
+
             IS_PRIVATE=$(jq -r '.private // "false"' "$PACKAGE_JSON")
             if [ "$IS_PRIVATE" = "true" ]; then
+              continue
+            fi
+
+            PACKAGE_NAME=$(jq -r '.name // empty' "$PACKAGE_JSON")
+            if [ -z "$PACKAGE_NAME" ]; then
+              echo "::warning::No name found in $PACKAGE_JSON; skipping"
               continue
             fi
 
@@ -222,12 +239,13 @@ jobs:
               continue
             fi
 
-            PACKAGE_NAME=$(jq -r '.name // empty' "$PACKAGE_JSON")
             NEW_VERSION="${CURRENT_VERSION}-${VERSION_SUFFIX}"
             echo "$PACKAGE_NAME: $CURRENT_VERSION -> $NEW_VERSION"
 
+            # --arg rather than interpolating into the jq program, so a suffix containing
+            # quotes or backslashes cannot corrupt or inject into it
             TMP_FILE=$(mktemp)
-            jq ".version = \"$NEW_VERSION\"" "$PACKAGE_JSON" > "$TMP_FILE" && mv "$TMP_FILE" "$PACKAGE_JSON"
+            jq --arg version "$NEW_VERSION" '.version = $version' "$PACKAGE_JSON" > "$TMP_FILE" && mv "$TMP_FILE" "$PACKAGE_JSON"
           done
 
       - name: Get new version number

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -203,22 +203,32 @@ jobs:
         env:
           VERSION_SUFFIX: ${{ inputs.version_suffix }}
         run: |
-          CURRENT_VERSION_JS=$(jq -r .version packages/analytics-js/package.json)
-          CURRENT_VERSION_V1=$(jq -r .version packages/analytics-v1.1/package.json)
-
-          # Append the suffix to create new versions
-          NEW_VERSION_JS="${CURRENT_VERSION_JS}-${VERSION_SUFFIX}"
-          NEW_VERSION_V1="${CURRENT_VERSION_V1}-${VERSION_SUFFIX}"
-
+          # Every publishable package must get the suffix, not just a hardcoded couple of
+          # them. A package that keeps its released version is skipped by nx at publish
+          # time in favour of "npm dist-tag add", and a failure there aborts the whole
+          # release, including the packages whose versions were perfectly valid.
+          # The private check mirrors the filter used to determine affected projects.
           echo "Updating versions:"
-          echo "analytics-js: $CURRENT_VERSION_JS -> $NEW_VERSION_JS"
-          echo "analytics-v1.1: $CURRENT_VERSION_V1 -> $NEW_VERSION_V1"
 
-          # Update all package.json files using jq
-          TMP_FILE_JS=$(mktemp)
-          jq ".version = \"$NEW_VERSION_JS\"" packages/analytics-js/package.json > "$TMP_FILE_JS" && mv "$TMP_FILE_JS" packages/analytics-js/package.json
-          TMP_FILE_V1=$(mktemp)
-          jq ".version = \"$NEW_VERSION_V1\"" packages/analytics-v1.1/package.json > "$TMP_FILE_V1" && mv "$TMP_FILE_V1" packages/analytics-v1.1/package.json
+          for PACKAGE_JSON in packages/*/package.json; do
+            IS_PRIVATE=$(jq -r '.private // "false"' "$PACKAGE_JSON")
+            if [ "$IS_PRIVATE" = "true" ]; then
+              continue
+            fi
+
+            CURRENT_VERSION=$(jq -r '.version // empty' "$PACKAGE_JSON")
+            if [ -z "$CURRENT_VERSION" ]; then
+              echo "::warning::No version found in $PACKAGE_JSON; skipping"
+              continue
+            fi
+
+            PACKAGE_NAME=$(jq -r '.name // empty' "$PACKAGE_JSON")
+            NEW_VERSION="${CURRENT_VERSION}-${VERSION_SUFFIX}"
+            echo "$PACKAGE_NAME: $CURRENT_VERSION -> $NEW_VERSION"
+
+            TMP_FILE=$(mktemp)
+            jq ".version = \"$NEW_VERSION\"" "$PACKAGE_JSON" > "$TMP_FILE" && mv "$TMP_FILE" "$PACKAGE_JSON"
+          done
 
       - name: Get new version number
         run: |

--- a/scripts/deprecate-beta-packages.sh
+++ b/scripts/deprecate-beta-packages.sh
@@ -10,12 +10,17 @@
 
 set -euo pipefail
 
+# Anchored to the script's own location so the package lookup below does not depend on
+# the working directory the script happens to be invoked from
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
 # Configuration
 # Derived from the workspace rather than hardcoded, so this list cannot drift from the
 # set of packages that beta deploys publish. The private check matches the one used to
 # pick the packages to version and publish.
 PACKAGES=()
-for package_json in packages/*/package.json; do
+for package_json in "$REPO_ROOT"/packages/*/package.json; do
   if [[ ! -f "$package_json" ]]; then
     continue
   fi
@@ -35,7 +40,7 @@ for package_json in packages/*/package.json; do
 done
 
 if [[ ${#PACKAGES[@]} -eq 0 ]]; then
-  echo "❌ No publishable packages found under packages/"
+  echo "❌ No publishable packages found under $REPO_ROOT/packages"
   exit 1
 fi
 

--- a/scripts/deprecate-beta-packages.sh
+++ b/scripts/deprecate-beta-packages.sh
@@ -11,16 +11,39 @@
 set -euo pipefail
 
 # Configuration
-PACKAGES=(
-  "@rudderstack/analytics-js"
-  "@rudderstack/analytics-js-service-worker"
-  "@rudderstack/analytics-js-cookies"
-)
+# Derived from the workspace rather than hardcoded, so this list cannot drift from the
+# set of packages that beta deploys publish. The private check matches the one used to
+# pick the packages to version and publish.
+PACKAGES=()
+for package_json in packages/*/package.json; do
+  if [[ ! -f "$package_json" ]]; then
+    continue
+  fi
+
+  is_private=$(jq -r '.private // "false"' "$package_json")
+  if [[ "$is_private" == "true" ]]; then
+    continue
+  fi
+
+  package_name=$(jq -r '.name // empty' "$package_json")
+  if [[ -z "$package_name" ]]; then
+    echo "⚠️  No name found in $package_json; skipping"
+    continue
+  fi
+
+  PACKAGES+=("$package_name")
+done
+
+if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+  echo "❌ No publishable packages found under packages/"
+  exit 1
+fi
 
 # Track processed PRs to avoid duplicate API calls
 declare -A PR_STATUSES
 
 echo "🚀 Starting beta package deprecation for closed PRs"
+echo "📦 Publishable packages: ${PACKAGES[*]}"
 
 # Validate required environment variables
 if [[ -z "${GH_TOKEN:-}" ]] || [[ -z "${GITHUB_REPOSITORY:-}" ]] || [[ -z "${NPM_TOKEN:-}" ]]; then


### PR DESCRIPTION
## PR Description

The beta NPM deploy fails whenever a package other than `analytics-js` / `analytics-v1.1` lands in the affected publishable set. Nothing is published at all, including `@rudderstack/analytics-js` itself.

First hit on #3188 ([failing job](https://github.com/rudderlabs/rudder-sdk-js/actions/runs/34222532930/job/102055137091)). Retries cannot help, for the reason below.

### Root cause

"Modify package versions" in `deploy-npm.yml` (added in #2212, May 2025, never extended) appended the suffix to **two** packages. The repo has **four** publishable ones, so two kept their released versions:

| Package | Version used for the beta | Already on npm |
| --- | --- | --- |
| `@rudderstack/analytics-js` | `3.32.0-beta.pr.3188.ed8dde9` | no |
| `rudder-sdk-js` | `2.52.19-beta.pr.3188.ed8dde9` | no |
| `@rudderstack/analytics-js-service-worker` | `3.3.14` | **yes** |
| `@rudderstack/analytics-js-cookies` | `0.5.13` | **yes** |

`nx release publish` checks `npm view <pkg> versions` first. For a version that already exists it skips publishing and runs `npm dist-tag add` instead. That fails, nx bails on the whole target, and `analytics-js` — which had a perfectly valid new version — never publishes. Since those two versions will always exist, every retry fails identically.

The failure log is unhelpful because [`@nx/js`](https://github.com/nrwl/nx/blob/master/packages/js/src/executors/release-publish/release-publish.impl.ts) runs the dist-tag command with `stdio: 'ignore'` and then prints `JSON.parse(err.stdout || '{}')`, so the real npm error is discarded and you get a bare `{}`.

It only surfaced now because it needs a *shared* package to be affected. #3188 edits `analytics-js-common`, which both service-worker and cookies depend on. The stale `beta` dist-tags corroborate it: `analytics-js` → `3.29.0-beta.pr.2791.7b70402`, service-worker → `3.3.3`, cookies → `0.5.3`.

### Changes

**1. Suffix every publishable package.** Derived from the `private` flag rather than hardcoded, mirroring the filter already used to determine affected publishable projects, so a package added later cannot be missed.

**2. Deprecate betas for every publishable package.** `scripts/deprecate-beta-packages.sh` already listed service-worker and cookies — which is itself evidence those betas were meant to publish — but not `rudder-sdk-js`, whose beta versions have never been deprecated. Now that all four publish betas, all four must be swept. Derived from the same flag so the two lists cannot drift apart again.

### Blast radius

Small, and none of it touches production releases:

- The versioning step is gated on `if: inputs.version_suffix != ''`. Production deploys pass no suffix, so the step is skipped entirely. Only beta/dev/staging are affected.
- `scripts/make-package-json-publish-ready.sh` strips `dependencies` from every `package.json` before publishing, so there are no inter-package version pins to keep in sync when the extra versions change.
- The deprecation script only ever acts on versions matching `-beta.pr.<n>.<sha>` whose PR is closed, so widening its package list cannot touch a release version.

### Verification

Both changes were executed locally rather than eyeballed.

The versioning step was extracted from the YAML and run against a throwaway copy of the real `packages/*/package.json`:

```
Updating versions:
@rudderstack/analytics-js-cookies: 0.5.13 -> 0.5.13-beta.pr.3188.ed8dde9
@rudderstack/analytics-js-service-worker: 3.3.14 -> 3.3.14-beta.pr.3188.ed8dde9
@rudderstack/analytics-js: 3.32.0 -> 3.32.0-beta.pr.3188.ed8dde9
rudder-sdk-js: 2.52.19 -> 2.52.19-beta.pr.3188.ed8dde9
```

Diffing that sandbox against the originals: 4 changed, 6 unchanged, 0 problems — no private package touched, no publishable package missed, JSON valid and key order preserved in each.

The deprecation script's new derivation was run under `set -euo pipefail` and yields all four names; `bash -n` passes on the full script.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-5452/beta-npm-deploy-fails-when-a-shared-package-is-affected

## Cross Browser Tests

Not applicable — CI workflow and release tooling only, no SDK code changed.

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

Not applicable — no SDK code changed.

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

No new credentials, permissions, or network calls. The deprecation script's package list is derived from files already in the repo, and its guard on `-beta.pr.` versions of closed PRs is unchanged, so it still cannot deprecate a release version.

### Known follow-up, deliberately not fixed here

`npm dist-tag add` has no credentials in this workflow — no `NODE_AUTH_TOKEN`, no `registry-url` on `setup-node`, no `_authToken`. It relies on OIDC trusted publishing, which mints a credential scoped to `npm publish` only. Other places that touch dist-tags set a token explicitly (`rollback.yml:201`, `scripts/deprecate-beta-packages.sh:32`). This is the most likely reason the dist-tag call 401s, though nx discarded the error so it is inference rather than proof. With versions always fresh, that path is no longer reached, so this is latent rather than blocking — tracked on SDK-5452 as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved package release automation to apply version updates consistently across all publishable packages.
  - Updated beta-package deprecation tooling to automatically identify eligible packages and report the packages selected for processing.
  - Added safeguards to skip private or incomplete packages and clearly report when no publishable packages are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->