### PR TITLE
feat(analytics-js): accept an absolute dataServiceEndpoint

### DIFF
--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -30,7 +30,7 @@ export default [
     name: 'Core - Modern - NPM (ESM)',
     path: 'dist/npm/modern/esm/index.mjs',
     import: '*',
-    limit: '28.5 KiB',
+    limit: '29 KiB',
   },
   {
     name: 'Core - Modern - NPM (CJS)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -77,7 +77,7 @@ export default [
     name: 'Core (Bundled) - Modern - NPM (CJS)',
     path: 'dist/npm/modern/bundled/cjs/index.cjs',
     import: '*',
-    limit: '42 KiB',
+    limit: '42.5 KiB',
   },
   {
     name: 'Core (Bundled) - Modern - NPM (UMD)',

--- a/packages/analytics-js/.size-limit.mjs
+++ b/packages/analytics-js/.size-limit.mjs
@@ -42,7 +42,7 @@ export default [
     name: 'Core - Modern - NPM (UMD)',
     path: 'dist/npm/modern/umd/index.js',
     import: '*',
-    limit: '28.5 KiB',
+    limit: '29 KiB',
   },
   {
     name: 'Core - Modern - CDN',

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -318,7 +318,7 @@ describe('Config Manager Common Utilities', () => {
       updateStorageStateFromLoadOptions(mockLogger);
 
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect(mockLogger.error).toHaveBeenCalledWith(
         "ConfigManager:: The provided cookie domain (random-host.com) does not match the current webpage's domain (www.test-host.com). Hence, the cookies will be set client-side.",
       );
     });

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -395,6 +395,25 @@ describe('Config Manager Common Utilities', () => {
       });
     });
 
+    it('should not force the cross-site cookie options when the cookie domain check disables server-side cookies', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.setCookieDomain = 'www.test-host.com';
+      state.loadOptions.value.dataServiceEndpoint = 'https://shop.test-host.com/rsaRequest';
+      state.loadOptions.value.storage = {
+        cookie: {
+          samesite: 'Lax',
+        },
+      };
+
+      (isWebpageTopLevelDomain as jest.Mock).mockImplementation(isWebpageTopLevelDomainOriginal);
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+      expect(state.storage.cookie.value?.samesite).toBe('Lax');
+      expect(state.storage.cookie.value?.secure).toBeUndefined();
+    });
+
     it('should ignore the port when matching the data service host against the webpage domain', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.dataServiceEndpoint = 'https://shop.test-host.com:8443/rsaRequest';

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../src/components/configManager/util/commonUtil';
 import {
   getDataServiceUrl,
+  isWebpageDataServiceHost,
   isWebpageTopLevelDomain,
 } from '../../../src/components/configManager/util/validate';
 import { state, resetState } from '../../../src/state';
@@ -45,6 +46,11 @@ describe('Config Manager Common Utilities', () => {
 
   let originalGetDataServiceUrl: (endpoint: string, useExactDomain: boolean) => string;
   let isWebpageTopLevelDomainOriginal: (domain: string) => boolean;
+  let isWebpageDataServiceHostOriginal: (
+    dataServiceHostname: string,
+    webpageTopDomain: string,
+    hostOnlyCookies: boolean,
+  ) => boolean;
 
   beforeAll(() => {
     // Save the original implementation
@@ -54,12 +60,16 @@ describe('Config Manager Common Utilities', () => {
     isWebpageTopLevelDomainOriginal = jest.requireActual(
       '../../../src/components/configManager/util/validate',
     ).isWebpageTopLevelDomain;
+    isWebpageDataServiceHostOriginal = jest.requireActual(
+      '../../../src/components/configManager/util/validate',
+    ).isWebpageDataServiceHost;
   });
 
   beforeEach(() => {
     resetState();
     state.lifecycle.writeKey.value = 'writeKey';
     (getDataServiceUrl as jest.Mock).mockRestore();
+    (isWebpageDataServiceHost as jest.Mock).mockImplementation(isWebpageDataServiceHostOriginal);
   });
 
   describe('getSDKUrl', () => {
@@ -351,9 +361,38 @@ describe('Config Manager Common Utilities', () => {
       updateStorageStateFromLoadOptions(mockLogger);
 
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        "ConfigManager:: The data service host (random-host.com) is not under the current webpage's domain (test-host.com). Hence, the cookies will be set client-side.",
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'ConfigManager:: The data service host (random-host.com) cannot set cookies for the current webpage (www.test-host.com). Hence, the cookies will be set client-side instead of server-side.',
       );
+    });
+
+    it('should set isEnabledServerSideCookies to false if sameDomainCookiesOnly is set and the data service host is not the exact webpage host', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.sameDomainCookiesOnly = true;
+      state.loadOptions.value.dataServiceEndpoint = 'https://shop.test-host.com/rsaRequest';
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+    });
+
+    it('should not force the cross-site cookie options when the data service host disables server-side cookies', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.dataServiceEndpoint = 'https://random-host.com/rsaRequest';
+      state.loadOptions.value.storage = {
+        cookie: {
+          samesite: 'Lax',
+        },
+      };
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+      expect(state.storage.cookie.value).toEqual({
+        samesite: 'Lax',
+      });
     });
 
     it('should ignore the port when matching the data service host against the webpage domain', () => {

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -252,11 +252,11 @@ describe('Config Manager Common Utilities', () => {
 
     it('should set the value of isEnabledServerSideCookies to true if the useServerSideCookies is set to true and the dataServiceUrl is a valid url', () => {
       state.loadOptions.value.useServerSideCookies = true;
-      (getDataServiceUrl as jest.Mock).mockImplementation(() => 'https://www.dummy.url');
+      (getDataServiceUrl as jest.Mock).mockImplementation(() => 'https://www.test-host.com/dummy');
       updateStorageStateFromLoadOptions(mockLogger);
 
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
-      expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.dummy.url');
+      expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.test-host.com/dummy');
     });
 
     it('should determine the dataServiceUrl from the exact domain if sameDomainCookiesOnly load option is set to true', () => {
@@ -311,6 +311,54 @@ describe('Config Manager Common Utilities', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.setCookieDomain = 'test-host.com';
       state.loadOptions.value.sameDomainCookiesOnly = true;
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
+    });
+
+    it('should use an absolute dataServiceEndpoint on the current origin as the data service URL', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.dataServiceEndpoint = 'https://www.test-host.com/rsaRequest';
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
+      expect(state.serverCookies.dataServiceUrl.value).toBe('https://www.test-host.com/rsaRequest');
+    });
+
+    it('should keep the cookie domain untouched for an absolute dataServiceEndpoint on a sibling subdomain', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.dataServiceEndpoint = 'https://shop.test-host.com/rsaRequest';
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
+      expect(state.serverCookies.dataServiceUrl.value).toBe(
+        'https://shop.test-host.com/rsaRequest',
+      );
+      expect(state.storage.cookie.value?.domain).toBeUndefined();
+    });
+
+    it('should set isEnabledServerSideCookies to false if the absolute dataServiceEndpoint host is outside the webpage domain', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.dataServiceEndpoint = 'https://random-host.com/rsaRequest';
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "ConfigManager:: The data service host (random-host.com) is not under the current webpage's domain (test-host.com). Hence, the cookies will be set client-side.",
+      );
+    });
+
+    it('should ignore the port when matching the data service host against the webpage domain', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.dataServiceEndpoint = 'https://shop.test-host.com:8443/rsaRequest';
 
       (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
       updateStorageStateFromLoadOptions(mockLogger);

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -443,6 +443,17 @@ describe('Config Manager Common Utilities', () => {
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
     });
 
+    it('should set isEnabledServerSideCookies to false if the provided cookie domain is above the webpage top domain', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.setCookieDomain = 'com';
+
+      (isWebpageTopLevelDomain as jest.Mock).mockImplementation(isWebpageTopLevelDomainOriginal);
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+    });
+
     it('should ignore the port when matching the data service host against the webpage domain', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.dataServiceEndpoint = 'https://shop.test-host.com:8443/rsaRequest';

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -432,6 +432,17 @@ describe('Config Manager Common Utilities', () => {
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
     });
 
+    it('should match the provided cookie domain regardless of its case', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.setCookieDomain = '.Test-Host.com';
+
+      (isWebpageTopLevelDomain as jest.Mock).mockImplementation(isWebpageTopLevelDomainOriginal);
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
+    });
+
     it('should ignore the port when matching the data service host against the webpage domain', () => {
       state.loadOptions.value.useServerSideCookies = true;
       state.loadOptions.value.dataServiceEndpoint = 'https://shop.test-host.com:8443/rsaRequest';

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../src/components/configManager/util/commonUtil';
 import {
   getDataServiceUrl,
+  isDomainMatch,
   isWebpageDataServiceHost,
   isWebpageTopLevelDomain,
 } from '../../../src/components/configManager/util/validate';
@@ -46,6 +47,7 @@ describe('Config Manager Common Utilities', () => {
 
   let originalGetDataServiceUrl: (endpoint: string, useExactDomain: boolean) => string;
   let isWebpageTopLevelDomainOriginal: (domain: string) => boolean;
+  let isDomainMatchOriginal: (hostname: string, cookieDomain: string) => boolean;
   let isWebpageDataServiceHostOriginal: (
     dataServiceHostname: string,
     webpageTopDomain: string,
@@ -63,6 +65,9 @@ describe('Config Manager Common Utilities', () => {
     isWebpageDataServiceHostOriginal = jest.requireActual(
       '../../../src/components/configManager/util/validate',
     ).isWebpageDataServiceHost;
+    isDomainMatchOriginal = jest.requireActual(
+      '../../../src/components/configManager/util/validate',
+    ).isDomainMatch;
   });
 
   beforeEach(() => {
@@ -70,6 +75,7 @@ describe('Config Manager Common Utilities', () => {
     state.lifecycle.writeKey.value = 'writeKey';
     (getDataServiceUrl as jest.Mock).mockRestore();
     (isWebpageDataServiceHost as jest.Mock).mockImplementation(isWebpageDataServiceHostOriginal);
+    (isDomainMatch as jest.Mock).mockImplementation(isDomainMatchOriginal);
   });
 
   describe('getSDKUrl', () => {
@@ -412,6 +418,18 @@ describe('Config Manager Common Utilities', () => {
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
       expect(state.storage.cookie.value?.samesite).toBe('Lax');
       expect(state.storage.cookie.value?.secure).toBeUndefined();
+    });
+
+    it('should set isEnabledServerSideCookies to false if the webpage cannot read cookies scoped to the provided cookie domain', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+      state.loadOptions.value.setCookieDomain = 'shop.test-host.com';
+      state.loadOptions.value.dataServiceEndpoint = 'https://shop.test-host.com/rsaRequest';
+
+      (isWebpageTopLevelDomain as jest.Mock).mockImplementation(isWebpageTopLevelDomainOriginal);
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+      updateStorageStateFromLoadOptions(mockLogger);
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
     });
 
     it('should ignore the port when matching the data service host against the webpage domain', () => {

--- a/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtil.test.ts
@@ -463,6 +463,24 @@ describe('Config Manager Common Utilities', () => {
 
       expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
     });
+
+    it('should set isEnabledServerSideCookies to false if the URL constructor is unavailable', () => {
+      state.loadOptions.value.useServerSideCookies = true;
+
+      (getDataServiceUrl as jest.Mock).mockImplementation(originalGetDataServiceUrl);
+
+      // Legacy JS engines without the URL polyfill: isValidURL falls back to a regex check
+      const originalURL = globalThis.URL;
+      delete (globalThis as any).URL;
+
+      try {
+        expect(() => updateStorageStateFromLoadOptions(mockLogger)).not.toThrow();
+      } finally {
+        globalThis.URL = originalURL;
+      }
+
+      expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(false);
+    });
   });
 
   describe('updateConsentsStateFromLoadOptions', () => {

--- a/packages/analytics-js/__tests__/components/configManager/commonUtilPortedHost.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/commonUtilPortedHost.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment-options {"url": "https://www.test-host.com:8443/some/page"}
+ */
+import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
+import { updateStorageStateFromLoadOptions } from '../../../src/components/configManager/util/commonUtil';
+import { state, resetState } from '../../../src/state';
+
+describe('Config Manager Common Utilities - webpage served on a custom port', () => {
+  const mockLogger = {
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as ILogger;
+
+  beforeEach(() => {
+    resetState();
+    state.lifecycle.writeKey.value = 'writeKey';
+  });
+
+  it('should keep the port of the current webpage in the derived data service URL', () => {
+    state.loadOptions.value.useServerSideCookies = true;
+
+    updateStorageStateFromLoadOptions(mockLogger);
+
+    expect(state.serverCookies.isEnabledServerSideCookies.value).toBe(true);
+    expect(state.serverCookies.dataServiceUrl.value).toBe('https://test-host.com:8443/rsaRequest');
+  });
+});

--- a/packages/analytics-js/__tests__/components/configManager/validate.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/validate.test.ts
@@ -1,6 +1,7 @@
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import {
   getDataServiceUrl,
+  isWebpageDataServiceHost,
   isWebpageTopLevelDomain,
   validateStorageOptions,
 } from '../../../src/components/configManager/util/validate';
@@ -11,22 +12,27 @@ describe('Config manager util - validate load arguments', () => {
       const dataServiceUrl = getDataServiceUrl('endpoint', false, 'test-host.com');
       expect(dataServiceUrl).toBe('https://test-host.com/endpoint');
     });
+
     it('should prepare the dataServiceUrl with endpoint without leading slash', () => {
       const dataServiceUrl = getDataServiceUrl('/endpoint', false, 'test-host.com');
       expect(dataServiceUrl).toBe('https://test-host.com/endpoint');
     });
+
     it('should return dataServiceUrl with exact domain', () => {
       const dataServiceUrl = getDataServiceUrl('endpoint', true, 'test-host.com');
       expect(dataServiceUrl).toBe('https://www.test-host.com/endpoint');
     });
+
     it('should derive the host from the provided top domain', () => {
       const dataServiceUrl = getDataServiceUrl('endpoint', false, 'example.co.uk');
       expect(dataServiceUrl).toBe('https://example.co.uk/endpoint');
     });
+
     it('should fall back to the exact origin if the top domain could not be determined', () => {
       const dataServiceUrl = getDataServiceUrl('endpoint', false, '');
       expect(dataServiceUrl).toBe('https://www.test-host.com/endpoint');
     });
+
     it('should use an absolute HTTPS endpoint as the data service URL as it is', () => {
       const dataServiceUrl = getDataServiceUrl(
         'https://shop.air-up.dev/rsaRequest',
@@ -35,6 +41,7 @@ describe('Config manager util - validate load arguments', () => {
       );
       expect(dataServiceUrl).toBe('https://shop.air-up.dev/rsaRequest');
     });
+
     it('should use an absolute HTTP endpoint as the data service URL as it is', () => {
       const dataServiceUrl = getDataServiceUrl(
         'http://shop.air-up.dev/rsaRequest',
@@ -43,10 +50,12 @@ describe('Config manager util - validate load arguments', () => {
       );
       expect(dataServiceUrl).toBe('http://shop.air-up.dev/rsaRequest');
     });
+
     it('should not append the default endpoint to an absolute endpoint without a path', () => {
       const dataServiceUrl = getDataServiceUrl('https://shop.air-up.dev', false, 'air-up.dev');
       expect(dataServiceUrl).toBe('https://shop.air-up.dev');
     });
+
     it('should ignore the exact domain flag for an absolute endpoint', () => {
       const dataServiceUrl = getDataServiceUrl(
         'https://shop.air-up.dev/rsaRequest',
@@ -57,11 +66,44 @@ describe('Config manager util - validate load arguments', () => {
     });
   });
 
+  describe('isWebpageDataServiceHost', () => {
+    it('should allow the exact webpage host', () => {
+      expect(isWebpageDataServiceHost('www.test-host.com', 'test-host.com', false)).toBe(true);
+    });
+
+    it('should allow the webpage top domain', () => {
+      expect(isWebpageDataServiceHost('test-host.com', 'test-host.com', false)).toBe(true);
+    });
+
+    it('should allow a sibling subdomain of the webpage top domain', () => {
+      expect(isWebpageDataServiceHost('shop.test-host.com', 'test-host.com', false)).toBe(true);
+    });
+
+    it('should not allow a host outside the webpage top domain', () => {
+      expect(isWebpageDataServiceHost('random-host.com', 'test-host.com', false)).toBe(false);
+    });
+
+    it('should not allow a host that merely ends with the webpage top domain', () => {
+      expect(isWebpageDataServiceHost('nottest-host.com', 'test-host.com', false)).toBe(false);
+    });
+
+    it('should only allow the exact webpage host for host-only cookies', () => {
+      expect(isWebpageDataServiceHost('shop.test-host.com', 'test-host.com', true)).toBe(false);
+      expect(isWebpageDataServiceHost('www.test-host.com', 'test-host.com', true)).toBe(true);
+    });
+
+    it('should only allow the exact webpage host if the top domain could not be determined', () => {
+      expect(isWebpageDataServiceHost('test-host.com', '', false)).toBe(false);
+      expect(isWebpageDataServiceHost('www.test-host.com', '', false)).toBe(true);
+    });
+  });
+
   describe('isWebpageTopLevelDomain', () => {
     it('should return true for top level domain', () => {
       const isTopLevel = isWebpageTopLevelDomain('test-host.com');
       expect(isTopLevel).toBe(true);
     });
+
     it('should return false for subdomain', () => {
       const isTopLevel = isWebpageTopLevelDomain('sub.test-host.com');
       expect(isTopLevel).toBe(false);

--- a/packages/analytics-js/__tests__/components/configManager/validate.test.ts
+++ b/packages/analytics-js/__tests__/components/configManager/validate.test.ts
@@ -1,36 +1,59 @@
 import type { ILogger } from '@rudderstack/analytics-js-common/types/Logger';
 import {
-  getTopDomainUrl,
   getDataServiceUrl,
   isWebpageTopLevelDomain,
   validateStorageOptions,
 } from '../../../src/components/configManager/util/validate';
 
 describe('Config manager util - validate load arguments', () => {
-  describe('getTopDomainUrl', () => {
-    const testCaseData = [
-      ['https://sub.example.com', 'https://example.com'],
-      ['https://www.example.com/some/page/iam/viewing.html', 'https://example.com'],
-      ['https://example.com/some/page/iam/viewing.html', 'https://example.com'],
-      ['http://localhost/some/page/iam/viewing.html', 'http://localhost'],
-    ];
-    it.each(testCaseData)('if url is "%s" it should return "%s"', (input, expectedOutput) => {
-      const actualOutput = getTopDomainUrl(input);
-      expect(actualOutput).toBe(expectedOutput);
-    });
-  });
   describe('getDataServiceUrl', () => {
     it('should return dataServiceUrl', () => {
-      const dataServiceUrl = getDataServiceUrl('endpoint', false);
+      const dataServiceUrl = getDataServiceUrl('endpoint', false, 'test-host.com');
       expect(dataServiceUrl).toBe('https://test-host.com/endpoint');
     });
     it('should prepare the dataServiceUrl with endpoint without leading slash', () => {
-      const dataServiceUrl = getDataServiceUrl('/endpoint', false);
+      const dataServiceUrl = getDataServiceUrl('/endpoint', false, 'test-host.com');
       expect(dataServiceUrl).toBe('https://test-host.com/endpoint');
     });
     it('should return dataServiceUrl with exact domain', () => {
-      const dataServiceUrl = getDataServiceUrl('endpoint', true);
+      const dataServiceUrl = getDataServiceUrl('endpoint', true, 'test-host.com');
       expect(dataServiceUrl).toBe('https://www.test-host.com/endpoint');
+    });
+    it('should derive the host from the provided top domain', () => {
+      const dataServiceUrl = getDataServiceUrl('endpoint', false, 'example.co.uk');
+      expect(dataServiceUrl).toBe('https://example.co.uk/endpoint');
+    });
+    it('should fall back to the exact origin if the top domain could not be determined', () => {
+      const dataServiceUrl = getDataServiceUrl('endpoint', false, '');
+      expect(dataServiceUrl).toBe('https://www.test-host.com/endpoint');
+    });
+    it('should use an absolute HTTPS endpoint as the data service URL as it is', () => {
+      const dataServiceUrl = getDataServiceUrl(
+        'https://shop.air-up.dev/rsaRequest',
+        false,
+        'air-up.dev',
+      );
+      expect(dataServiceUrl).toBe('https://shop.air-up.dev/rsaRequest');
+    });
+    it('should use an absolute HTTP endpoint as the data service URL as it is', () => {
+      const dataServiceUrl = getDataServiceUrl(
+        'http://shop.air-up.dev/rsaRequest',
+        false,
+        'air-up.dev',
+      );
+      expect(dataServiceUrl).toBe('http://shop.air-up.dev/rsaRequest');
+    });
+    it('should not append the default endpoint to an absolute endpoint without a path', () => {
+      const dataServiceUrl = getDataServiceUrl('https://shop.air-up.dev', false, 'air-up.dev');
+      expect(dataServiceUrl).toBe('https://shop.air-up.dev');
+    });
+    it('should ignore the exact domain flag for an absolute endpoint', () => {
+      const dataServiceUrl = getDataServiceUrl(
+        'https://shop.air-up.dev/rsaRequest',
+        true,
+        'air-up.dev',
+      );
+      expect(dataServiceUrl).toBe('https://shop.air-up.dev/rsaRequest');
     });
   });
 

--- a/packages/analytics-js/__tests__/components/utilities/url.test.ts
+++ b/packages/analytics-js/__tests__/components/utilities/url.test.ts
@@ -1,6 +1,7 @@
 import {
   extractUTMParameters,
   getUrlWithoutHash,
+  getHostname,
   getReferringDomain,
   removeTrailingSlashes,
 } from '../../../src/components/utilities/url';
@@ -29,6 +30,27 @@ describe('utilities - url', () => {
 
     it('should get empty string if referrer is not a valid URL', () => {
       expect(getReferringDomain('abcd')).toBe('');
+    });
+  });
+
+  describe('getHostname', () => {
+    it('should get the hostname without the port if the input is a valid URL', () => {
+      expect(getHostname('https://rudderlabs.com:8080/blog')).toBe('rudderlabs.com');
+    });
+
+    it('should get null if the input is not a valid URL', () => {
+      expect(getHostname('abcd')).toBe(null);
+    });
+
+    it('should get null if the URL constructor is unavailable', () => {
+      const originalURL = globalThis.URL;
+      delete (globalThis as any).URL;
+
+      try {
+        expect(getHostname('https://rudderlabs.com')).toBe(null);
+      } finally {
+        globalThis.URL = originalURL;
+      }
     });
   });
 

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -36,7 +36,7 @@ import {
   DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY,
   UNSUPPORTED_STORAGE_ENCRYPTION_VERSION_WARNING,
   SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
-  SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_WARNING,
+  SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR,
 } from '../../../constants/logMessages';
 import {
   isErrorReportingEnabled,
@@ -51,7 +51,12 @@ import {
   StorageEncryptionVersionsToPluginNameMap,
 } from '../constants';
 import { domain } from '../../../services/StoreManager/top-domain';
-import { getDataServiceUrl, isWebpageTopLevelDomain, validateStorageOptions } from './validate';
+import {
+  getDataServiceUrl,
+  isWebpageDataServiceHost,
+  isWebpageTopLevelDomain,
+  validateStorageOptions,
+} from './validate';
 import { getConsentManagementData } from '../../utilities/consent';
 
 /**
@@ -126,7 +131,7 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
     const webpageTopDomain = domain(globalThis.location.href);
 
     // The cookie domain probe drops the port, which the derived data service host must keep
-    const { port } = window.location;
+    const { port, hostname: webpageHostname } = globalThis.location;
     const webpageTopHost =
       webpageTopDomain && port ? `${webpageTopDomain}:${port}` : webpageTopDomain;
 
@@ -142,21 +147,22 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
       const curHost = getDomain(window.location.href);
       const dataServiceHost = getDomain(dataServiceUrl);
 
-      // The data service can only set cookies for its own domain or a parent of it, so a host
-      // outside the webpage's domain sets cookies that the webpage will never be able to read
+      // The data service sets the cookies, so it has to be a host whose cookies the webpage
+      // can read back. In the same domain cookies mode they are host-only, hence the exact host
       const dataServiceHostname = new URL(dataServiceUrl).hostname;
-      const isDataServiceHostAllowed = webpageTopDomain
-        ? dataServiceHostname === webpageTopDomain ||
-          dataServiceHostname.endsWith(`.${webpageTopDomain}`)
-        : dataServiceHostname === window.location.hostname;
-
-      if (!isDataServiceHostAllowed) {
+      if (
+        !isWebpageDataServiceHost(
+          dataServiceHostname,
+          webpageTopDomain,
+          sameDomainCookiesOnly as boolean,
+        )
+      ) {
         sscEnabled = false;
-        logger.warn(
-          SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_WARNING(
+        logger.error(
+          SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR(
             CONFIG_MANAGER,
             dataServiceHostname,
-            webpageTopDomain,
+            webpageHostname,
           ),
         );
       }
@@ -166,7 +172,7 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
       // One round of cookie options manipulation is taking place here
       // Based on these(setCookieDomain/storage.cookie or sameDomainCookiesOnly) two load-options, final cookie options are set in the storage module
       // TODO: Refactor the cookie options manipulation logic in one place
-      if (curHost !== dataServiceHost) {
+      if (sscEnabled && curHost !== dataServiceHost) {
         cookieOptions = {
           ...cookieOptions,
           samesite: 'None',

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -35,7 +35,7 @@ import {
   UNSUPPORTED_PRE_CONSENT_STORAGE_STRATEGY,
   DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY,
   UNSUPPORTED_STORAGE_ENCRYPTION_VERSION_WARNING,
-  SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
+  SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_ERROR,
   SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR,
 } from '../../../constants/logMessages';
 import {
@@ -100,6 +100,70 @@ const updateReportingState = (res: SourceConfigResponse): void => {
   state.reporting.isMetricsReportingEnabled.value = isMetricsReportingEnabled(res.source.config);
 };
 
+/**
+ * Resolves the webpage's browser-verified cookie domain, along with the same domain carrying
+ * the current port so that a derived data service URL still points at the webpage's own server.
+ * Note: the storage module probes the same cookie levels again while building the default
+ * cookie options; both belong in the refactor noted below.
+ */
+const getWebpageTopDomain = (): { topDomain: string; topHost: string } => {
+  const topDomain = domain(globalThis.location.href);
+  const { port } = globalThis.location;
+
+  return { topDomain, topHost: topDomain && port ? `${topDomain}:${port}` : topDomain };
+};
+
+/**
+ * Determines whether the cookies the data service would set are ones the webpage can read
+ * back, and reports the reason when they are not.
+ */
+const isServerSideCookiesUsable = (
+  dataServiceHostname: string,
+  providedCookieDomain: string | undefined,
+  webpage: { hostname: string; topDomain: string },
+  sameDomainCookiesOnly: boolean,
+  logger: ILogger,
+): boolean => {
+  // The data service sets the cookies, so it has to be a host whose cookies the webpage
+  // can read back. In the same domain cookies mode they are host-only, hence the exact host
+  if (!isWebpageDataServiceHost(dataServiceHostname, webpage.topDomain, sameDomainCookiesOnly)) {
+    logger.error(
+      SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR(
+        CONFIG_MANAGER,
+        dataServiceHostname,
+        webpage.hostname,
+      ),
+    );
+    return false;
+  }
+
+  // The cookie domain is dropped altogether in the same domain cookies mode
+  if (sameDomainCookiesOnly || !isDefined(providedCookieDomain)) {
+    return true;
+  }
+
+  /**
+   * A provided cookie domain only works if the data service is able to set it and the webpage
+   * falls under it, ex: cookie domain 'random.com', or a sibling subdomain of the webpage
+   */
+  const cookieDomain = removeLeadingPeriod(providedCookieDomain as string);
+  if (
+    !isDomainMatch(dataServiceHostname, cookieDomain) ||
+    !isDomainMatch(webpage.hostname, cookieDomain)
+  ) {
+    logger.error(
+      SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_ERROR(
+        CONFIG_MANAGER,
+        providedCookieDomain,
+        webpage.hostname,
+      ),
+    );
+    return false;
+  }
+
+  return true;
+};
+
 const getServerSideCookiesStateData = (logger: ILogger) => {
   const {
     useServerSideCookies,
@@ -125,16 +189,8 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
         !isWebpageTopLevelDomain(removeLeadingPeriod(providedCookieDomain as string))) ||
       (sameDomainCookiesOnly as boolean);
 
-    // The browser-verified domain of the webpage, used both to derive the default
-    // data service host and to validate an explicitly provided one
-    // Note: the storage module probes the same cookie levels again while building the default
-    // cookie options; both belong in the refactor noted below
-    const webpageTopDomain = domain(globalThis.location.href);
-
-    // The cookie domain probe drops the port, which the derived data service host must keep
-    const { port, hostname: webpageHostname } = globalThis.location;
-    const webpageTopHost =
-      webpageTopDomain && port ? `${webpageTopDomain}:${port}` : webpageTopDomain;
+    const { hostname: webpageHostname } = globalThis.location;
+    const { topDomain: webpageTopDomain, topHost: webpageTopHost } = getWebpageTopDomain();
 
     const dataServiceUrl = getDataServiceUrl(
       dataServiceEndpoint ?? DEFAULT_DATA_SERVICE_ENDPOINT,
@@ -148,62 +204,14 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
       const curHost = getDomain(window.location.href);
       const dataServiceHost = getDomain(dataServiceUrl);
 
-      // The data service sets the cookies, so it has to be a host whose cookies the webpage
-      // can read back. In the same domain cookies mode they are host-only, hence the exact host
       const dataServiceHostname = new URL(dataServiceUrl).hostname;
-      if (
-        !isWebpageDataServiceHost(
-          dataServiceHostname,
-          webpageTopDomain,
-          sameDomainCookiesOnly as boolean,
-        )
-      ) {
-        sscEnabled = false;
-        logger.error(
-          SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR(
-            CONFIG_MANAGER,
-            dataServiceHostname,
-            webpageHostname,
-          ),
-        );
-      }
-
-      // A cookie domain the webpage itself does not fall under yields cookies it cannot read,
-      // no matter which host sets them
-      if (
-        !sameDomainCookiesOnly &&
-        isDefined(providedCookieDomain) &&
-        !isDomainMatch(webpageHostname, removeLeadingPeriod(providedCookieDomain as string))
-      ) {
-        sscEnabled = false;
-        logger.warn(
-          SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING(
-            CONFIG_MANAGER,
-            providedCookieDomain,
-            webpageHostname,
-          ),
-        );
-      }
-
-      /**
-       * If the sameDomainCookiesOnly flag is not set and the cookie domain is provided(not top level domain),
-       * and the data service host is different from the provided cookie domain, then we disable server-side cookies
-       * ex: provided cookie domain: 'random.com', data service host: 'sub.example.com'
-       */
-      if (
-        !sameDomainCookiesOnly &&
-        useExactDomain &&
-        dataServiceHost !== removeLeadingPeriod(providedCookieDomain as string)
-      ) {
-        sscEnabled = false;
-        logger.warn(
-          SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING(
-            CONFIG_MANAGER,
-            providedCookieDomain,
-            dataServiceHost as string,
-          ),
-        );
-      }
+      sscEnabled = isServerSideCookiesUsable(
+        dataServiceHostname,
+        providedCookieDomain,
+        { hostname: webpageHostname, topDomain: webpageTopDomain },
+        sameDomainCookiesOnly as boolean,
+        logger,
+      );
 
       // If the current host is different from the data service host, then it is a cross-site request
       // For server-side cookies to work, we need to set the SameSite=None and Secure attributes

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -148,9 +148,16 @@ const isServerSideCookiesUsable = (
    */
   // Hostnames reach us already lowercased, a configured cookie domain does not
   const cookieDomain = removeLeadingPeriod(providedCookieDomain as string).toLowerCase();
+
+  /**
+   * The cookie domain also has to sit at or below the browser-verified domain of the webpage.
+   * Anything above it is a public suffix, ex: 'co.uk', which the browser refuses to scope
+   * cookies to however well it matches as a string suffix.
+   */
   if (
     !isDomainMatch(dataServiceHostname, cookieDomain) ||
-    !isDomainMatch(webpage.hostname, cookieDomain)
+    !isDomainMatch(webpage.hostname, cookieDomain) ||
+    (webpage.topDomain && !isDomainMatch(cookieDomain, webpage.topDomain))
   ) {
     logger.error(
       SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_ERROR(

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -125,10 +125,15 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
     // cookie options; both belong in the refactor noted below
     const webpageTopDomain = domain(globalThis.location.href);
 
+    // The cookie domain probe drops the port, which the derived data service host must keep
+    const { port } = window.location;
+    const webpageTopHost =
+      webpageTopDomain && port ? `${webpageTopDomain}:${port}` : webpageTopDomain;
+
     const dataServiceUrl = getDataServiceUrl(
       dataServiceEndpoint ?? DEFAULT_DATA_SERVICE_ENDPOINT,
       useExactDomain,
-      webpageTopDomain,
+      webpageTopHost,
     );
 
     if (isValidURL(dataServiceUrl)) {

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -167,18 +167,6 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
         );
       }
 
-      // If the current host is different from the data service host, then it is a cross-site request
-      // For server-side cookies to work, we need to set the SameSite=None and Secure attributes
-      // One round of cookie options manipulation is taking place here
-      // Based on these(setCookieDomain/storage.cookie or sameDomainCookiesOnly) two load-options, final cookie options are set in the storage module
-      // TODO: Refactor the cookie options manipulation logic in one place
-      if (sscEnabled && curHost !== dataServiceHost) {
-        cookieOptions = {
-          ...cookieOptions,
-          samesite: 'None',
-          secure: true,
-        };
-      }
       /**
        * If the sameDomainCookiesOnly flag is not set and the cookie domain is provided(not top level domain),
        * and the data service host is different from the provided cookie domain, then we disable server-side cookies
@@ -197,6 +185,19 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
             dataServiceHost as string,
           ),
         );
+      }
+
+      // If the current host is different from the data service host, then it is a cross-site request
+      // For server-side cookies to work, we need to set the SameSite=None and Secure attributes
+      // One round of cookie options manipulation is taking place here
+      // Based on these(setCookieDomain/storage.cookie or sameDomainCookiesOnly) two load-options, final cookie options are set in the storage module
+      // TODO: Refactor the cookie options manipulation logic in one place
+      if (sscEnabled && curHost !== dataServiceHost) {
+        cookieOptions = {
+          ...cookieOptions,
+          samesite: 'None',
+          secure: true,
+        };
       }
     } else {
       sscEnabled = false;

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -42,7 +42,7 @@ import {
   isErrorReportingEnabled,
   isMetricsReportingEnabled,
 } from '../../utilities/statsCollection';
-import { getDomain, removeTrailingSlashes } from '../../utilities/url';
+import { getDomain, getHostname, removeTrailingSlashes } from '../../utilities/url';
 import type { ConfigResponseDestinationItem, SourceConfigResponse } from '../types';
 import {
   CUSTOM_DEVICE_MODE_DESTINATION_DISPLAY_NAME,
@@ -206,13 +206,16 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
       webpageTopHost,
     );
 
-    if (isValidURL(dataServiceUrl)) {
+    // The hostname is unavailable on legacy JS engines without the URL polyfill,
+    // in which case the data service host cannot be verified
+    const dataServiceHostname = getHostname(dataServiceUrl);
+
+    if (isValidURL(dataServiceUrl) && dataServiceHostname) {
       finalDataServiceUrl = removeTrailingSlashes(dataServiceUrl) as string;
 
       const curHost = getDomain(window.location.href);
       const dataServiceHost = getDomain(dataServiceUrl);
 
-      const dataServiceHostname = new URL(dataServiceUrl).hostname;
       sscEnabled = isServerSideCookiesUsable(
         dataServiceHostname,
         providedCookieDomain,

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -146,7 +146,8 @@ const isServerSideCookiesUsable = (
    * A provided cookie domain only works if the data service is able to set it and the webpage
    * falls under it, ex: cookie domain 'random.com', or a sibling subdomain of the webpage
    */
-  const cookieDomain = removeLeadingPeriod(providedCookieDomain as string);
+  // Hostnames reach us already lowercased, a configured cookie domain does not
+  const cookieDomain = removeLeadingPeriod(providedCookieDomain as string).toLowerCase();
   if (
     !isDomainMatch(dataServiceHostname, cookieDomain) ||
     !isDomainMatch(webpage.hostname, cookieDomain)

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -53,6 +53,7 @@ import {
 import { domain } from '../../../services/StoreManager/top-domain';
 import {
   getDataServiceUrl,
+  isDomainMatch,
   isWebpageDataServiceHost,
   isWebpageTopLevelDomain,
   validateStorageOptions,
@@ -162,6 +163,23 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
           SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR(
             CONFIG_MANAGER,
             dataServiceHostname,
+            webpageHostname,
+          ),
+        );
+      }
+
+      // A cookie domain the webpage itself does not fall under yields cookies it cannot read,
+      // no matter which host sets them
+      if (
+        !sameDomainCookiesOnly &&
+        isDefined(providedCookieDomain) &&
+        !isDomainMatch(webpageHostname, removeLeadingPeriod(providedCookieDomain as string))
+      ) {
+        sscEnabled = false;
+        logger.warn(
+          SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING(
+            CONFIG_MANAGER,
+            providedCookieDomain,
             webpageHostname,
           ),
         );

--- a/packages/analytics-js/src/components/configManager/util/commonUtil.ts
+++ b/packages/analytics-js/src/components/configManager/util/commonUtil.ts
@@ -36,6 +36,7 @@ import {
   DEPRECATED_PRE_CONSENT_STORAGE_STRATEGY,
   UNSUPPORTED_STORAGE_ENCRYPTION_VERSION_WARNING,
   SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
+  SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_WARNING,
 } from '../../../constants/logMessages';
 import {
   isErrorReportingEnabled,
@@ -49,6 +50,7 @@ import {
   DEFAULT_STORAGE_ENCRYPTION_VERSION,
   StorageEncryptionVersionsToPluginNameMap,
 } from '../constants';
+import { domain } from '../../../services/StoreManager/top-domain';
 import { getDataServiceUrl, isWebpageTopLevelDomain, validateStorageOptions } from './validate';
 import { getConsentManagementData } from '../../utilities/consent';
 
@@ -117,9 +119,16 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
         !isWebpageTopLevelDomain(removeLeadingPeriod(providedCookieDomain as string))) ||
       (sameDomainCookiesOnly as boolean);
 
+    // The browser-verified domain of the webpage, used both to derive the default
+    // data service host and to validate an explicitly provided one
+    // Note: the storage module probes the same cookie levels again while building the default
+    // cookie options; both belong in the refactor noted below
+    const webpageTopDomain = domain(globalThis.location.href);
+
     const dataServiceUrl = getDataServiceUrl(
       dataServiceEndpoint ?? DEFAULT_DATA_SERVICE_ENDPOINT,
       useExactDomain,
+      webpageTopDomain,
     );
 
     if (isValidURL(dataServiceUrl)) {
@@ -127,6 +136,25 @@ const getServerSideCookiesStateData = (logger: ILogger) => {
 
       const curHost = getDomain(window.location.href);
       const dataServiceHost = getDomain(dataServiceUrl);
+
+      // The data service can only set cookies for its own domain or a parent of it, so a host
+      // outside the webpage's domain sets cookies that the webpage will never be able to read
+      const dataServiceHostname = new URL(dataServiceUrl).hostname;
+      const isDataServiceHostAllowed = webpageTopDomain
+        ? dataServiceHostname === webpageTopDomain ||
+          dataServiceHostname.endsWith(`.${webpageTopDomain}`)
+        : dataServiceHostname === window.location.hostname;
+
+      if (!isDataServiceHostAllowed) {
+        sscEnabled = false;
+        logger.warn(
+          SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_WARNING(
+            CONFIG_MANAGER,
+            dataServiceHostname,
+            webpageTopDomain,
+          ),
+        );
+      }
 
       // If the current host is different from the data service host, then it is a cross-site request
       // For server-side cookies to work, we need to set the SameSite=None and Secure attributes

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -89,6 +89,13 @@ const getDataServiceUrl = (endpoint: string, useExactDomain: boolean, topHost: s
 };
 
 /**
+ * Determines whether a host falls under a cookie domain, as the browser does when
+ * it decides which cookies to send to a request.
+ */
+const isDomainMatch = (hostname: string, cookieDomain: string): boolean =>
+  hostname === cookieDomain || hostname.endsWith(`.${cookieDomain}`);
+
+/**
  * Determines whether the data service can set cookies that the current webpage is able to read.
  * A host outside the webpage's domain can only set cookies for its own domain.
  */
@@ -102,9 +109,7 @@ const isWebpageDataServiceHost = (
     return dataServiceHostname === globalThis.location.hostname;
   }
 
-  return (
-    dataServiceHostname === webpageTopDomain || dataServiceHostname.endsWith(`.${webpageTopDomain}`)
-  );
+  return isDomainMatch(dataServiceHostname, webpageTopDomain);
 };
 
 const isWebpageTopLevelDomain = (providedDomain: string): boolean => {
@@ -117,6 +122,7 @@ export {
   isValidStorageType,
   validateStorageOptions,
   getDataServiceUrl,
+  isDomainMatch,
   isWebpageDataServiceHost,
   isWebpageTopLevelDomain,
 };

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -65,7 +65,7 @@ const getTopDomain = (url: string) => {
   // Handle different cases, especially for co.uk or similar TLDs
   if (parts.length > 2) {
     // Join the last two parts for the top-level domain
-    topDomain = `${parts.at(-2)}.${parts.at(-1)}`;
+    topDomain = parts.slice(-2).join('.');
   } else {
     // If only two parts or less, return as it is
     topDomain = host;

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -65,7 +65,7 @@ const getTopDomain = (url: string) => {
   // Handle different cases, especially for co.uk or similar TLDs
   if (parts.length > 2) {
     // Join the last two parts for the top-level domain
-    topDomain = `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+    topDomain = `${parts.at(-2)}.${parts.at(-1)}`;
   } else {
     // If only two parts or less, return as it is
     topDomain = host;

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -73,13 +73,19 @@ const getTopDomain = (url: string) => {
   return { topDomain, protocol };
 };
 
-const getTopDomainUrl = (url: string) => {
-  const { topDomain, protocol } = getTopDomain(url);
-  return `${protocol}//${topDomain}`;
-};
+const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
 
-const getDataServiceUrl = (endpoint: string, useExactDomain: boolean) => {
-  const url = useExactDomain ? window.location.origin : getTopDomainUrl(window.location.href);
+const getDataServiceUrl = (endpoint: string, useExactDomain: boolean, topDomain: string) => {
+  // An absolute URL carries its own host, so it is used as the final request URL as it is
+  if (ABSOLUTE_URL_REGEX.test(endpoint)) {
+    return endpoint;
+  }
+
+  // An unknown top domain (ex: IP address hosts) leaves the current origin as the only usable host
+  const url =
+    useExactDomain || !topDomain
+      ? window.location.origin
+      : `${window.location.protocol}//${topDomain}`;
   const formattedEndpoint = endpoint.startsWith('/') ? endpoint.substring(1) : endpoint;
   return `${url}/${formattedEndpoint}`;
 };
@@ -93,7 +99,6 @@ export {
   isValidSourceConfig,
   isValidStorageType,
   validateStorageOptions,
-  getTopDomainUrl,
   getDataServiceUrl,
   isWebpageTopLevelDomain,
 };

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -88,6 +88,25 @@ const getDataServiceUrl = (endpoint: string, useExactDomain: boolean, topHost: s
   return `${url}/${formattedEndpoint}`;
 };
 
+/**
+ * Determines whether the data service can set cookies that the current webpage is able to read.
+ * A host outside the webpage's domain can only set cookies for its own domain.
+ */
+const isWebpageDataServiceHost = (
+  dataServiceHostname: string,
+  webpageTopDomain: string,
+  hostOnlyCookies: boolean,
+): boolean => {
+  // Host-only cookies can be read back only by the exact host that set them
+  if (hostOnlyCookies || !webpageTopDomain) {
+    return dataServiceHostname === globalThis.location.hostname;
+  }
+
+  return (
+    dataServiceHostname === webpageTopDomain || dataServiceHostname.endsWith(`.${webpageTopDomain}`)
+  );
+};
+
 const isWebpageTopLevelDomain = (providedDomain: string): boolean => {
   const { topDomain } = getTopDomain(window.location.href);
   return topDomain === providedDomain;
@@ -98,5 +117,6 @@ export {
   isValidStorageType,
   validateStorageOptions,
   getDataServiceUrl,
+  isWebpageDataServiceHost,
   isWebpageTopLevelDomain,
 };

--- a/packages/analytics-js/src/components/configManager/util/validate.ts
+++ b/packages/analytics-js/src/components/configManager/util/validate.ts
@@ -75,17 +75,15 @@ const getTopDomain = (url: string) => {
 
 const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
 
-const getDataServiceUrl = (endpoint: string, useExactDomain: boolean, topDomain: string) => {
+const getDataServiceUrl = (endpoint: string, useExactDomain: boolean, topHost: string) => {
   // An absolute URL carries its own host, so it is used as the final request URL as it is
   if (ABSOLUTE_URL_REGEX.test(endpoint)) {
     return endpoint;
   }
 
-  // An unknown top domain (ex: IP address hosts) leaves the current origin as the only usable host
+  // An unknown top host (ex: IP address hosts) leaves the current origin as the only usable host
   const url =
-    useExactDomain || !topDomain
-      ? window.location.origin
-      : `${window.location.protocol}//${topDomain}`;
+    useExactDomain || !topHost ? window.location.origin : `${window.location.protocol}//${topHost}`;
   const formattedEndpoint = endpoint.startsWith('/') ? endpoint.substring(1) : endpoint;
   return `${url}/${formattedEndpoint}`;
 };

--- a/packages/analytics-js/src/components/utilities/url.ts
+++ b/packages/analytics-js/src/components/utilities/url.ts
@@ -18,6 +18,15 @@ const getDomain = (url: string): Nullable<string> => {
   }
 };
 
+const getHostname = (url: string): Nullable<string> => {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.hostname;
+  } catch (error) {
+    return null;
+  }
+};
+
 /**
  * Get the referring domain from the referrer URL
  * @param referrer Page referrer
@@ -73,4 +82,5 @@ export {
   extractUTMParameters,
   getUrlWithoutHash,
   getDomain,
+  getHostname,
 };

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -146,6 +146,13 @@ const SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The provided cookie domain (${providedCookieDomain}) does not match the current webpage's domain (${currentCookieDomain}). Hence, the cookies will be set client-side.`;
 
+const SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_WARNING = (
+  context: string,
+  dataServiceHost: string,
+  webpageDomain: string,
+): string =>
+  `${context}${LOG_CONTEXT_SEPARATOR}The data service host (${dataServiceHost}) is not under the current webpage's domain (${webpageDomain}). Hence, the cookies will be set client-side.`;
+
 const RESERVED_KEYWORD_WARNING = (
   context: string,
   property: string,
@@ -333,6 +340,7 @@ export {
   SOURCE_DISABLED_ERROR,
   COMPONENT_BASE_URL_ERROR,
   SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
+  SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_WARNING,
   PAGE_UNLOAD_ON_BEACON_DISABLED_WARNING,
   BREADCRUMB_ERROR,
   NON_ERROR_WARNING,

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -146,12 +146,12 @@ const SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The provided cookie domain (${providedCookieDomain}) does not match the current webpage's domain (${currentCookieDomain}). Hence, the cookies will be set client-side.`;
 
-const SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_WARNING = (
+const SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR = (
   context: string,
   dataServiceHost: string,
-  webpageDomain: string,
+  webpageHost: string,
 ): string =>
-  `${context}${LOG_CONTEXT_SEPARATOR}The data service host (${dataServiceHost}) is not under the current webpage's domain (${webpageDomain}). Hence, the cookies will be set client-side.`;
+  `${context}${LOG_CONTEXT_SEPARATOR}The data service host (${dataServiceHost}) cannot set cookies for the current webpage (${webpageHost}). Hence, the cookies will be set client-side instead of server-side.`;
 
 const RESERVED_KEYWORD_WARNING = (
   context: string,
@@ -340,7 +340,7 @@ export {
   SOURCE_DISABLED_ERROR,
   COMPONENT_BASE_URL_ERROR,
   SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
-  SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_WARNING,
+  SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR,
   PAGE_UNLOAD_ON_BEACON_DISABLED_WARNING,
   BREADCRUMB_ERROR,
   NON_ERROR_WARNING,

--- a/packages/analytics-js/src/constants/logMessages.ts
+++ b/packages/analytics-js/src/constants/logMessages.ts
@@ -139,7 +139,7 @@ const STORAGE_DATA_MIGRATION_OVERRIDE_WARNING = (
 ): string =>
   `${context}${LOG_CONTEXT_SEPARATOR}The storage data migration has been disabled because the configured storage encryption version (${storageEncryptionVersion}) is not the latest (${defaultVersion}). To enable storage data migration, please update the storage encryption version to the latest version.`;
 
-const SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING = (
+const SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_ERROR = (
   context: string,
   providedCookieDomain: string | undefined,
   currentCookieDomain: string,
@@ -339,7 +339,7 @@ export {
   INVALID_POLYFILL_URL_WARNING,
   SOURCE_DISABLED_ERROR,
   COMPONENT_BASE_URL_ERROR,
-  SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_WARNING,
+  SERVER_SIDE_COOKIE_FEATURE_OVERRIDE_ERROR,
   SERVER_SIDE_COOKIE_DATA_SERVICE_HOST_ERROR,
   PAGE_UNLOAD_ON_BEACON_DISABLED_WARNING,
   BREADCRUMB_ERROR,


### PR DESCRIPTION
## PR Description

`dataServiceEndpoint` now accepts a full URL as well as a path. An absolute value becomes the request URL as it is, so the rsaRequest host can be stated explicitly instead of being derived from the cookie domain.

That derivation made one combination unreachable: request on the page's own origin, cookies scoped to the parent domain. A page on `shop.example.com` posts to `example.com/rsaRequest`, and where that apex is not served the request fails and the SDK falls back to client-side cookies, losing the ITP resistance the feature exists for. Every existing option that fixes the host also narrows the cookie scope.

```js
rudderanalytics.load(WRITE_KEY, DATA_PLANE_URL, {
  useServerSideCookies: true,
  dataServiceEndpoint: 'https://shop.example.com/rsaRequest',
});
// request -> https://shop.example.com/rsaRequest
// cookies -> .example.com, unchanged
```

Server-side cookies are now disabled, with an error, whenever the resolved host cannot set cookies the page can read: a host outside the page's domain, a non-exact host under `sameDomainCookiesOnly`, or a cookie domain the page does not fall under.

Separately, the derived host for compound suffixes was the public suffix itself — `shop.example.co.uk` resolved to `co.uk`.

Start at `isServerSideCookiesUsable` in `commonUtil.ts`.

## Linear task (optional)

https://linear.app/rudderstack/issue/SDK-5464/support-an-explicit-data-service-host-for-server-side-cookies-via

## Cross Browser Tests

Please confirm you have tested for the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] IE11

## Sanity Suite

- [ ] All sanity suite test cases pass locally

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

https://claude.ai/code/session_014wfDLKmKCDQqoSMMEwY4Rq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server-side cookie validation to prevent unsupported cookie domains and incompatible data-service hosts.
  - Preserved custom webpage ports when deriving the data-service URL.
  - Improved handling of absolute endpoints and invalid data-service URLs.
  - Added fallback behavior for environments where the standard URL parser is unavailable.
  - Server-side cookies now safely fall back to client-side cookies when configuration validation fails.
  - Enhanced error logging provides clearer context for invalid URLs and cookie configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->