### PR TITLE
fix(analytics-js): set log level before attaching effects

### DIFF
--- a/packages/analytics-js/__tests__/components/configManager/ConfigManager.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/ConfigManager.test.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 import type { ResponseDetails } from '@rudderstack/analytics-js-common/types/HttpClient';
 import { defaultHttpClient } from '../../../src/services/HttpClient';
 import { defaultErrorHandler } from '../../../src/services/ErrorHandler';
-import { defaultLogger } from '../../../src/services/Logger';
+import { defaultLogger, Logger } from '../../../src/services/Logger';
 import { ConfigManager } from '../../../src/components/configManager';
 import { state, resetState } from '../../../src/state';
 import { getSDKUrl } from '../../../src/components/configManager/util/commonUtil';
@@ -402,6 +402,47 @@ describe('ConfigManager', () => {
       }
     });
   });
+
+  it.each([
+    {
+      optionName: 'storage.type',
+      loadOptions: { storage: { type: 'random-type' } },
+      expectedWarning: 'The storage type "random-type" is not supported',
+    },
+    {
+      optionName: 'preConsent.storage.strategy',
+      loadOptions: { preConsent: { storage: { strategy: 'random-strategy' } } },
+      expectedWarning: 'The pre-consent storage strategy "random-strategy" is not supported',
+    },
+  ])(
+    'should emit the load option validation warning for $optionName at the configured log level',
+    ({ loadOptions, expectedWarning }) => {
+      const logProvider = {
+        log: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+      const logger = new Logger('WARN', undefined, logProvider);
+      const configManager = new ConfigManager(defaultHttpClient, defaultErrorHandler, logger);
+      configManager.getConfig = jest.fn();
+
+      state.lifecycle.writeKey.value = sampleWriteKey;
+      state.lifecycle.dataPlaneUrl.value = sampleDataPlaneUrl;
+      state.loadOptions.value.logLevel = 'WARN';
+      // @ts-expect-error Testing invalid input
+      state.loadOptions.value = { ...state.loadOptions.value, ...loadOptions };
+
+      configManager.init();
+
+      expect(logProvider.warn).toHaveBeenCalledWith(
+        expect.stringContaining(expectedWarning),
+        expect.any(String),
+        expect.any(String),
+      );
+    },
+  );
 
   it('should handle promise rejection errors from getSourceConfig function', done => {
     // @ts-expect-error Testing invalid input

--- a/packages/analytics-js/src/components/configManager/ConfigManager.ts
+++ b/packages/analytics-js/src/components/configManager/ConfigManager.ts
@@ -102,6 +102,13 @@ class ConfigManager implements IConfigManager {
       return;
     }
 
+    // Set the log level before attaching the effects so that the effect that syncs it
+    // to the logger does not pin the logger at the default level and swallow the
+    // warnings emitted while processing the rest of the load options
+    if (logLevel) {
+      state.lifecycle.logLevel.value = logLevel;
+    }
+
     this.attachEffects();
 
     state.lifecycle.activeDataplaneUrl.value = removeTrailingSlashes(
@@ -116,10 +123,6 @@ class ConfigManager implements IConfigManager {
     batch(() => {
       state.lifecycle.integrationsCDNPath.value = intgCdnUrl;
       state.lifecycle.pluginsCDNPath.value = pluginsCDNPath;
-
-      if (logLevel) {
-        state.lifecycle.logLevel.value = logLevel;
-      }
 
       state.lifecycle.sourceConfigUrl.value = getSourceConfigURL(
         configUrl,


### PR DESCRIPTION
## PR Description

`ConfigManager.init()` called `attachEffects()` before processing the load options. That effect is `effect(() => this.logger.setMinLogLevel(state.lifecycle.logLevel.value))`, and a `@preact/signals-core` effect runs synchronously on registration — so the logger was immediately pinned at the still-default `POST_LOAD_LOG_LEVEL = 'ERROR'`. The configured `logLevel` only reached that signal in the `batch()` afterwards, so every `logger.warn` emitted by `updateStorageStateFromLoadOptions`, `updateConsentsStateFromLoadOptions` and `updateDataPlaneEventsStateFromLoadOptions` was dropped, whatever level the customer configured.

`Analytics.load` does call `setMinLogLevel(loadOptions.logLevel ?? POST_LOAD_LOG_LEVEL)` earlier, but `attachEffects` overwrote it a moment later.

### Fix

Seed `state.lifecycle.logLevel` from the load options before registering the effect, and drop the now-redundant assignment from the `batch()` block. No change to which messages are emitted — only to whether they are visible.

### Warnings this restores

`STORAGE_TYPE_VALIDATION_WARNING`, `UNSUPPORTED_STORAGE_ENCRYPTION_VERSION_WARNING`, `STORAGE_DATA_MIGRATION_OVERRIDE_WARNING`, `SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING`, `UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY`, `UNSUPPORTED_PRE_CONSENT_EVENTS_DELIVERY_TYPE`, `UNSUPPORTED_BEACON_API_WARNING`, `INVALID_CONFIG_URL_WARNING`.

### Tests

Added an `it.each` regression test that drives the real load path (`configManagerInstance.init()`) with an actual `Logger` and a mock log provider, rather than passing a mock logger straight into the util — which is why the existing unit tests never caught this. Both cases assert 0 warn calls before the fix:

| Case | Before | After |
| -- | -- | -- |
| `storage.type: 'random-type'` | dropped | warning emitted |
| `preConsent.storage.strategy: 'random-strategy'` | dropped | warning emitted |

### Notes for reviewers

- **New noise is bounded.** Nothing changes for a customer who does not set `logLevel` — the logger stays at `ERROR`. For those on `WARN` or lower, every restored warning is gated on an actually-invalid option, with one exception: `UNSUPPORTED_BEACON_API_WARNING` fires on a *valid* config (`useBeacon: true`) in a browser without the Beacon API.
- **SDK-5448 dependency.** `DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY` does not exist on `develop` yet, so its acceptance criterion is not covered here. Once SDK-5448 merges, this fix makes that deprecation warning visible with no further work — today it would have shipped inert.
- `__tests__/browser.test.ts` fails with 9 "SDK did not become ready within the timeout" errors on this branch. Verified the same 9 failures on pristine `develop` in the same worktree — pre-existing, unrelated to this change.

## Linear task

https://linear.app/rudderstack/issue/SDK-5451/config-manager-warnings-are-swallowed-during-load

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Load-option validation warnings now respect the configured log level during initialization.
  * Warnings for unsupported storage configuration values are no longer suppressed or incorrectly emitted at the default level.

* **Tests**
  * Added coverage to verify warning behavior across supported log-level configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->