### PR TITLE
docs(analytics-js): deep-link serverless usage sections

### DIFF
--- a/packages/analytics-js/README.md
+++ b/packages/analytics-js/README.md
@@ -94,8 +94,8 @@ RudderStack JS SDK [service worker](https://www.npmjs.com/package/@rudderstack/a
 
 For more details, see:
 
-- [Vercel Edge Usage](https://github.com/rudderlabs/rudder-sdk-js/blob/main/examples/serverless/USAGE.md)
-- [Cloudflare Worker Usage](https://github.com/rudderlabs/rudder-sdk-js/blob/main/examples/serverless/USAGE.md)
+- [Vercel Edge Usage](https://github.com/rudderlabs/rudder-sdk-js/blob/main/examples/serverless/USAGE.md#vercel-edge)
+- [Cloudflare Worker Usage](https://github.com/rudderlabs/rudder-sdk-js/blob/main/examples/serverless/USAGE.md#cloudflare-worker)
 
 ## License
 


### PR DESCRIPTION
## PR Description

Both serverless links in the package README pointed at the same file:

```
- [Vercel Edge Usage](.../examples/serverless/USAGE.md)
- [Cloudflare Worker Usage](.../examples/serverless/USAGE.md)
```

`examples/serverless/USAGE.md` is a combined document with separate `## Cloudflare Worker` and `## Vercel Edge` sections, so each link now lands on its own section instead of the top of the page.

Docs only. No source, config, or build change.

### Why now

This also serves as the trigger for a beta deployment of the current `develop`, which already carries the granular pre-consent storage work (#3188), the beta NPM deploy fix (#3192) and the log-level ordering fix (#3193). Those merged directly, so there is no longer an open PR to deploy from, and `deploy-beta.yml` requires one.

The affected set for this change is:

```
@rudderstack/analytics-js
@rudderstack/analytics-js-loading-scripts   (private, filtered)
@rudderstack/analytics-js-sanity-suite      (private, filtered)
```

so the NPM deploy publishes `@rudderstack/analytics-js` only. `analytics-js-service-worker` and `analytics-js-cookies` are untouched and stay out of this release.

## Linear task (optional)

Not tracked - trivial docs correction.

## Cross Browser Tests

Not applicable - no SDK code changed.

- [ ] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

Not applicable - no SDK code changed.

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

Two Markdown link fragments in a README. No executable content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated serverless runtime documentation links for Vercel Edge and Cloudflare Workers to point to the relevant guide sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->